### PR TITLE
Add :return param: to docstrings

### DIFF
--- a/phdi/cloud/azure.py
+++ b/phdi/cloud/azure.py
@@ -31,6 +31,7 @@ class AzureCredentialManager(BaseCredentialManager):
 
         :param resource_location: URL or other location of the requested resource.
         :param scope: A space-delimited list of scopes to limit access to resource.
+        :param return:
         """
         self.__resource_location = resource_location
         self.__scope = scope
@@ -54,6 +55,7 @@ class AzureCredentialManager(BaseCredentialManager):
 
         :param force_refresh: force token refresh even if the current token is
           still valid
+        :param return: An access token from the Azure identity provider
         """
         if force_refresh or (self.access_token is None) or self._need_new_token():
             creds = self.get_credential_object()
@@ -65,7 +67,7 @@ class AzureCredentialManager(BaseCredentialManager):
         """
         Determine whether the token already stored for this object can be reused,
         or if it needs to be re-requested.
-
+        :param return: An access token from the Azure identity provider if still valid
         """
         try:
             current_time_utc = datetime.now(timezone.utc).timestamp()

--- a/phdi/cloud/azure.py
+++ b/phdi/cloud/azure.py
@@ -50,7 +50,7 @@ class AzureCredentialManager(BaseCredentialManager):
 
     def get_access_token(self, force_refresh: bool = False) -> str:
         """
-        Obtain an access token from the Azure identity provider.  Return the
+        Obtain an access token from the Azure identity provider. Return the
         access token string, refreshed if expired or force_refresh is specified.
 
         :param force_refresh: force token refresh even if the current token is
@@ -102,7 +102,7 @@ class AzureCloudContainerConnection(BaseCloudContainerConnection):
 
     def _get_container_client(self, container_url: str) -> ContainerClient:
         """
-        Obtains a client connected to an Azure storage container by
+        Obtain a client connected to an Azure storage container by
         utilizing the first valid credentials Azure can find. For
         more information on the order in which the credentials are
         checked, see the Azure documentation:
@@ -117,7 +117,7 @@ class AzureCloudContainerConnection(BaseCloudContainerConnection):
         self, container_name: str, filename: str, encoding: str = "UTF-8"
     ) -> str:
         """
-        Downloads a character blob from storage and returns it as a string.
+        Download a character blob from storage and return it as a string.
 
         :param container_name: The name of the container containing object to download
         :param filename: Location of file within Azure blob storage
@@ -140,7 +140,7 @@ class AzureCloudContainerConnection(BaseCloudContainerConnection):
         filename: str,
     ) -> None:
         """
-        Uploads the content of a given message to Azure blob storage.
+        Upload the content of a given message to Azure blob storage.
         Message can be passed either as a raw string or as JSON.
 
         :param message: The contents of a message, encoded either as a

--- a/phdi/cloud/azure.py
+++ b/phdi/cloud/azure.py
@@ -42,7 +42,8 @@ class AzureCredentialManager(BaseCredentialManager):
     def get_credential_object(self) -> object:
         """
         Get an Azure-specific credential object.
-        This returns an instance of one of the \\*Credential objects from the
+
+        :return: An instance of one of the \\*Credential objects from the
         `azure.identity` package.
         """
         return DefaultAzureCredential()
@@ -161,6 +162,8 @@ class AzureCloudContainerConnection(BaseCloudContainerConnection):
     def list_containers(self) -> List[str]:
         """
         List names for this CloudContainerConnection's containers.
+
+        :return: a list of container names
         """
         creds = self.cred_manager.get_credential_object()
         service_client = BlobServiceClient(

--- a/phdi/cloud/azure.py
+++ b/phdi/cloud/azure.py
@@ -54,7 +54,7 @@ class AzureCredentialManager(BaseCredentialManager):
 
         :param force_refresh: force token refresh even if the current token is
           still valid
-        :return: True if Azure access token is valid; false otherwise
+        :return: Azure access token
         """
         if force_refresh or (self.access_token is None) or self._need_new_token():
             creds = self.get_credential_object()

--- a/phdi/cloud/azure.py
+++ b/phdi/cloud/azure.py
@@ -31,7 +31,6 @@ class AzureCredentialManager(BaseCredentialManager):
 
         :param resource_location: URL or other location of the requested resource.
         :param scope: A space-delimited list of scopes to limit access to resource.
-        :param return:
         """
         self.__resource_location = resource_location
         self.__scope = scope
@@ -55,7 +54,7 @@ class AzureCredentialManager(BaseCredentialManager):
 
         :param force_refresh: force token refresh even if the current token is
           still valid
-        :param return: An access token from the Azure identity provider
+        :return: True if Azure access token is valid; false otherwise
         """
         if force_refresh or (self.access_token is None) or self._need_new_token():
             creds = self.get_credential_object()
@@ -67,7 +66,7 @@ class AzureCredentialManager(BaseCredentialManager):
         """
         Determine whether the token already stored for this object can be reused,
         or if it needs to be re-requested.
-        :param return: An access token from the Azure identity provider if still valid
+        :return: True if new Azure access token is needed; False otherwise
         """
         try:
             current_time_utc = datetime.now(timezone.utc).timestamp()
@@ -109,6 +108,7 @@ class AzureCloudContainerConnection(BaseCloudContainerConnection):
         https://docs.microsoft.com/en-us/azure/developer/python/sdk/authentication-overview#sequence-of-authentication-methods-when-using-defaultazurecredential
 
         :param container_url: The url at which to access the container
+        :return: Azure ContainerClient
         """
         creds = self.cred_manager.get_credential_object()
         return ContainerClient.from_container_url(container_url, credential=creds)
@@ -122,6 +122,7 @@ class AzureCloudContainerConnection(BaseCloudContainerConnection):
         :param container_name: The name of the container containing object to download
         :param filename: Location of file within Azure blob storage
         :param encoding: Encoding applied to the downloaded content
+        :return: Character blob (as a string) from given container and filename
         """
         container_location = f"{self.storage_account_url}/{container_name}"
         container_client = self._get_container_client(container_location)
@@ -179,6 +180,7 @@ class AzureCloudContainerConnection(BaseCloudContainerConnection):
 
         :param container_name: The name of the container to look for objects
         :param prefix: Filter for objects whose filenames begin with this value
+        :return: List of names for objects in given container
         """
         container_location = f"{self.storage_account_url}/{container_name}"
         container_client = self._get_container_client(container_location)

--- a/phdi/cloud/core.py
+++ b/phdi/cloud/core.py
@@ -28,12 +28,13 @@ class BaseCloudContainerConnection(ABC):
         self, container_name: str, filename: str, encoding: str = "utf-8"
     ) -> str:
         """
-        Download a blob from storage. Return the `stream` parameter, if supplied.
-        Otherwise a new stream object containing blob content.
+        Download a blob from storage.
 
         :param container_name: The name of the container containing object to download
         :param filename: Location of file within storage
         :param encoding: Encoding applied to the downloaded content
+        :return: The `stream` parameter, if supplied. Otherwise a new stream object
+        containing blob content.
         """
         pass
 

--- a/phdi/cloud/core.py
+++ b/phdi/cloud/core.py
@@ -10,7 +10,9 @@ class BaseCredentialManager(ABC):
     @abstractmethod
     def get_credential_object(self) -> object:
         """
-        Return a cloud-specific credential object.
+        Get a cloud-specific credential object.
+
+        :return: A credential object
         """
         pass
 
@@ -18,6 +20,8 @@ class BaseCredentialManager(ABC):
     def get_access_token(self) -> str:
         """
         Return an access token using the managed credentials.
+
+        :return: An access token
         """
         pass
 
@@ -60,6 +64,8 @@ class BaseCloudContainerConnection(ABC):
     def list_containers(self) -> List[str]:
         """
         List names for this CloudContainerConnection's containers.
+
+        :return: A list of container names
         """
         pass
 
@@ -70,5 +76,6 @@ class BaseCloudContainerConnection(ABC):
 
         :param container_name: The name of the container to look for objects
         :param prefix: Filter for objects whose filenames begin with this value
+        :return: A list of objects within a container
         """
         pass

--- a/phdi/cloud/core.py
+++ b/phdi/cloud/core.py
@@ -4,21 +4,20 @@ from typing import List, Union
 
 class BaseCredentialManager(ABC):
     """
-    This class is intended to provide a common interface for managing service
-    credentials.
+    This class provides a common interface for managing service credentials.
     """
 
     @abstractmethod
     def get_credential_object(self) -> object:
         """
-        Returns a cloud-specific credential object
+        Return a cloud-specific credential object.
         """
         pass
 
     @abstractmethod
     def get_access_token(self) -> str:
         """
-        Returns an access token using the managed credentials
+        Return an access token using the managed credentials.
         """
         pass
 
@@ -29,7 +28,7 @@ class BaseCloudContainerConnection(ABC):
         self, container_name: str, filename: str, encoding: str = "utf-8"
     ) -> str:
         """
-        Downloads a blob from storage.  Returns the `stream` parameter, if supplied.
+        Download a blob from storage. Return the `stream` parameter, if supplied.
         Otherwise a new stream object containing blob content.
 
         :param container_name: The name of the container containing object to download
@@ -46,7 +45,7 @@ class BaseCloudContainerConnection(ABC):
         filename: str,
     ) -> None:
         """
-        Uploads the content of a given message to Azure blob storage.
+        Upload the content of a given message to Azure blob storage.
         Message can be passed either as a raw string or as JSON.
 
         :param message: The contents of a message, encoded either as a
@@ -59,15 +58,14 @@ class BaseCloudContainerConnection(ABC):
     @abstractmethod
     def list_containers(self) -> List[str]:
         """
-        List names for this CloudContainerConnection's containers
-
+        List names for this CloudContainerConnection's containers.
         """
         pass
 
     @abstractmethod
     def list_objects(self) -> List[str]:
         """
-        List names for objects within a container
+        List names for objects within a container.
 
         :param container_name: The name of the container to look for objects
         :param prefix: Filter for objects whose filenames begin with this value

--- a/phdi/cloud/gcp.py
+++ b/phdi/cloud/gcp.py
@@ -38,7 +38,7 @@ class GcpCredentialManager(BaseCredentialManager):
         """
         Get a GCP-specific credential object.
 
-        :return: Returns a scoped instance of the Credentials class from google.auth
+        :return: A scoped instance of the Credentials class from google.auth
             package, refreshed if necessary.
         """
         # Get credentials if they don't exist or are expired.

--- a/phdi/fhir/cloud/azure.py
+++ b/phdi/fhir/cloud/azure.py
@@ -20,6 +20,9 @@ def download_from_fhir_export_response(
     :param export_response: JSON-type dictionary holding the response from
       the export URL the FHIR server set up
     :param cred_manager: Service used to get an access token used to make a request
+    :return: An iterator of tuples. Each tuple is comprised of:
+      - FHIR resource type (str)
+      - Export file content (io.TextIO)
     """
     # TODO: Handle error array that could be contained in the response content.
 
@@ -42,6 +45,7 @@ def _download_export_blob(
     :param blob_url: Blob URL location to download from blob storage
     :param cred_manager: Service used to get an access token used to make a request
     :param encoding: encoding to apply to the ndjson content, defaults to "utf-8"
+    :return: Content of export file located at `blob_url`
     """
     bytes_buffer = io.BytesIO()
     azure_creds = cred_manager.get_credential_object()

--- a/phdi/fhir/conversion/convert.py
+++ b/phdi/fhir/conversion/convert.py
@@ -27,14 +27,13 @@ def convert_to_fhir(
     use_default_ccda=False,
 ):
     """
-    Given a message in either HL7 v2 (pipe-delimited flat file) or
-    CCDA (XML), attempt to convert that message into FHIR format
-    (JSON) for further processing using the FHIR server. HL7v2
-    messages have their datetimes standardized before conversion.
+    Convert a given message from either HL7 v2 (pipe-delimited flat file) or CCDA (XML)
+    into FHIR format (JSON) for further processing using the FHIR server. Standardize
+    datetimes in HL7v2 messages before conversion.
 
     The FHIR server will respond with a status code of 400 if the
     message itself is invalid, such as containing improperly
-    formatted timestamps.  Otherwise, the FHIR server will respond
+    formatted timestamps. Otherwise, the FHIR server will respond
     with the converted FHIR data. In either case, a
     `requests.Response` object will be returned.
 
@@ -45,9 +44,11 @@ def convert_to_fhir(
       make a request
     :param fhir_url: A URL that points to the location of the FHIR
       server
-    :param use_default_ccda: Optionally, whether to default to the
+    :param use_default_ccda: Whether to default to the
       base "CCD" root template if a resource's LOINC code doesn't
-      map to a specific supported template. Default is No.
+      map to a specific supported template (Optional, default is No)
+    :param return: A requests.Response object
+
     """
     conversion_settings = _get_fhir_conversion_settings(message, use_default_ccda)
     if conversion_settings.get("input_data_type") == "HL7v2":
@@ -95,15 +96,13 @@ def convert_to_fhir(
 def _get_fhir_conversion_settings(message: str, use_default_ccda=False) -> dict:
     """
     Private helper function to determine what settings to use with the
-    FHIR server to facilitate message conversion. Some data streams
-    will be encoded in HL7 format, whereas others will be XML data.
-    Attempts to identify which data type the input has and determine
-    the appropriate FHIR converter root template to use. If the user
-    opts to not use the default CCDA root template in cases where an
-    input resource isn't supported, the functionwill raise an
-    exception if a message's extracted LOINC code doesn't correspond to
-    an existing CCDA template. More information about the required
-    templates and settings can be found here:
+    FHIR server to facilitate message conversion. Attempt to identify which data type
+    the input has (HL7 or XML) and determine the appropriate FHIR converter root
+    template to use. Raise an exception if the user opts to not use the default CCDA
+    root template for an unsupported input resouece and a message's extracted
+    LOINC code doesn't correspond to an existing CCDA template.
+
+    More information about the required templates and settings can be found here:
 
     https://docs.microsoft.com/en-us/azure/healthcare-apis/azure-api-for-fhir/convert-data
 

--- a/phdi/fhir/conversion/convert.py
+++ b/phdi/fhir/conversion/convert.py
@@ -47,7 +47,7 @@ def convert_to_fhir(
     :param use_default_ccda: Whether to default to the
       base "CCD" root template if a resource's LOINC code doesn't
       map to a specific supported template (Optional, default is No)
-    :param return: A requests.Response object
+    :return: A requests.Response object
 
     """
     conversion_settings = _get_fhir_conversion_settings(message, use_default_ccda)

--- a/phdi/fhir/geospatial/core.py
+++ b/phdi/fhir/geospatial/core.py
@@ -15,28 +15,27 @@ class BaseFhirGeocodeClient(ABC):
     @abstractmethod
     def geocode_resource(self, resource: dict) -> dict:
         """
-        Function that uses the implementing client to perform geocoding
-        on the provided resource, which is passed in as a dictionary.
+        Perform geocoding, using the implementing client, on the provided resource,
+        which is passed in as a dictionary.
         """
         pass
 
     @abstractmethod
     def geocode_bundle(self, bundle: List[dict]):
         """
-        Function that uses the implementing client to perform geocoding
-        on all supported resources in the provided FHIR bundle, which
-        is passed in as a list of FHIR-formatted dictionaries.
+        Perform geocoding, using the implementing client, on all supported resources in
+        the provided FHIR bundle, which is passed in as a list of FHIR-formatted
+        dictionaries.
         """
         pass
 
     @staticmethod
     def _store_lat_long_extension(address: dict, lat: float, long: float) -> None:
         """
-        Given a FHIR-formatted dictionary holding address fields, add
-        appropriate extension data for latitude and longitude, if the fields
-        aren't already present. The extension data is added directly to the
-        input dictionary, leaving lat and long as FHIR-identified
-        geolocation elements.
+        Add appropriate extension data for latitude and longitude, if the fields
+        aren't already present, to a given FHIR-formatted dictionary holding address
+        fields. Add the extension data directly to the input dictionary, leaving lat and
+        long as FHIR-identified geolocation elements.
 
         :param address: A FHIR formatted dictionary holding address fields
         :param lat: The latitude to add to the FHIR data as an extension

--- a/phdi/fhir/geospatial/core.py
+++ b/phdi/fhir/geospatial/core.py
@@ -17,6 +17,8 @@ class BaseFhirGeocodeClient(ABC):
         """
         Perform geocoding, using the implementing client, on the provided resource,
         which is passed in as a dictionary.
+
+        :return: Geocoded resource as a dict
         """
         pass
 
@@ -26,6 +28,8 @@ class BaseFhirGeocodeClient(ABC):
         Perform geocoding, using the implementing client, on all supported resources in
         the provided FHIR bundle, which is passed in as a list of FHIR-formatted
         dictionaries.
+
+        :return: List of geocoded resources, each resource as a dict
         """
         pass
 
@@ -40,7 +44,6 @@ class BaseFhirGeocodeClient(ABC):
         :param address: A FHIR formatted dictionary holding address fields
         :param lat: The latitude to add to the FHIR data as an extension
         :param long: The longitude to add to the FHIR data as an extension
-        :param return:
         """
         if "extension" not in address:
             address["extension"] = []

--- a/phdi/fhir/geospatial/core.py
+++ b/phdi/fhir/geospatial/core.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from typing import List
 
 
 class BaseFhirGeocodeClient(ABC):
@@ -13,23 +12,30 @@ class BaseFhirGeocodeClient(ABC):
     """
 
     @abstractmethod
-    def geocode_resource(self, resource: dict) -> dict:
+    def geocode_resource(self, resource: dict, overwrite=True) -> dict:
         """
         Perform geocoding, using the implementing client, on the provided resource,
         which is passed in as a dictionary.
 
+        :param bundle: A bundle of fhir resources
+        :param overwrite: Whether to overwrite the address data in the given
+          bundle's resources (True), or whether to create a copy of the bundle
+          and overwrite that instead (False). Defaults to True
         :return: Geocoded resource as a dict
         """
         pass
 
     @abstractmethod
-    def geocode_bundle(self, bundle: List[dict]):
+    def geocode_bundle(self, bundle: dict, overwrite=True) -> dict:
         """
         Perform geocoding, using the implementing client, on all supported resources in
-        the provided FHIR bundle, which is passed in as a list of FHIR-formatted
-        dictionaries.
+        the provided FHIR bundle which is passed in as a dictionary.
 
-        :return: List of geocoded resources, each resource as a dict
+        :param bundle: A bundle of fhir resources
+        :param overwrite: Whether to overwrite the address data in the given
+          bundle's resources (True), or whether to create a copy of the bundle
+          and overwrite that instead (False). Defaults to True
+        :return: Geocoded bundle as a dict
         """
         pass
 

--- a/phdi/fhir/geospatial/core.py
+++ b/phdi/fhir/geospatial/core.py
@@ -41,6 +41,7 @@ class BaseFhirGeocodeClient(ABC):
         :param address: A FHIR formatted dictionary holding address fields
         :param lat: The latitude to add to the FHIR data as an extension
         :param long: The longitude to add to the FHIR data as an extension
+        :param return:
         """
         if "extension" not in address:
             address["extension"] = []

--- a/phdi/fhir/geospatial/smarty.py
+++ b/phdi/fhir/geospatial/smarty.py
@@ -1,4 +1,3 @@
-from typing import List
 from copy import copy
 from smartystreets_python_sdk import us_street
 
@@ -75,7 +74,7 @@ class SmartyFhirGeocodeClient(BaseFhirGeocodeClient):
                     address, standardized_address.lat, standardized_address.lng
                 )
 
-    def geocode_bundle(self, bundle: List[dict], overwrite=True) -> List[dict]:
+    def geocode_bundle(self, bundle: dict, overwrite=True) -> dict:
         """
         Perform geocoding on all resources in a given FHIR bundle whose
         resource type is among those supported by the PHDI SDK. Currently,

--- a/phdi/fhir/geospatial/smarty.py
+++ b/phdi/fhir/geospatial/smarty.py
@@ -77,7 +77,7 @@ class SmartyFhirGeocodeClient(BaseFhirGeocodeClient):
 
     def geocode_bundle(self, bundle: List[dict], overwrite=True) -> List[dict]:
         """
-        Performs geocoding on all resources in a given FHIR bundle whose
+        Perform geocoding on all resources in a given FHIR bundle whose
         resource type is among those supported by the PHDI SDK. Currently,
         this includes:
 

--- a/phdi/fhir/geospatial/smarty.py
+++ b/phdi/fhir/geospatial/smarty.py
@@ -45,7 +45,7 @@ class SmartyFhirGeocodeClient(BaseFhirGeocodeClient):
         :param overwrite: Whether to save the geocoding information over
           the raw data, or to create a copy of the given data and write
           over that instead. Defaults to True (write over given data).
-        :param return: Geocoded address(es)
+        :return: Geocoded resource as a dict
         """
         if not overwrite:
             resource = copy.deepcopy(resource)
@@ -87,7 +87,7 @@ class SmartyFhirGeocodeClient(BaseFhirGeocodeClient):
         :param overwrite: Whether to overwrite the address data in the given
           bundle's resources (True), or whether to create a copy of the bundle
           and overwrite that instead (False). Defaults to True
-        :param return: A FHIR bundle with geocoded address(es)
+        :return: A FHIR bundle with geocoded address(es)
         """
         if not overwrite:
             bundle = copy.deepcopy(bundle)

--- a/phdi/fhir/geospatial/smarty.py
+++ b/phdi/fhir/geospatial/smarty.py
@@ -45,6 +45,7 @@ class SmartyFhirGeocodeClient(BaseFhirGeocodeClient):
         :param overwrite: Whether to save the geocoding information over
           the raw data, or to create a copy of the given data and write
           over that instead. Defaults to True (write over given data).
+        :param return: Geocoded address(es)
         """
         if not overwrite:
             resource = copy.deepcopy(resource)
@@ -85,7 +86,8 @@ class SmartyFhirGeocodeClient(BaseFhirGeocodeClient):
         :param bundle: A bundle of fhir resources
         :param overwrite: Whether to overwrite the address data in the given
           bundle's resources (True), or whether to create a copy of the bundle
-          and overwrite that instead (False). Defaults to True.
+          and overwrite that instead (False). Defaults to True
+        :param return: A FHIR bundle with geocoded address(es)
         """
         if not overwrite:
             bundle = copy.deepcopy(bundle)

--- a/phdi/fhir/harmonization/standardization.py
+++ b/phdi/fhir/harmonization/standardization.py
@@ -84,7 +84,7 @@ def _standardize_names_in_resource(
     case: Literal["upper", "lower", "title"] = "upper",
     remove_numbers: bool = True,
     overwrite: bool = True,
-) -> Union[dict, None]:
+) -> dict:
     """
     Helper method to standardize all found names in a given resource.
     The resource can be of any type currently supported by the

--- a/phdi/fhir/harmonization/standardization.py
+++ b/phdi/fhir/harmonization/standardization.py
@@ -15,9 +15,8 @@ def standardize_names(
     overwrite: bool = True,
 ) -> dict:
     """
-    Given either a FHIR bundle or a FHIR resource, transform all names
-    contained in any resource in the input.  The default standardization
-    behavior is our defined non-numeric, space-trimming, full
+    Standardize all names contained in a given FHIR bundle or a FHIR resource. The
+    default standardization behavior is our defined non-numeric, space-trimming, full
     capitalization standardization, but other modes may be specified.
 
     :param data: Either a FHIR bundle or a FHIR-formatted JSON dict
@@ -51,12 +50,10 @@ def standardize_names(
 
 def standardize_phones(data: dict, overwrite=True) -> dict:
     """
-    Given a FHIR bundle or a FHIR resource, standardize all phone
-    numbers contained in any resources in the input data.
-    Standardization is done according to the underlying
-    standardize_phone function in phdi.harmonization, so for more
-    information on country-coding and parsing, see the relevant
-    docstring.
+    Standardize all phone numbers in a given FHIR bundle or a FHIR resource
+    Standardization is done according to the underlying standardize_phone function in
+    phdi.harmonization. For more information on country-coding and parsing, see the
+    relevant docstring.
 
     :param data: A FHIR bundle or FHIR-formatted JSON dict
     :param overwrite: Whether to replace the original phone numbers
@@ -157,10 +154,9 @@ def _extract_countries_from_resource(
     resource: dict, code_type: Literal["alpha_2", "alpha_3", "numeric"] = "alpha_2"
 ) -> List[str]:
     """
-    Given a FHIR resource, build a list containing all of the counries
-    found in the addresses associated with that resource, standardized
-    by code_type. If the resource is not of a supported type, no countries
-    will be contained in the returned list. Currently supported resource types are:
+    Build a list containing all of the countries, standardized by code_type, in the
+    addresses of a given FHIR resource. If the resource is not of a supported type, no
+    countries will bereturned. Currently supported resource types are:
 
     - Patient
 

--- a/phdi/fhir/harmonization/standardization.py
+++ b/phdi/fhir/harmonization/standardization.py
@@ -108,8 +108,7 @@ def _standardize_names_in_resource(
       names in the resource
     :param overwrite: Whether to overwrite the input data with the
       new, standardized value (default is yes)
-    :return: The resource (or a copy thereof) with standardized
-      information in place of the raw
+    :return: The resource with appropriately standardized names
     """
 
     if not overwrite:
@@ -159,16 +158,17 @@ def _extract_countries_from_resource(
 ) -> List[str]:
     """
     Given a FHIR resource, build a list containing all of the counries
-    found in the addresses associated with that resource in a standardized
-    form sepcified by code_type. If the resource is not of a supported
-    type, no countries will be contained in the returned list. Currently
-    supported resource types are:
+    found in the addresses associated with that resource, standardized
+    by code_type. If the resource is not of a supported type, no countries
+    will be contained in the returned list. Currently supported resource types are:
 
     - Patient
 
     :param resource: A FHIR-formatted JSON dictionary
     :param code_type: A string equal to 'alpha_2', 'alpha_3', or 'numeric'
       to specify which type of standard country identifier to generate
+    :param return: A list of all the standardized countries found in the resource's
+     addresses
     """
     countries = []
     resource_type = resource.get("resourceType")

--- a/phdi/fhir/harmonization/standardization.py
+++ b/phdi/fhir/harmonization/standardization.py
@@ -50,7 +50,7 @@ def standardize_names(
 
 def standardize_phones(data: dict, overwrite=True) -> dict:
     """
-    Standardize all phone numbers in a given FHIR bundle or a FHIR resource
+    Standardize all phone numbers in a given FHIR bundle or a FHIR resource.
     Standardization is done according to the underlying standardize_phone function in
     phdi.harmonization. For more information on country-coding and parsing, see the
     relevant docstring.
@@ -58,8 +58,7 @@ def standardize_phones(data: dict, overwrite=True) -> dict:
     :param data: A FHIR bundle or FHIR-formatted JSON dict
     :param overwrite: Whether to replace the original phone numbers
       in the input data with the standardized versions (default is yes)
-    :return: The bundle or resource with phones appropriately
-      standardized
+    :return: The bundle or resource with phones appropriately standardized
     """
 
     if not overwrite:
@@ -156,14 +155,14 @@ def _extract_countries_from_resource(
     """
     Build a list containing all of the countries, standardized by code_type, in the
     addresses of a given FHIR resource. If the resource is not of a supported type, no
-    countries will bereturned. Currently supported resource types are:
+    countries will be returned. Currently supported resource types are:
 
     - Patient
 
     :param resource: A FHIR-formatted JSON dictionary
     :param code_type: A string equal to 'alpha_2', 'alpha_3', or 'numeric'
       to specify which type of standard country identifier to generate
-    :param return: A list of all the standardized countries found in the resource's
+    :return: A list of all the standardized countries found in the resource's
      addresses
     """
     countries = []

--- a/phdi/fhir/linkage/link.py
+++ b/phdi/fhir/linkage/link.py
@@ -23,6 +23,7 @@ def add_patient_identifier_in_bundle(
     :param overwrite: Whether to write the new standardizations
         directly into the given bundle, changing the original data (True
         is yes)
+    :return: The bundle, resources updated with additional patient identifier
     """
     if not overwrite:
         bundle = copy.deepcopy(bundle)
@@ -48,6 +49,7 @@ def add_patient_identifier(patient_resource, salt_str, overwrite):
     :param overwrite: Whether to write the new standardizations
         directly into the given bundle, changing the original data (True
         is yes)
+    :return: The resource updated with additional patient identifier
     """
     if not overwrite:
         patient_resource = copy.deepcopy(patient_resource)

--- a/phdi/fhir/tabulation/tables.py
+++ b/phdi/fhir/tabulation/tables.py
@@ -4,7 +4,7 @@ import random
 import pathlib
 
 from functools import cache
-from typing import Any, Callable, Literal, List, Union
+from typing import Any, Callable, Literal, List
 
 from phdi.cloud.core import BaseCredentialManager
 from phdi.fhir.transport import fhir_server_get
@@ -13,13 +13,12 @@ from phdi.tabulation.tables import load_schema, write_table
 
 def apply_selection_criteria(
     value: List[Any],
-    selection_criteria: Literal["first", "last", "random", "all"],
-) -> Union[str, List[str]]:
+    selection_criteria: Literal["first", "last", "random"],
+) -> str:
     """
     Return value(s), according to the selection criteria, from a given list of values
-    parsed from a FHIR resource. In general a single value is returned, but when
-    selection_criteria is set to "all", a list containing all of the parsed values is
-    returned.
+    parsed from a FHIR resource. A single string value is returned - if the selected
+    value is a complex structure (list or dict), it is converted to a string.
 
     :param value: A list containing the values parsed from a FHIR resource
     :param selection_criteria: A string indicating which element(s) of a list to select
@@ -86,7 +85,7 @@ def generate_table(
     output_format: Literal["parquet"],
     fhir_url: str,
     cred_manager: BaseCredentialManager,
-):
+) -> None:
     """
     Make a table for a single schema.
 
@@ -149,7 +148,7 @@ def generate_all_tables_in_schema(
     output_format: Literal["parquet"],
     fhir_url: str,
     cred_manager: BaseCredentialManager,
-):
+) -> None:
     """
     Given the url for a FHIR server, the location of a schema file, and the output
     directory generate the specified schema and store the tables in the desired
@@ -180,6 +179,7 @@ def _get_fhirpathpy_parser(fhirpath_expression: str) -> Callable:
     fhirpath_expression on that resource.
 
     :param fhirpath_expression: The FHIRPath expression to evaluate
-    :return: The evaluated value at fhirpath_expression for a given resource
+    :return: A function that, when called passing in a FHIR resource, will return value
+      at fhirpath_expression
     """
     return fhirpathpy.compile(fhirpath_expression)

--- a/phdi/fhir/tabulation/tables.py
+++ b/phdi/fhir/tabulation/tables.py
@@ -21,8 +21,10 @@ def apply_selection_criteria(
     selection_criteria is set to "all" a list containing all of the parsed values is
     returned.
 
-    :param value: A list containing the values parsed from a FHIR resource.
-    :param selection_criteria: A string indicating which element(s) of a list to select.
+    :param value: A list containing the values parsed from a FHIR resource
+    :param selection_criteria: A string indicating which element(s) of a list to select
+    :param return: Value(s) parsed from a FHIR resource that conform to the selection
+      criteria
     """
 
     if selection_criteria == "first":
@@ -53,8 +55,9 @@ def apply_schema_to_resource(resource: dict, schema: dict) -> dict:
     particular variable should be called. If a schema can't be found for the given
     resource type, the raw resource is instead returned.
 
-    :param resource: A FHIR resource on which to apply a schema.
-    :param schema: A schema specifying the desired values by FHIR resource type.
+    :param resource: A FHIR resource on which to apply a schema
+    :param schema: A schema specifying the desired values by FHIR resource type
+    :param return: A dictionary of data with the desired values specified in the schema
     """
 
     data = {}
@@ -93,6 +96,7 @@ def generate_table(
     :param fhir_url: URL to a FHIR server.
     :param cred_manager: Service used to get an access token used to make a
         request.
+    :param return:
     """
     output_path.mkdir(parents=True, exist_ok=True)
     for resource_type in schema:
@@ -148,7 +152,7 @@ def generate_all_tables_in_schema(
     cred_manager: BaseCredentialManager,
 ):
     """
-    Given the url for a FHIR server, the location of a schema file, and and output
+    Given the url for a FHIR server, the location of a schema file, and the output
     directory generate the specified schema and store the tables in the desired
     location.
 
@@ -159,6 +163,7 @@ def generate_all_tables_in_schema(
     :param fhir_url: URL to a FHIR server.
     :param cred_manager: Service used to get an access token used to make a
         request.
+    :param return:
     """
 
     schema = load_schema(schema_path)
@@ -178,5 +183,6 @@ def _get_fhirpathpy_parser(fhirpath_expression: str) -> Callable:
     `fhirpath_expression`
 
     :param fhirpath_expression: The FHIRPath expression to evaluate
+    :param return:
     """
     return fhirpathpy.compile(fhirpath_expression)

--- a/phdi/fhir/tabulation/tables.py
+++ b/phdi/fhir/tabulation/tables.py
@@ -23,7 +23,7 @@ def apply_selection_criteria(
 
     :param value: A list containing the values parsed from a FHIR resource
     :param selection_criteria: A string indicating which element(s) of a list to select
-    :param return: Value(s) parsed from a FHIR resource that conform to the selection
+    :return: Value(s) parsed from a FHIR resource that conform to the selection
       criteria
     """
 
@@ -57,7 +57,7 @@ def apply_schema_to_resource(resource: dict, schema: dict) -> dict:
 
     :param resource: A FHIR resource on which to apply a schema
     :param schema: A schema specifying the desired values by FHIR resource type
-    :param return: A dictionary of data with the desired values specified in the schema
+    :return: A dictionary of data with the desired values specified in the schema
     """
 
     data = {}
@@ -96,7 +96,6 @@ def generate_table(
     :param fhir_url: URL to a FHIR server.
     :param cred_manager: Service used to get an access token used to make a
         request.
-    :param return:
     """
     output_path.mkdir(parents=True, exist_ok=True)
     for resource_type in schema:
@@ -163,7 +162,6 @@ def generate_all_tables_in_schema(
     :param fhir_url: URL to a FHIR server.
     :param cred_manager: Service used to get an access token used to make a
         request.
-    :param return:
     """
 
     schema = load_schema(schema_path)
@@ -178,11 +176,10 @@ def generate_all_tables_in_schema(
 @cache
 def _get_fhirpathpy_parser(fhirpath_expression: str) -> Callable:
     """
-    Return a fhirpathpy parser for a specific FHIRPath. This cached function minimizes
-    calls to the relatively expensive :func:`fhirpathpy.compile` function for any given
-    `fhirpath_expression`
+    A function that accepts a resource parameter, and returns the evaluated value at
+    fhirpath_expression on that resource.
 
     :param fhirpath_expression: The FHIRPath expression to evaluate
-    :param return:
+    :return: The evaluated value at fhirpath_expression for a given resource
     """
     return fhirpathpy.compile(fhirpath_expression)

--- a/phdi/fhir/tabulation/tables.py
+++ b/phdi/fhir/tabulation/tables.py
@@ -16,9 +16,9 @@ def apply_selection_criteria(
     selection_criteria: Literal["first", "last", "random", "all"],
 ) -> Union[str, List[str]]:
     """
-    Given a list of values parsed from a FHIR resource, return value(s) according to the
-    selection criteria. In general a single value is returned, but when
-    selection_criteria is set to "all" a list containing all of the parsed values is
+    Return value(s), according to the selection criteria, from a given list of values
+    parsed from a FHIR resource. In general a single value is returned, but when
+    selection_criteria is set to "all", a list containing all of the parsed values is
     returned.
 
     :param value: A list containing the values parsed from a FHIR resource
@@ -48,7 +48,7 @@ def apply_selection_criteria(
 
 def apply_schema_to_resource(resource: dict, schema: dict) -> dict:
     """
-    Creates and returns a dictionary of data based on a FHIR resource and a schema. The
+    Create and return a dictionary of data based on a FHIR resource and a schema. The
     keys of the created dict are the "new names" for the fields in the given schema, and
     the values are the elements of the given resource that correspond to these fields.
     Here, "new name" is a property contained in the schema that specifies what a
@@ -88,7 +88,7 @@ def generate_table(
     cred_manager: BaseCredentialManager,
 ):
     """
-    Given the schema for a single table, make the table.
+    Make a table for a single schema.
 
     :param schema: A schema specifying the desired values by FHIR resource type.
     :param output_path: A path specifying where the table should be written.
@@ -178,7 +178,7 @@ def generate_all_tables_in_schema(
 @cache
 def _get_fhirpathpy_parser(fhirpath_expression: str) -> Callable:
     """
-    Return a fhirpathpy parser for a specific FHIRPath.  This cached function minimizes
+    Return a fhirpathpy parser for a specific FHIRPath. This cached function minimizes
     calls to the relatively expensive :func:`fhirpathpy.compile` function for any given
     `fhirpath_expression`
 

--- a/phdi/fhir/transport/export.py
+++ b/phdi/fhir/transport/export.py
@@ -35,6 +35,7 @@ def export_from_fhir_server(
       for export files to be generated
     :param poll_timeout: The maximum number of seconds to wait for export files to
       be generated
+    :param return:
     """
 
     # Combine template variables into export endpoint
@@ -97,6 +98,7 @@ def export_from_fhir_server_poll(
       for export files to be generated
     :param poll_timeout: the maximum number of seconds to wait for export files to
       be generated
+    :param return: A response from polled endpoint
     :raises polling.TimeoutException: If the FHIR server continually returns a 202
       status indicating in progress until the timeout is reached
     :raises requests.HTTPError: If an unexpected status code is returned
@@ -138,6 +140,7 @@ def _compose_export_url(
       back
     :param container: The container where we want to store the uploaded
     files
+    :param return: An export url string
     """
     export_url = fhir_url
     if export_scope == "Patient" or export_scope.startswith("Group/"):
@@ -178,6 +181,7 @@ def _export_from_fhir_server_poll_call(
     :param poll_url: The endpoint the FHIR server gave us to query for if
       our files are ready
     :param cred_manager: Service used to get an access token used to make a request
+    :param return: An HTTP response (if 200) or None (if still in progress)
     """
     access_token = cred_manager.get_access_token()
     response = http_request_with_reauth(

--- a/phdi/fhir/transport/export.py
+++ b/phdi/fhir/transport/export.py
@@ -35,7 +35,7 @@ def export_from_fhir_server(
       for export files to be generated
     :param poll_timeout: The maximum number of seconds to wait for export files to
       be generated
-    :param return:
+    :return: The JSON-formatted HTTP response of a completed export operation as a dict
     """
 
     # Combine template variables into export endpoint
@@ -98,7 +98,7 @@ def export_from_fhir_server_poll(
       for export files to be generated
     :param poll_timeout: the maximum number of seconds to wait for export files to
       be generated
-    :param return: A response from polled endpoint
+    :return: A response from polled endpoint
     :raises polling.TimeoutException: If the FHIR server continually returns a 202
       status indicating in progress until the timeout is reached
     :raises requests.HTTPError: If an unexpected status code is returned
@@ -140,7 +140,7 @@ def _compose_export_url(
       back
     :param container: The container where we want to store the uploaded
     files
-    :param return: An export url string
+    :return: An export url string
     """
     export_url = fhir_url
     if export_scope == "Patient" or export_scope.startswith("Group/"):
@@ -181,7 +181,7 @@ def _export_from_fhir_server_poll_call(
     :param poll_url: The endpoint the FHIR server gave us to query for if
       our files are ready
     :param cred_manager: Service used to get an access token used to make a request
-    :param return: An HTTP response (if 200) or None (if still in progress)
+    :return: An HTTP response (if 200) or None (if still in progress)
     """
     access_token = cred_manager.get_access_token()
     response = http_request_with_reauth(

--- a/phdi/fhir/transport/http.py
+++ b/phdi/fhir/transport/http.py
@@ -119,9 +119,7 @@ def upload_bundle_to_fhir_server(
     return response
 
 
-def fhir_server_get(
-    url: str, cred_manager: BaseCredentialManager
-) -> requests.models.Response:
+def fhir_server_get(url: str, cred_manager: BaseCredentialManager) -> requests.Response:
     """
     Submit a GET request to a FHIR server given a url and access token for
     authentication.

--- a/phdi/fhir/transport/http.py
+++ b/phdi/fhir/transport/http.py
@@ -16,7 +16,7 @@ def http_request_with_reauth(
     data: dict = None,
 ) -> requests.Response:
     """
-    First, call :func:`utils.http_request_with_retry`.  If the first call failed
+    First, call :func:`utils.http_request_with_retry`. If the first call failed
     with an authorization error (HTTP status 401), obtain a new token using the
     `cred_manager`, and if the original request had an Authorization header, replace
     with the new token and re-initiate :func:`utils.http_request_with_retry`.
@@ -149,7 +149,7 @@ def fhir_server_get(
 
 def _log_fhir_server_error(status_code: int, batch_entry_index: int = None) -> None:
     """
-    Given an HTTP status code from a FHIR server's response, log the specified error.
+    Log the error for a given an HTTP status code from a FHIR server's response.
 
     :param status_code: Status code returned by a FHIR server
     :param return:

--- a/phdi/fhir/transport/http.py
+++ b/phdi/fhir/transport/http.py
@@ -70,13 +70,13 @@ def upload_bundle_to_fhir_server(
     Import a FHIR resource bundle to the FHIR server.
 
     :param bundle: FHIR bundle (type "batch" or "transaction") to post.  Each entry in
-      the bundle must contain a `request` element in addition to a `resource`.
+      the bundle must contain a `request` element in addition to a `resource`
       The FHIR API provides additional details on creating
       [FHIR-conformant batch/transaction](https://hl7.org/fhir/http.html#transaction)
-      bundles.
+      bundles
     :param access_token: FHIR Server access token
     :param fhir_url: The url of the FHIR server to upload to
-    :return: A requests.Request object containing the response from the FHIR server.
+    :return: A requests.Request object containing the response from the FHIR server
     """
 
     access_token = cred_manager.get_access_token()
@@ -126,10 +126,10 @@ def fhir_server_get(
     Submit a GET request to a FHIR server given a url and access token for
     authentication.
 
-    :param url: URL specifying a GET request on a FHIR server.
+    :param url: URL specifying a GET request on a FHIR server
     :param cred_manager: Service used to get an access token used to make a
-        request.
-    :return: A requests.Request object containing the response from the FHIR server.
+        request
+    :return: A requests.Request object containing the response from the FHIR server
     """
     access_token = cred_manager.get_access_token()
     # Open connection to the export operation and kickoff process
@@ -148,9 +148,11 @@ def fhir_server_get(
 
 
 def _log_fhir_server_error(status_code: int, batch_entry_index: int = None) -> None:
-    """Given an HTTP status code from a FHIR server's response, log the specified error.
+    """
+    Given an HTTP status code from a FHIR server's response, log the specified error.
 
     :param status_code: Status code returned by a FHIR server
+    :param return:
     """
     # TODO: We may dedcide to remove logging, and instead report errors back to
     # calling function as raised exceptions.

--- a/phdi/fhir/transport/http.py
+++ b/phdi/fhir/transport/http.py
@@ -32,8 +32,8 @@ def http_request_with_reauth(
     :param headers: JSON-type dictionary of headers to make the request with,
       including Authorization and content-type
     :param data: JSON data in the case that the request requires data to be
-      posted. Defaults to none.
-    :return: A requests.Request object containing the response from the FHIR server.
+      posted. Defaults to none
+    :return: A requests.Request object containing the response from the FHIR server
     """
 
     response = http_request_with_retry(
@@ -152,7 +152,6 @@ def _log_fhir_server_error(status_code: int, batch_entry_index: int = None) -> N
     Log the error for a given an HTTP status code from a FHIR server's response.
 
     :param status_code: Status code returned by a FHIR server
-    :param return:
     """
     # TODO: We may dedcide to remove logging, and instead report errors back to
     # calling function as raised exceptions.

--- a/phdi/fhir/utils.py
+++ b/phdi/fhir/utils.py
@@ -36,7 +36,7 @@ def get_field(resource: dict, field: str, use: str, default_field: int) -> str:
     :param default_field: The index of the field type to treat as
       the default return type if no field with the requested use case is
       found
-    :param return: The first instance of the field value matching the desired
+    :return: The first instance of the field value matching the desired
       use, or a default field value if a match couldn't be found
     """
     # The next function returns the "next" (in our case first) item from an
@@ -54,7 +54,7 @@ def get_one_line_address(address: dict) -> str:
     JSON dictionary holding address information.
 
     :param address: The address bundle
-    :param return: A one-line string representation of an address
+    :return: A one-line string representation of an address
     """
     raw_one_line = " ".join(address.get("line", []))
     raw_one_line += f" {address.get('city')}, {address.get('state')}"

--- a/phdi/fhir/utils.py
+++ b/phdi/fhir/utils.py
@@ -22,14 +22,13 @@ def find_entries_by_resource_type(bundle: dict, resource_type: str) -> List[dict
 # facing (i.e. make it more robust, less fragile, etc.)
 def get_field(resource: dict, field: str, use: str, default_field: int) -> str:
     """
-    For a given field (such as name or address), find the first-occuring
-    instance of the field in a given FHIR-formatted JSON dict, such that
-    the instance is associated with a particular "use" case of the field
-    (use case here refers to the FHIR-based usage of classifying how a
-    value is used in reporting). For example, find the first name for a
-    patient that has a "use" of "official" (meaning the name is used
-    for official reports). If no instance of a field with the requested
-    use case can be found, instead return a specified default field.
+    Find the first-occuring instance of the field in a given FHIR-formatted JSON dict,
+    such that the instance is associated with a particular "use" case of a given field
+    (such as name or address). Use case here refers to the FHIR-based usage of
+    classifying how a value is used in reporting. For example, find the first name for a
+    patient that has a "use" of "official" (meaning the name is used for official
+    reports). If no instance of a field with the requested use case can be found,
+    instead return a specified default field.
 
     :param resource: Resource from a FHIR bundle
     :param field: The field to extract
@@ -37,7 +36,7 @@ def get_field(resource: dict, field: str, use: str, default_field: int) -> str:
     :param default_field: The index of the field type to treat as
       the default return type if no field with the requested use case is
       found
-    :return: The first instance of the field value matching the desired
+    :param return: The first instance of the field value matching the desired
       use, or a default field value if a match couldn't be found
     """
     # The next function returns the "next" (in our case first) item from an
@@ -55,6 +54,7 @@ def get_one_line_address(address: dict) -> str:
     JSON dictionary holding address information.
 
     :param address: The address bundle
+    :param return: A one-line string representation of an address
     """
     raw_one_line = " ".join(address.get("line", []))
     raw_one_line += f" {address.get('city')}, {address.get('state')}"

--- a/phdi/geospatial/smarty.py
+++ b/phdi/geospatial/smarty.py
@@ -44,7 +44,7 @@ class SmartyGeocodeClient(BaseGeocodeClient):
         to precisely geocode the address, so no result is returned.
 
         :param address: The address to geocode, given as a string
-        :return: A GeocodeResult object (if valid result) or None (if invalid
+        :return: A GeocodeResult object (if valid result) or None (if no valid
           result)
         """
         lookup = Lookup(street=address)
@@ -58,7 +58,7 @@ class SmartyGeocodeClient(BaseGeocodeClient):
         return, otherwise the return None.
 
         :param address: a dictionary with fields outlined above
-        :return: A GeocodeResult object (if valid result) or None (if invalid
+        :return: A GeocodeResult object (if valid result) or None (if no valid
           result)
         """
 
@@ -79,7 +79,7 @@ class SmartyGeocodeClient(BaseGeocodeClient):
         return self._parse_smarty_result(lookup)
 
     @staticmethod
-    def _parse_smarty_result(lookup):
+    def _parse_smarty_result(lookup) -> Union[GeocodeResult, None]:
         """
         Private helper function to parse a returned Smarty geocoding result into
         our standardized GeocodeResult class. If the Smarty lookup is null or
@@ -88,7 +88,7 @@ class SmartyGeocodeClient(BaseGeocodeClient):
 
         :param lookup: The us_street.lookup client instantiated for geocoding
         :return: A parsed GeocodeResult object (if valid result) or None (if
-          invalid result)
+          no valid result)
         """
         # Valid responses have results with lat/long
         if lookup.result and lookup.result[0].metadata.latitude:

--- a/phdi/geospatial/smarty.py
+++ b/phdi/geospatial/smarty.py
@@ -38,7 +38,7 @@ class SmartyGeocodeClient(BaseGeocodeClient):
 
     def geocode_from_str(self, address: str) -> Union[GeocodeResult, None]:
         """
-        Geocodes a string-formatted address using SmartyStreets. If the result
+        Geocode a string-formatted address using SmartyStreets. If the result
         comes back valid, output is stored in a GeocodeResult object. If the
         result could not be latitude- or longitude-located, then Smarty failed
         to precisely geocode the address, so no result is returned.
@@ -53,9 +53,9 @@ class SmartyGeocodeClient(BaseGeocodeClient):
 
     def geocode_from_dict(self, address: dict) -> Union[GeocodeResult, None]:
         """
-        Geocodes a dictionary-formatted address using SmartyStreets.
-        If a result is found, it is encoded as a GeocodeResult object and
-        returned, otherwise the function returns None.
+        Geocode a dictionary-formatted address using SmartyStreets.
+        If a result is found, encode as a GeocodeResult object and
+        return, otherwise the return None.
 
         :param address: a dictionary with fields outlined above
         :param return: A GeocodeResult object (if valid result) or None (if invalid

--- a/phdi/geospatial/smarty.py
+++ b/phdi/geospatial/smarty.py
@@ -44,6 +44,8 @@ class SmartyGeocodeClient(BaseGeocodeClient):
         to precisely geocode the address, so no result is returned.
 
         :param address: The address to geocode, given as a string
+        :param return: A GeocodeResult object (if valid result) or None (if invalid
+          result)
         """
         lookup = Lookup(street=address)
         self.__client.send_lookup(lookup)
@@ -56,6 +58,8 @@ class SmartyGeocodeClient(BaseGeocodeClient):
         returned, otherwise the function returns None.
 
         :param address: a dictionary with fields outlined above
+        :param return: A GeocodeResult object (if valid result) or None (if invalid
+          result)
         """
 
         # Configure the lookup with whatever provided address values
@@ -83,6 +87,8 @@ class SmartyGeocodeClient(BaseGeocodeClient):
         instead.
 
         :param lookup: The us_street.lookup client instantiated for geocoding
+        :param return: A parsed GeocodeResult object (if valid result) or None (if
+          invalid result)
         """
         # Valid responses have results with lat/long
         if lookup.result and lookup.result[0].metadata.latitude:

--- a/phdi/geospatial/smarty.py
+++ b/phdi/geospatial/smarty.py
@@ -44,7 +44,7 @@ class SmartyGeocodeClient(BaseGeocodeClient):
         to precisely geocode the address, so no result is returned.
 
         :param address: The address to geocode, given as a string
-        :param return: A GeocodeResult object (if valid result) or None (if invalid
+        :return: A GeocodeResult object (if valid result) or None (if invalid
           result)
         """
         lookup = Lookup(street=address)
@@ -58,7 +58,7 @@ class SmartyGeocodeClient(BaseGeocodeClient):
         return, otherwise the return None.
 
         :param address: a dictionary with fields outlined above
-        :param return: A GeocodeResult object (if valid result) or None (if invalid
+        :return: A GeocodeResult object (if valid result) or None (if invalid
           result)
         """
 
@@ -87,7 +87,7 @@ class SmartyGeocodeClient(BaseGeocodeClient):
         instead.
 
         :param lookup: The us_street.lookup client instantiated for geocoding
-        :param return: A parsed GeocodeResult object (if valid result) or None (if
+        :return: A parsed GeocodeResult object (if valid result) or None (if
           invalid result)
         """
         # Valid responses have results with lat/long

--- a/phdi/harmonization/hl7.py
+++ b/phdi/harmonization/hl7.py
@@ -106,8 +106,8 @@ def convert_hl7_batch_messages_to_list(
     }
     [FTS] (file trailer segment)
 
-    We ignore lines that start with these since we don't want to include
-    them in a message.
+    We ignore lines that start with these header/tail segments since we don't want to
+    include them in a message.
 
     :param content: the batch content to turn into a list
     :param delimiter: the character delimiting messages in the batch
@@ -200,7 +200,7 @@ def _normalize_hl7_datetime_segment(
 ) -> None:
     """
     Utility function used to apply datetime normalization
-    to multiple fields in a segment.
+    to multiple fields in a segment, overwriting the input segment.
 
     :param message: The HL7 message, represented as a list
       of indexable component strings (which is how the HL7 library
@@ -210,7 +210,7 @@ def _normalize_hl7_datetime_segment(
     :param field_list: The list of fields contained in the
       indexed message component, which are themselves indices to
       data strings
-    :return: None (overwrites the input segment)
+    :return:
     """
     try:
         for segment in message.segments(segment_id):

--- a/phdi/harmonization/hl7.py
+++ b/phdi/harmonization/hl7.py
@@ -210,7 +210,6 @@ def _normalize_hl7_datetime_segment(
     :param field_list: The list of fields contained in the
       indexed message component, which are themselves indices to
       data strings
-    :return:
     """
     try:
         for segment in message.segments(segment_id):

--- a/phdi/harmonization/hl7.py
+++ b/phdi/harmonization/hl7.py
@@ -199,8 +199,8 @@ def _normalize_hl7_datetime_segment(
     message: hl7.Message, segment_id: str, field_list: list
 ) -> None:
     """
-    Utility function used to apply datetime normalization
-    to multiple fields in a segment, overwriting the input segment.
+    Apply datetime normalization to multiple fields in a segment,
+    overwriting the input segment.
 
     :param message: The HL7 message, represented as a list
       of indexable component strings (which is how the HL7 library

--- a/phdi/harmonization/standardization.py
+++ b/phdi/harmonization/standardization.py
@@ -23,6 +23,8 @@ def standardize_country_code(
       put in ISO 3611 standardized form
     :param code_type: One of 'alpha_2', 'alpha_3', or 'numeric'; the
       desired identifier type to generate
+    :param return: A list of all the standardized countries found in the resource's
+     addresses
     """
 
     # @TODO: Potentially do some minor restructuring around this logic

--- a/phdi/harmonization/standardization.py
+++ b/phdi/harmonization/standardization.py
@@ -21,8 +21,7 @@ def standardize_country_code(
       put in ISO 3611 standardized form
     :param code_type: One of 'alpha_2', 'alpha_3', or 'numeric'; the
       desired identifier type to generate
-    :param return: A list of all the standardized countries found in the resource's
-     addresses
+    :return: The standardized country identifier found in the resource's addresses
     """
 
     # @TODO: Potentially do some minor restructuring around this logic

--- a/phdi/harmonization/standardization.py
+++ b/phdi/harmonization/standardization.py
@@ -7,12 +7,10 @@ def standardize_country_code(
     raw_country: str, code_type: Literal["alpha_2", "alpha_3", "numeric"] = "alpha_2"
 ) -> str:
     """
-    Given a string representation of a country (whether a full name
-    such as "United States", or an abbreviation such as "US" or "USA"),
-    first identify the country represented by the string, then
-    generate the ISO 3611 standardized country identifier of the
-    desired type. If the country cannot be determined, the function
-    returns None.
+    Identify the country represented and generate the desired type of the ISO
+    3611 standardized country identifier for a given string representation of a country
+    (whether a full name such as "United States", or an abbreviation such as "US"
+    or "USA"). If the country cannot be determined, return None.
 
     Example: If raw_country = "United States of America," then
       - alpha_2 would be "US"
@@ -63,12 +61,11 @@ def standardize_phone(
     raw_phone: Union[str, List[str]], countries: List = [None, "US"]
 ) -> Union[str, List[str]]:
     """
-    Given one or more phone numbers, and optionally a list of countries
-    associated with those phone numbers, parse each phone number and
-    generate its standardized ISO E.164 international format. If an
-    input phone number can't be parsed, that number will return the
-    empty string. The function attempts to parse the inputs using
-    the first successful strategy out of the following:
+    Parse phone number and generate its standardized ISO E.164 international format for
+    each given phone number and optional list of associated countries. If an input phone
+    number can't be parsed, that number will return the empty string. The function
+    attempts to parse the inputs using the first successful strategy out of the
+    following:
 
     1. parse the phone number on its own
     2. parse the phone number using the provided list of possible
@@ -133,10 +130,10 @@ def standardize_name(
     remove_numbers: bool = True,
 ) -> Union[str, List[str]]:
     """
-    Given one or more names, perform some basic standardization on each
-    of them. All given input strings have punctuation characters removed,
-    and then a variety of additional cleaning operations can be toggled
-    on or off using the relevant parameter. The options include:
+    Perform basic standardization (described below) on each given name. All given input
+    strings have punctuation characters removed, and then a variety of additional
+    cleaning operations can be toggled on or off using the relevant parameter.
+    The cleaning operations include:
 
     - trim: stripping leading and trailing whitespace
     - remove_numbers: remove all numeric characters from the input
@@ -153,7 +150,6 @@ def standardize_name(
     :remove_numbers: Whether to remove numeric characters from the inputs
     :return: Either a string or a list of strings, depending on the
       input of raw_name, holding the cleaned name(s)
-
     """
     names_to_clean = raw_name
     if isinstance(raw_name, str):

--- a/phdi/harmonization/standardization.py
+++ b/phdi/harmonization/standardization.py
@@ -75,10 +75,8 @@ def standardize_phone(
     :param countries: An optional list containing 2 letter ISO codes
       associated with the phone numbers, signifying to which countries
       the phone numbers might belong
-    :return: Either a string representing the cleaned phone numbers,
-      or a list of strings of cleaned numbers; if one phone number in
-      the input list couldn't be standardized, the index in the returned
-      list for that phone number will be the empty string
+    :return: Either a string or a list of strings, depending on the
+      input of raw_phone, holding the standardized phone number(s)
     """
 
     # Base cases: we always want to try the phone # on its own first;

--- a/phdi/linkage/link.py
+++ b/phdi/linkage/link.py
@@ -10,7 +10,7 @@ def generate_hash_str(linking_identifier: str, salt_str: str) -> str:
         address, and date of birth, delimited by dashes
     :param salt_str: The salt to concatenate onto the end to prevent
         being able to reverse-engineer PII
-    :param return: Hash of the linking_identifier string
+    :return: Hash of the linking_identifier string
     """
     hash_obj = hashlib.sha256()
     to_encode = (linking_identifier + salt_str).encode("utf-8")

--- a/phdi/linkage/link.py
+++ b/phdi/linkage/link.py
@@ -3,9 +3,8 @@ import hashlib
 
 def generate_hash_str(linking_identifier: str, salt_str: str) -> str:
     """
-    Given a string made of concatenated patient information, generate
-    a hash for this string to serve as a "unique" identifier for the
-    patient.
+    Generate a hash for a given string of concatenated patient information. The hash
+    will serve as a "unique" identifier for the patient.
 
     :param linking_identifier: The concatenation of a patient's name,
         address, and date of birth, delimited by dashes

--- a/phdi/linkage/link.py
+++ b/phdi/linkage/link.py
@@ -11,6 +11,7 @@ def generate_hash_str(linking_identifier: str, salt_str: str) -> str:
         address, and date of birth, delimited by dashes
     :param salt_str: The salt to concatenate onto the end to prevent
         being able to reverse-engineer PII
+    :param return: Hash of the linking_identifier string
     """
     hash_obj = hashlib.sha256()
     to_encode = (linking_identifier + salt_str).encode("utf-8")

--- a/phdi/tabulation/tables.py
+++ b/phdi/tabulation/tables.py
@@ -16,6 +16,7 @@ def load_schema(path: str) -> dict:
     If the file can't be found, raises an error.
 
     :param path: File path to a YAML file holding a schema
+    :param return:
     """
     try:
         with open(path, "r") as file:
@@ -46,7 +47,8 @@ def write_table(
     :param output_format: The file format of the table to be written
     :param writer: Optional; a writer object that can be maintained
       between different calls of this function to support file formats
-      that cannot be appended to after being written (e.g. parquet).
+      that cannot be appended to after being written (e.g. parquet)
+    :param return:
     """
 
     if file_format == "parquet":
@@ -78,6 +80,7 @@ def print_schema_summary(
     :param display_head: Print the head of each table when true.
       Note: depending on the file format, this may require
       reading large amounts of data into memory
+    :param return:
     """
     for (directory_path, _, file_names) in os.walk(directory):
         for file_name in file_names:

--- a/phdi/tabulation/tables.py
+++ b/phdi/tabulation/tables.py
@@ -6,7 +6,7 @@ import pyarrow.parquet as pq
 import yaml
 
 from pathlib import Path
-from typing import Literal, List
+from typing import Literal, List, Union
 
 
 def load_schema(path: str) -> dict:
@@ -31,7 +31,7 @@ def write_table(
     output_file_name: pathlib.Path,
     file_format: Literal["parquet", "csv"],
     writer: pq.ParquetWriter = None,
-) -> None:
+) -> Union[None, pq.ParquetWriter]:
     """
     Given data stored as a list of dictionaries, where all dicts
     have a common set of keys, write the set of data to an output
@@ -48,6 +48,7 @@ def write_table(
     :param writer: Optional; a writer object that can be maintained
       between different calls of this function to support file formats
       that cannot be appended to after being written (e.g. parquet)
+    :return: pq.ParquetWriter if file_format is parquet; else None
     """
 
     if file_format == "parquet":
@@ -55,6 +56,7 @@ def write_table(
         if writer is None:
             writer = pq.ParquetWriter(output_file_name, table.schema)
         writer.write_table(table=table)
+        return writer
 
     if file_format == "csv":
         keys = data[0].keys()

--- a/phdi/tabulation/tables.py
+++ b/phdi/tabulation/tables.py
@@ -16,7 +16,7 @@ def load_schema(path: str) -> dict:
     If the file can't be found, raises an error.
 
     :param path: File path to a YAML file holding a schema
-    :param return:
+    :return: A dict representing a schema read from the given path
     """
     try:
         with open(path, "r") as file:
@@ -48,7 +48,6 @@ def write_table(
     :param writer: Optional; a writer object that can be maintained
       between different calls of this function to support file formats
       that cannot be appended to after being written (e.g. parquet)
-    :param return:
     """
 
     if file_format == "parquet":
@@ -56,7 +55,6 @@ def write_table(
         if writer is None:
             writer = pq.ParquetWriter(output_file_name, table.schema)
         writer.write_table(table=table)
-        return writer
 
     if file_format == "csv":
         keys = data[0].keys()
@@ -80,7 +78,6 @@ def print_schema_summary(
     :param display_head: Print the head of each table when true.
       Note: depending on the file format, this may require
       reading large amounts of data into memory
-    :param return:
     """
     for (directory_path, _, file_names) in os.walk(directory):
         for file_name in file_names:

--- a/phdi/tabulation/tables.py
+++ b/phdi/tabulation/tables.py
@@ -73,8 +73,8 @@ def print_schema_summary(
     display_head: bool = False,
 ) -> None:
     """
-    Given a directory containing tables in either CSV or Parquet
-    format, print a summary of each table.
+    Print a summary of each CSV of Parquet formatted table in a given directory of
+    tables.
 
     :param directory: Path to a direct holding table files
     :param display_head: Print the head of each table when true.

--- a/phdi/transport/http.py
+++ b/phdi/transport/http.py
@@ -14,7 +14,7 @@ def http_request_with_retry(
     data: dict = None,
 ) -> requests.Response:
     """
-    Executes an HTTP request, retrying the request if the returned HTTP status code
+    Execute an HTTP request, retrying the request if the returned HTTP status code
     is one of a specified list of codes.
 
     :param url: The url at which to make the HTTP request

--- a/phdi/transport/http.py
+++ b/phdi/transport/http.py
@@ -28,9 +28,9 @@ def http_request_with_retry(
       including Authorization and content-type
     :param data: JSON data in the case that the request requires data to be
       posted. Defaults to none
-    :param return: A HTTP request response
     :raises ValueError: An unsupported HTTP method (e.g. PATCH, DELETE, etc) was passed
       to the request_type parameter
+    :return: A HTTP request response
     """
 
     request_type = request_type.upper()

--- a/phdi/transport/http.py
+++ b/phdi/transport/http.py
@@ -21,15 +21,16 @@ def http_request_with_retry(
     :param retry_count: The number of times to re-try the request, if the
       first attempt fails
     :param request_type: The type of request to be made. Currently supports
-      GET and POST.
+      GET and POST
     :param allowed_methods: The list of allowed HTTP request methods (i.e.
       POST, PUT, etc.) for the specific URL and query
     :param headers: JSON-type dictionary of headers to make the request with,
       including Authorization and content-type
     :param data: JSON data in the case that the request requires data to be
-      posted. Defaults to none.
+      posted. Defaults to none
+    :param return: A HTTP request response
     :raises ValueError: An unsupported HTTP method (e.g. PATCH, DELETE, etc) was passed
-      to the request_type parameter.
+      to the request_type parameter
     """
 
     request_type = request_type.upper()


### PR DESCRIPTION
Started adding :param return: items to all functions with docstrings but wanted someone to take a look at general formatting (e.g.,) removed periods from docstring params) before proceeding. Some of the docstring descriptions and return params are repetitive but for the sake of consistency, I think it's okay. 