### PR TITLE
Make get_access_token return a string, allow token reuse

### DIFF
--- a/phdi/cloud/azure.py
+++ b/phdi/cloud/azure.py
@@ -1,6 +1,7 @@
 from .core import BaseCredentialManager
 from azure.core.credentials import AccessToken
 from azure.identity import DefaultAzureCredential
+from datetime import datetime, timezone
 
 
 class AzureCredentialManager(BaseCredentialManager):
@@ -16,6 +17,10 @@ class AzureCredentialManager(BaseCredentialManager):
     def scope(self) -> str:
         return self.__scope
 
+    @property
+    def access_token(self) -> AccessToken:
+        return self.__access_token
+
     def __init__(self, resource_location: str, scope: str = None):
         """
         Create a new AzureCredentialManager object.
@@ -25,6 +30,7 @@ class AzureCredentialManager(BaseCredentialManager):
         """
         self.__resource_location = resource_location
         self.__scope = scope
+        self.__access_token = None
 
         if self.scope is None:
             self.__scope = f"{self.resource_location}/.default"
@@ -38,11 +44,31 @@ class AzureCredentialManager(BaseCredentialManager):
         """
         return DefaultAzureCredential()
 
-    def get_access_token(self) -> AccessToken:
+    def get_access_token(self, force_refresh: bool = False) -> str:
         """
         Obtain an access token from the Azure identity provider.
-        """
-        creds = self.get_credential_object()
 
-        access_token = creds.get_token(self.scope)
-        return access_token
+        :param force_refresh: force token refresh even if the current token is
+          still valid
+        :return: The access token, refreshed if necessary
+        """
+
+        if force_refresh or (self.access_token is None) or self._need_new_token():
+            creds = self.get_credential_object()
+            self.__access_token = creds.get_token(self.scope)
+
+        return self.access_token.token
+
+    def _need_new_token(self) -> bool:
+        """
+        Determine whether the token already stored for this object can be reused,
+        or if it needs to be re-requested.
+
+        :return: Whether we need a new token (True means we do)
+        """
+        try:
+            current_time_utc = datetime.now(timezone.utc).timestamp()
+            return self.access_token.expires_on < current_time_utc
+        except AttributeError:
+            # access_token not set
+            return True

--- a/phdi/cloud/core.py
+++ b/phdi/cloud/core.py
@@ -15,7 +15,7 @@ class BaseCredentialManager(ABC):
         pass
 
     @abstractmethod
-    def get_access_token(self) -> object:
+    def get_access_token(self) -> str:
         """
         Returns an access token using the managed credentials
         """

--- a/tests/cloud/test_cloud.py
+++ b/tests/cloud/test_cloud.py
@@ -1,5 +1,5 @@
+from datetime import datetime, timezone
 from unittest import mock
-
 from phdi.cloud.azure import AzureCredentialManager
 
 
@@ -9,17 +9,22 @@ def test_azure_credential_manager(mock_az_creds):
     mock_az_creds_instance = mock_az_creds.return_value
     az_resource_location = "https://some-url"
     az_scope = "some-scope"
-    az_access_token = mock.Mock(token="some-token")
+    az_access_token_str = "some-token"
+    az_access_token_exp = datetime.now(timezone.utc).timestamp() + 1000
+    az_access_token = mock.Mock(
+        token=az_access_token_str, expires_on=az_access_token_exp
+    )
     mock_az_creds_instance.get_token = mock.Mock(return_value=az_access_token)
 
     cred_manager = AzureCredentialManager(az_resource_location, az_scope)
 
     assert cred_manager.get_credential_object() == mock_az_creds_instance
     access_token = cred_manager.get_access_token()
-    assert access_token == az_access_token
+    assert access_token == az_access_token_str
 
     access_token = cred_manager.get_access_token()
     mock_az_creds_instance.get_token.assert_called_with(az_scope)
+    assert access_token == az_access_token_str
 
 
 @mock.patch("phdi.cloud.azure.DefaultAzureCredential")
@@ -27,16 +32,88 @@ def test_azure_credential_manager_default_scope(mock_az_creds):
 
     mock_az_creds_instance = mock_az_creds.return_value
     az_resource_location = "https://some-url"
-    az_access_token = mock.Mock(token="some-token")
+
+    az_access_token_str = "some-token"
+    az_access_token_exp = datetime.now(timezone.utc).timestamp() + 1000
+    az_access_token = mock.Mock(
+        token=az_access_token_str, expires_on=az_access_token_exp
+    )
     mock_az_creds_instance.get_token = mock.Mock(return_value=az_access_token)
 
     cred_manager = AzureCredentialManager(az_resource_location)
 
     assert cred_manager.get_credential_object() == mock_az_creds_instance
     access_token = cred_manager.get_access_token()
-    assert access_token == az_access_token
+    assert access_token == az_access_token_str
 
     access_token = cred_manager.get_access_token()
     mock_az_creds_instance.get_token.assert_called_with(
         f"{az_resource_location}/.default"
     )
+    assert access_token == az_access_token_str
+
+
+@mock.patch("phdi.cloud.azure.DefaultAzureCredential")
+def test_azure_credential_manager_reuse_token(mock_az_creds):
+
+    mock_az_creds_instance = mock_az_creds.return_value
+    az_resource_location = "https://some-url"
+
+    az_access_token_str1 = "some-token1"
+    az_access_token_exp1 = datetime.now(timezone.utc).timestamp() + 1000
+    az_access_token1 = mock.Mock(
+        token=az_access_token_str1, expires_on=az_access_token_exp1
+    )
+    az_access_token_str2 = "some-token2"
+    az_access_token_exp2 = datetime.now(timezone.utc).timestamp() + 1000
+    az_access_token2 = mock.Mock(
+        token=az_access_token_str2, expires_on=az_access_token_exp2
+    )
+    mock_az_creds_instance.get_token = mock.Mock(
+        side_effect=[az_access_token1, az_access_token2]
+    )
+
+    cred_manager = AzureCredentialManager(az_resource_location)
+
+    assert cred_manager.get_credential_object() == mock_az_creds_instance
+    access_token = cred_manager.get_access_token()
+    assert access_token == az_access_token_str1
+
+    access_token = cred_manager.get_access_token()
+    mock_az_creds_instance.get_token.assert_called_with(
+        f"{az_resource_location}/.default"
+    )
+    assert access_token == az_access_token_str1
+
+
+@mock.patch("phdi.cloud.azure.DefaultAzureCredential")
+def test_azure_credential_manager_refresh_token(mock_az_creds):
+
+    mock_az_creds_instance = mock_az_creds.return_value
+    az_resource_location = "https://some-url"
+
+    az_access_token_str1 = "some-token1"
+    az_access_token_exp1 = datetime.now(timezone.utc).timestamp() - 1000
+    az_access_token1 = mock.Mock(
+        token=az_access_token_str1, expires_on=az_access_token_exp1
+    )
+    az_access_token_str2 = "some-token2"
+    az_access_token_exp2 = datetime.now(timezone.utc).timestamp() + 1000
+    az_access_token2 = mock.Mock(
+        token=az_access_token_str2, expires_on=az_access_token_exp2
+    )
+    mock_az_creds_instance.get_token = mock.Mock(
+        side_effect=[az_access_token1, az_access_token2]
+    )
+
+    cred_manager = AzureCredentialManager(az_resource_location)
+
+    assert cred_manager.get_credential_object() == mock_az_creds_instance
+    access_token = cred_manager.get_access_token()
+    assert access_token == az_access_token_str1
+
+    access_token = cred_manager.get_access_token()
+    mock_az_creds_instance.get_token.assert_called_with(
+        f"{az_resource_location}/.default"
+    )
+    assert access_token == az_access_token_str2


### PR DESCRIPTION
Previously, the BaseCredentialManager returned a cloud-specific object from get_access_token.  After talking with Dan about GCP, we are changing to string to make our wrapper functions more cloud agnostic.  The Azure AccessToken object has been made available as a property of the class. 

Also, the AzureCredentialManager is now reusing tokens if the access_token has not expired.