### PR TITLE
Refactor upload object params

### DIFF
--- a/phdi/cloud/core.py
+++ b/phdi/cloud/core.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List
+from typing import List, Union
 
 
 class BaseCredentialManager(ABC):
@@ -41,19 +41,18 @@ class BaseCloudContainerConnection(ABC):
     @abstractmethod
     def upload_object(
         self,
+        message: Union[str, dict],
         container_name: str,
         filename: str,
-        message_json: dict = None,
-        message: str = None,
     ) -> None:
         """
         Uploads content to storage.
         Exactly one of message_json or message should be provided.
 
+        :param message: The contents of a message, encoded either as a
+          string or in a JSON format
         :param container_name: The name of the target container for upload
         :param filename: Location of file within storage container
-        :param message_json: The content of a message in JSON format
-        :param message: The content of a message encoded as a string
         """
         pass
 

--- a/phdi/cloud/core.py
+++ b/phdi/cloud/core.py
@@ -46,8 +46,8 @@ class BaseCloudContainerConnection(ABC):
         filename: str,
     ) -> None:
         """
-        Uploads content to storage.
-        Exactly one of message_json or message should be provided.
+        Uploads the content of a given message to Azure blob storage.
+        Message can be passed either as a raw string or as JSON.
 
         :param message: The contents of a message, encoded either as a
           string or in a JSON format

--- a/tests/cloud/test_cloud.py
+++ b/tests/cloud/test_cloud.py
@@ -265,9 +265,9 @@ def test_upload_object(mock_get_client):
     )
 
     phdi_container_client.upload_object(
+        object_content,
         object_container,
         object_path,
-        object_content,
     )
 
     mock_container_client.get_blob_client.assert_called_with(object_path)

--- a/tests/cloud/test_cloud.py
+++ b/tests/cloud/test_cloud.py
@@ -256,24 +256,33 @@ def test_upload_object(mock_get_client):
     mock_cred_manager = mock.Mock()
 
     object_storage_account = "some-resource-location"
-    object_container = "some-container"
-    object_path = "output/path/some-bundle-type/some-filename-1.fhir"
-    object_content = {"hello": "world"}
-
     phdi_container_client = AzureCloudContainerConnection(
         object_storage_account, mock_cred_manager
     )
+    object_container = "some-container"
+    object_path = "output/path/some-bundle-type/some-filename-1.fhir"
+
+    # Test both cases of input data types
+    object_content_json = {"hello": "world"}
+    object_content_str = "hello world"
 
     phdi_container_client.upload_object(
-        object_content,
+        object_content_json,
         object_container,
         object_path,
     )
-
     mock_container_client.get_blob_client.assert_called_with(object_path)
-
     mock_blob_client.upload_blob.assert_called_with(
-        json.dumps(object_content).encode("utf-8"), overwrite=True
+        json.dumps(object_content_json).encode("utf-8"), overwrite=True
+    )
+
+    phdi_container_client.upload_object(
+        object_content_str,
+        object_container,
+        object_path,
+    )
+    mock_blob_client.upload_blob.assert_called_with(
+        bytes(object_content_str, "utf-8"), overwrite=True
     )
 
 


### PR DESCRIPTION
This PR addresses the work scoped in https://app.clickup.com/t/3c06bt8. The function signature has been modified to put the data parameter (`message`) first, and message now accepts either a string or a dictionary to eliminate the need for maintaining separate upload functions.