### PR TITLE
Cloud documentation

### DIFF
--- a/phdi/cloud/README.md
+++ b/phdi/cloud/README.md
@@ -1,0 +1,3 @@
+# The Cloud Package
+
+This package contains functions for integrating with cloud services. Currently, this consists of abstract base classes to support credential management, and interacting with cloud-based object storage.

--- a/phdi/fhir/cloud/README.md
+++ b/phdi/fhir/cloud/README.md
@@ -1,0 +1,3 @@
+# The FHIR Cloud Package
+
+This package contains FHIR-related functionality for integrating with cloud services. The Azure Health Data Services (FHIR) platform stores the exported output data to blob stoarage. This module contains functionality to simplify retrieval of FHIR-exported content.

--- a/tutorials/cloud-tutorial.md
+++ b/tutorials/cloud-tutorial.md
@@ -2,7 +2,7 @@
 This guide serves as a tutorial overview of the functionality available in both `phdi.cloud` and `phdi.fhir.cloud` packages. It covers concepts such as credential managers, cloud storage, and FHIR export file downloads.
 
 ## The Basics: Cloud Managers and Clients
-The goal of the `phdi.cloud` and `phdi.fhir.cloud` modules is to provide a cloud platform-agnostic way to interact with common cloud services that have similar, but differing implementations across cloud providers. Doing provides a way for users other building blocks who need to leverage general cloud functionality to do so in a cloud platform-agnostic way. 
+The goal of the `phdi.cloud` and `phdi.fhir.cloud` modules is to provide a cloud platform-agnostic way to interact with common cloud services that have similar, but differing implementations across cloud providers. Doing so provides a way for users of other building blocks who need to leverage general cloud functionality to do so in a cloud platform-agnostic way. 
 
 For example, the `phdi.fhir.transport` module requires an authorized user/service to make requests to the FHIR API. Authentication may happen different ways on different platforms, but since the related FHIR transport functions make use of a common credential management interface, the functions can support connections with Azure credentials, GCP credentials, etc.
 
@@ -47,7 +47,7 @@ BaseCloudContainerConnection:
 ```
 
 ## FHIR Export Download
-Azure FHIR server places files full of FHIR resources in blob storage during [FHIR bulk data exports](http://hl7.org/fhir/uv/bulkdata/export/index.html). To simplify download of these files, you can directly use the completed export job's status. FHIR export and related poll responses are described more detail in the [transport tutorial](transport-tutorial.md).
+Azure FHIR server places files full of FHIR resources in blob storage during [FHIR bulk data exports](http://hl7.org/fhir/uv/bulkdata/export/index.html). To make it easier to download these files, you can directly use the completed export job's status. FHIR export and related poll responses are described more detail in the [transport tutorial](transport-tutorial.md).
 
 ```python
 from phdi.fhir.transport import export_from_fhir_server

--- a/tutorials/cloud-tutorial.md
+++ b/tutorials/cloud-tutorial.md
@@ -1,0 +1,124 @@
+# Tutorials: The Cloud Module
+This guide serves as a tutorial overview of the functionality available in both `phdi.cloud` and `phdi.fhir.cloud` packages. It covers concepts such as credential managers, cloud storage, and FHIR export file downloads.
+
+## The Basics: Cloud Managers and Clients
+The goal of the `phdi.cloud` and `phdi.fhir.cloud` modules is to provide a cloud platform-agnostic way to interact with common cloud services that have similar, but differing implementations across cloud providers. Doing provides a way for users other building blocks who need to leverage general cloud functionality to do so in a cloud platform-agnostic way. 
+
+For example, the `phdi.fhir.transport` module requires an authorized user/service to make requests to the FHIR API. Authentication may happen different ways on different platforms, but since the related FHIR transport functions make use of a common credential management interface, the functions can support connections with Azure credentials, GCP credentials, etc.
+
+### Credential Managers
+The generic (cloud-agnostic) class representing a credential manager is specified by the `BaseCredentialManager` class. It provides the following methods:
+```
+BaseCredentialManager:
+    get_access_token()
+        '''
+        Returns an access token using the managed credentials
+        '''
+    
+    get_credential_object()
+        '''
+        Returns a cloud-specific credential object
+        '''
+```
+
+### Cloud Storage
+The generic class representing a connection to cloud-based object storage is specified by the `BaseCloudContainerConnection` class.
+```
+BaseCloudContainerConnection:
+    upload_object()
+        '''
+        Uploads content to storage
+        '''
+    
+    download_object()
+        '''
+        Downloads an object from storage
+        '''
+
+    list_containers()
+        '''
+        List containers for this connection.
+        '''
+    
+    list_objects()
+        '''
+        List objects within a container.
+        '''
+```
+
+## FHIR Export Download
+Azure FHIR server places files full of FHIR resources in blob storage during [FHIR bulk data exports](http://hl7.org/fhir/uv/bulkdata/export/index.html). To simplify download of these files, you can directly use the completed export job's status. FHIR export and related poll responses are described more detail in the [transport tutorial](transport-tutorial.md).
+
+```python
+from phdi.fhir.transport import export_from_fhir_server
+from phdi.fhir.cloud.azure import download_from_fhir_export_response
+
+url = "https://some_fhir_url"
+cred_manager = AzureCredentialManager(url)
+
+export_response = export_from_fhir_server(cred_manager, url, export_scope="Patient", since="2022-01-01T00:00:00Z", resource_type="Patient,Observation")
+
+file_iter = download_from_fhir_export_response(export_response, cred_manager)
+
+# Read the beginning of each downloaded file
+for resource_type, file_stream in file_iter:
+    print(f"The beginning content for a {resource_type} export file is: {file_stream.read(50)}")
+```
+
+## Common Uses
+Listed below are several example use cases for employing the cloud module.
+
+### Object Uploads
+In order to upload objects, you will need both a credential manager and storage connection that are specific to the cloud implementation you need to use.  However, once those objects are created, you can interact with them in the same way.
+
+```python
+from phdi.cloud.azure import AzureCredentialManager, AzureCloudConnectionManager
+
+storage_account_url = "https://my-storage.blob.storage.azure.net"
+cred_manager = AzureCredentialManager(storage_account_url)
+
+storage_connection = AzureCloudContainerConnection(storage_account_url, cred_manager)
+
+storage_connection.upload_object("my-container", "some/location/filename.txt", message="Hello world!")
+```
+
+### Object Downloads
+Downloading from cloud storage works similarly.
+
+```python
+from phdi.cloud.azure import AzureCredentialManager, AzureCloudConnectionManager
+
+storage_account_url = "https://my-storage.blob.storage.azure.net"
+container = "my-container"
+file_location = "some/location"
+filename = "filename.txt"
+cred_manager = AzureCredentialManager(storage_account_url)
+
+storage_connection = AzureCloudContainerConnection(storage_account_url, cred_manager)
+
+object_contents = storage_connection.download_object("my-container", f"{file_location}/{filename}")
+
+print(f"Blob contents: {object_contents}")
+```
+
+### Listing contents
+You can also retrieve a list of files in a storage container, or folder.
+
+```python
+from phdi.cloud.azure import AzureCredentialManager, AzureCloudConnectionManager
+
+storage_account_url = "https://my-storage.blob.storage.azure.net"
+container = "my-container"
+file_location = "some/location"
+cred_manager = AzureCredentialManager(storage_account_url)
+
+storage_connection = AzureCloudContainerConnection(storage_account_url, cred_manager)
+
+container_listing = storage_connection.list_containers()
+
+file_listing = storage_connection.list_objects(container, prefix=file_location)
+
+print(f"The following containers exist in {storage_account_url}: {container_listing}")
+
+print(f"The following objects exist in {storage_account_url}, in {container}/{file_location}: {file_listing}")
+```

--- a/tutorials/geospatial-tutorial.md
+++ b/tutorials/geospatial-tutorial.md
@@ -3,11 +3,11 @@
 This guide serves as a tutorial overview of the functionality available in both `phdi.geospatial` and `phdi.fhir.geospatial`. It will cover concepts such as data type basics, imports, and common uses invocations.
 
 ## The Basics: Clients and Results
-The basic data structures used by the geospatial model are a `GeocodeClient` and a `GeocodeResult`. The former is an abstract base class (see https://docs.python.org/3/library/abc.html for more details) that provides vendor-agnostic function skeletons for use on raw data (e.g. strings and dictionaries); the latter is a dataclass (see https://docs.python.org/3/library/dataclasses.html) designed to hold address field information in a standardized fashion. The `fhir` wrapper for the geospatial module also provides a `FhirGeocodeClient`, which is an abstract class that behaves like `GeocodeClient` but which is designed to work with FHIR-formatted data. For clarity, we'll use `GeocodeClient` to refer to implementations that deal with raw data, `FhirGeocodeClient` to refer to implementations that deal with FHIR-formatted data, and "Geocode Clients" to refer the set of both types.
+The basic data structures used by the geospatial model are a `BaseGeocodeClient` and a `GeocodeResult`. The former is an abstract base class (see https://docs.python.org/3/library/abc.html for more details) that provides vendor-agnostic function skeletons for use on raw data (e.g. strings and dictionaries); the latter is a dataclass (see https://docs.python.org/3/library/dataclasses.html) designed to hold address field information in a standardized fashion. The `fhir` wrapper for the geospatial module also provides a `BaseFhirGeocodeClient`, which is an abstract class that behaves like `BaseGeocodeClient` but which is designed to work with FHIR-formatted data. For clarity, we'll use `BaseGeocodeClient` to refer to implementations that deal with raw data, `BaseFhirGeocodeClient` to refer to implementations that deal with FHIR-formatted data, and "Geocode Clients" to refer the set of both types.
 
 The Geocode Clients have the following important methods:
 ```
-GeocodeClient:
+BaseGeocodeClient:
     geocode_from_str()
         '''
         Geocode an address given as a string
@@ -18,7 +18,7 @@ GeocodeClient:
         Geocode an address given as a dictionary (does not need to be FHIR-formatted)
         '''
 
-FhirGeocodeClient:
+BaseFhirGeocodeClient:
     geocode_resource()
         '''
         Geocode one or more addresses contained in a given FHIR resource
@@ -54,8 +54,8 @@ All attributes which are `Optional`-typed may or may not be included in the resu
 Using the geospatial module's functionality begins with simple imports. The Geocode Client abstract classes and `GeocodeResult` likely do not need to be imported (see the common uses section below), but can be used directly from the relevant package:
 
 ```
-from phdi.geospatial import GeocodeClient, GeocodeResult
-from phdi.fhir.geospatial import FhirGeocodeClient
+from phdi.geospatial.core import BaseGeocodeClient, GeocodeResult
+from phdi.fhir.geospatial.core import BaseFhirGeocodeClient
 ```
 
 Of more relevance are the vendor-specific implementations of the Geocode Client classes, which can be imported from the specific `.py` file of the desired vendor. For example, to import a geocoder that uses the SmartyStreets API:


### PR DESCRIPTION
# Description
This contains documentation for the cloud module.

# Additional Changes
`geospatial-tutorial.md` has been updated to reflect the correct naming for abstract classes (`BaseGeocodeClient`, `FhirBaseGeocodeClient`), and import from the correct package (`phdi.geospatial.core`, `phdi.fhir.geospatial.core` respectively).
