### PR TITLE
Code Coverage for Linkage

### DIFF
--- a/phdi/fhir/linkage/link.py
+++ b/phdi/fhir/linkage/link.py
@@ -29,11 +29,13 @@ def add_patient_identifier_in_bundle(
 
     for entry in find_resource_by_type(bundle, "Patient"):
         patient = entry.get("resource")
-        add_patient_identifier(patient, salt_str, overwrite)
+        add_patient_identifier(patient, salt_str)
     return bundle
 
 
-def add_patient_identifier(patient_resource, salt_str, overwrite):
+def add_patient_identifier(
+    patient_resource: dict, salt_str: str, overwrite: bool = True
+):
     """
     Given a FHIR resource:
 

--- a/tests/fhir/linkage/test_fhir_link.py
+++ b/tests/fhir/linkage/test_fhir_link.py
@@ -85,3 +85,67 @@ def test_patient_identifier():
             assert len(resource["identifier"]) == 2
             assert resource["identifier"][-1] == expected_new_identifier
             break
+
+
+def test_bundle_overwrite():
+    salt_str = "super-legit-salt"
+
+    incoming_bundle = json.load(
+        open(
+            pathlib.Path(__file__).parent.parent.parent
+            / "assets"
+            / "patient_with_linking_id_bundle.json"
+        )
+    )
+
+    plaintext = (
+        "John-Tiberius-Shepard-2053-11-07-"
+        + "1234 Silversun Strip Zakera Ward, Citadel 99999"
+    )
+
+    expected_new_identifier = {
+        "value": generate_hash_str(plaintext, salt_str),
+        "system": "urn:ietf:rfc:3986",
+        "use": "temp",
+    }
+
+    new_bundle = add_patient_identifier_in_bundle(incoming_bundle, salt_str, False)
+    assert new_bundle != incoming_bundle
+    assert len(new_bundle["entry"]) == 3
+
+    for resource in new_bundle["entry"]:
+        if resource["resource"]["resourceType"] == "Patient":
+            assert len(resource["resource"]["identifier"]) == 2
+            assert resource["resource"]["identifier"][-1] == expected_new_identifier
+
+
+def test_overwrite():
+    salt_str = "super-legit-salt"
+
+    incoming_bundle = json.load(
+        open(
+            pathlib.Path(__file__).parent.parent.parent
+            / "assets"
+            / "patient_with_linking_id_bundle.json"
+        )
+    )
+
+    plaintext = (
+        "John-Tiberius-Shepard-2053-11-07-"
+        + "1234 Silversun Strip Zakera Ward, Citadel 99999"
+    )
+
+    expected_new_identifier = {
+        "value": generate_hash_str(plaintext, salt_str),
+        "system": "urn:ietf:rfc:3986",
+        "use": "temp",
+    }
+
+    for entry in incoming_bundle["entry"]:
+        if entry["resource"]["resourceType"] == "Patient":
+            resource = entry.get("resource")
+            new_resource = add_patient_identifier(resource, salt_str, False)
+            assert len(new_resource["identifier"]) == 2
+            assert new_resource["identifier"][-1] == expected_new_identifier
+            assert new_resource != resource
+            break

--- a/tests/fhir/linkage/test_fhir_link.py
+++ b/tests/fhir/linkage/test_fhir_link.py
@@ -26,7 +26,7 @@ def test_missing_address():
     assert actual == expected
 
 
-def test_add_patient_identifier_by_bundle():
+def test_add_patient_identifier_by_bundle_overwrite():
     salt_str = "super-legit-salt"
 
     incoming_bundle = json.load(
@@ -56,7 +56,7 @@ def test_add_patient_identifier_by_bundle():
             assert resource["resource"]["identifier"][-1] == expected_new_identifier
 
 
-def test_patient_identifier():
+def test_patient_identifier_overwrite():
     salt_str = "super-legit-salt"
 
     incoming_bundle = json.load(
@@ -87,7 +87,7 @@ def test_patient_identifier():
             break
 
 
-def test_bundle_overwrite():
+def test_add_patient_identifier_by_bundle():
     salt_str = "super-legit-salt"
 
     incoming_bundle = json.load(
@@ -119,7 +119,7 @@ def test_bundle_overwrite():
             assert resource["resource"]["identifier"][-1] == expected_new_identifier
 
 
-def test_overwrite():
+def test_add_patient_identifier():
     salt_str = "super-legit-salt"
 
     incoming_bundle = json.load(


### PR DESCRIPTION
[ClickUp Ticket](https://reportstream-service-request.clickup.com/t/3g9pbgz)

To increase the code coverage for linkage unit tests. The `overwrite = False` needed to be tested. This PR adds two tests for both bundle and resource linkage as well as fixing a logic bug on the linkage bundle 

