### PR TITLE
Document coverage evaluation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,11 +112,21 @@ poetry run make test
 
 If that fails, stating a file cannot be found, you can also try running `poetry run pytest` directly to run the tests.
 
+If you're running the SDK library in a virtual environment (in which you've run `poetry install` to install all dependencies), you can also simply activate the environment, navigate to `phdi/tests/`, and run `pytest`.
+
 
 Foundational libraries used for testing include:
 - [pytest](https://docs.pytest.org/en/6.2.x/) - for easy unit testing
 - [Black](https://black.readthedocs.io/en/stable/) - automatic code formatter that enforces PEP best practices
 - [flake8](https://flake8.pycqa.org/en/latest/) - for code style enforcement
+
+##### Evaluating code coverage
+
+We use `coverage.py` to monitor our test suite's coverage of our code. To evaluate coverage, simply prepend `coverage run -m` before the command you typically use to run the tests (i.e. `coverage run -m pytest` if using the SDK from within a virtual environment). This generates a file `.coverage` in the `tests/` directory, which contains the results of the coverage run. To view a summary of these statistics, run `coverage report`. 
+
+You can also create an HTML-formatted and -tagged report by running `coverage html`, which creates a folder `htmlcov` inside the `tests/` directory. Opening the `index.html` file inside this directory will take you to a browser view of the coverage report and identify which (if any) code statements were not executed in the test run.
+
+More information can be found in the documentation for [coverage](https://coverage.readthedocs.io/en/6.4.4/).
 
 ##### Building the docs
 


### PR DESCRIPTION
This PR documents how the `coverage.py` package can be used to measure and evaluate our code coverage, as well as explore specific areas that may be deficient in terms of coverage. The information is currently stored in `CONTRIBUTING.md` because that's where we discuss running the tests, but if that isn't the right place for this I'm happy to move it.

The results of our initial coverage assessment are really good. We have overall 95% statement coverage, with the only noteworthy under-covered group being our cloud functionality (`azure.py`, `cloud.core.py`, etc.). That code is relatively new in port, though, so those tests are likely coming (or we still need to write them). Among modules that were already ported with their tests, we score horrendously on `fhir.transport.http.py`, which has only 36% coverage (the single lowest coverage score we have--everything else is around at least 80%, with most being in the 90s).