### PR TITLE
rename find_resource_by_type to find_entry_by_resource_type

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
           cache: pip
       - name: Install poetry
         run: |
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+          curl -sSL https://install.python-poetry.org | python3 -
           echo "${HOME}/.poetry/bin" >> $GITHUB_PATH
       - name: Install dependencies
         run: poetry install

--- a/phdi/fhir/linkage/link.py
+++ b/phdi/fhir/linkage/link.py
@@ -1,6 +1,6 @@
 import copy
 from phdi.fhir.utils import (
-    find_entry_by_resource_type,
+    find_entries_by_resource_type,
     get_field,
     get_one_line_address,
 )
@@ -27,7 +27,7 @@ def add_patient_identifier_in_bundle(
     if not overwrite:
         bundle = copy.deepcopy(bundle)
 
-    for entry in find_entry_by_resource_type(bundle, "Patient"):
+    for entry in find_entries_by_resource_type(bundle, "Patient"):
         patient = entry.get("resource")
         add_patient_identifier(patient, salt_str, overwrite)
     return bundle

--- a/phdi/fhir/linkage/link.py
+++ b/phdi/fhir/linkage/link.py
@@ -1,6 +1,6 @@
 import copy
 from phdi.fhir.utils import (
-    find_resource_by_type,
+    find_entry_by_resource_type,
     get_field,
     get_one_line_address,
 )
@@ -27,7 +27,7 @@ def add_patient_identifier(bundle: dict, salt_str: str, overwrite: bool = True) 
     if not overwrite:
         bundle = copy.deepcopy(bundle)
 
-    for resource in find_resource_by_type(bundle, "Patient"):
+    for resource in find_entry_by_resource_type(bundle, "Patient"):
         patient = resource.get("resource")
 
         # Combine given and family name

--- a/phdi/fhir/utils.py
+++ b/phdi/fhir/utils.py
@@ -1,7 +1,7 @@
 from typing import List
 
 
-def find_entry_by_resource_type(bundle: dict, resource_type: str) -> List[dict]:
+def find_entries_by_resource_type(bundle: dict, resource_type: str) -> List[dict]:
     """
     Collect all entries of a specific type in a bundle of FHIR data and
     return references to them in a list.
@@ -14,7 +14,7 @@ def find_entry_by_resource_type(bundle: dict, resource_type: str) -> List[dict]:
     return [
         entry
         for entry in bundle.get("entry")
-        if entry.get("resource").get("resourceType") == resource_type
+        if entry.get("resource", {}).get("resourceType") == resource_type
     ]
 
 

--- a/phdi/fhir/utils.py
+++ b/phdi/fhir/utils.py
@@ -1,20 +1,20 @@
 from typing import List
 
 
-def find_resource_by_type(bundle: dict, resource_type: str) -> List[dict]:
+def find_entry_by_resource_type(bundle: dict, resource_type: str) -> List[dict]:
     """
-    Collect all resources of a specific type in a bundle of FHIR data and
+    Collect all entries of a specific type in a bundle of FHIR data and
     return references to them in a list.
 
     :param bundle: The FHIR bundle to find patients in
     :param resource_type: The type of FHIR resource to find
-    :return: List holding all resources of the requested type that were
+    :return: List holding all entries of the requested resource type that were
       found in the input bundle
     """
     return [
-        resource
-        for resource in bundle.get("entry")
-        if resource.get("resource").get("resourceType") == resource_type
+        entry
+        for entry in bundle.get("entry")
+        if entry.get("resource").get("resourceType") == resource_type
     ]
 
 

--- a/tests/assets/cp1252-sample.txt
+++ b/tests/assets/cp1252-sample.txt
@@ -1,4 +1,1 @@
-Testing windows-1252 encoding
-€
-œ
-Ÿ
+Testing windows-1252 encoding € œ Ÿ

--- a/tests/assets/patient_bundle.json
+++ b/tests/assets/patient_bundle.json
@@ -66,6 +66,12 @@
                     }
                 ]
             }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "url": "testing for entry with no resource"
+            }
         }
     ]
 }

--- a/tests/cloud/test_cloud.py
+++ b/tests/cloud/test_cloud.py
@@ -363,8 +363,6 @@ def test_download_object_cp1252(mock_get_client):
 
     assert download_content_buffer.readline() == "Testing windows-1252 encoding € œ Ÿ"
 
-    # assert download_content == "Testing windows-1252 encoding\n€\nœ\nŸ\n"
-
     with pytest.raises(UnicodeDecodeError):
         object_content.decode("utf-8")
 

--- a/tests/cloud/test_cloud.py
+++ b/tests/cloud/test_cloud.py
@@ -1,6 +1,7 @@
 import json
 import pathlib
 import pytest
+import io
 
 from datetime import datetime, timezone
 from unittest import mock
@@ -349,7 +350,11 @@ def test_download_object_cp1252(mock_get_client):
         object_container, object_path, "cp1252"
     )
 
-    assert download_content == "Testing windows-1252 encoding\n€\nœ\nŸ\n"
+    download_content_buffer = io.StringIO(download_content)
+
+    assert download_content_buffer.readline() == "Testing windows-1252 encoding € œ Ÿ"
+
+    # assert download_content == "Testing windows-1252 encoding\n€\nœ\nŸ\n"
 
     with pytest.raises(UnicodeDecodeError):
         object_content.decode("utf-8")

--- a/tests/fhir/test_utils.py
+++ b/tests/fhir/test_utils.py
@@ -2,7 +2,7 @@ import json
 import pathlib
 
 from phdi.fhir.utils import (
-    find_entry_by_resource_type,
+    find_entries_by_resource_type,
     get_field,
 )
 
@@ -11,7 +11,7 @@ def test_find_resource_by_type():
     bundle = json.load(
         open(pathlib.Path(__file__).parent.parent / "assets" / "patient_bundle.json")
     )
-    found_patients = find_entry_by_resource_type(bundle, "Patient")
+    found_patients = find_entries_by_resource_type(bundle, "Patient")
     assert len(found_patients) == 1
     assert found_patients[0].get("resource").get("resourceType") == "Patient"
 

--- a/tests/fhir/test_utils.py
+++ b/tests/fhir/test_utils.py
@@ -2,7 +2,7 @@ import json
 import pathlib
 
 from phdi.fhir.utils import (
-    find_resource_by_type,
+    find_entry_by_resource_type,
     get_field,
 )
 
@@ -11,7 +11,7 @@ def test_find_resource_by_type():
     bundle = json.load(
         open(pathlib.Path(__file__).parent.parent / "assets" / "patient_bundle.json")
     )
-    found_patients = find_resource_by_type(bundle, "Patient")
+    found_patients = find_entry_by_resource_type(bundle, "Patient")
     assert len(found_patients) == 1
     assert found_patients[0].get("resource").get("resourceType") == "Patient"
 


### PR DESCRIPTION
Renamed find_resource_by_type to find_entry_by_resource_type to better articulate the function returning a list of resources within entries by resource type.

Newbie question: In the FHIR documentation it says that an entry can have a resource _or information_. I haven't been able to find any examples of bundles without resources but could this function error on an entry in a bundle that only has information (and therefore no resourceType)?

From https://build.fhir.org/bundle.html:
`"[entry](https://build.fhir.org/bundle-definitions.html#Bundle.entry)" : [{ // [Entry in the bundle - will have a resource or information](https://build.fhir.org/terminologies.html#unbound)`
