### PR TITLE
Cloud code coverage

### DIFF
--- a/phdi/cloud/core.py
+++ b/phdi/cloud/core.py
@@ -14,7 +14,7 @@ class BaseCredentialManager(ABC):
 
         :return: A credential object
         """
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     def get_access_token(self) -> str:
@@ -23,7 +23,7 @@ class BaseCredentialManager(ABC):
 
         :return: An access token
         """
-        pass
+        pass  # pragma: no cover
 
 
 class BaseCloudContainerConnection(ABC):
@@ -40,7 +40,7 @@ class BaseCloudContainerConnection(ABC):
         :return: The `stream` parameter, if supplied. Otherwise a new stream object
         containing blob content.
         """
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     def upload_object(
@@ -58,7 +58,7 @@ class BaseCloudContainerConnection(ABC):
         :param container_name: The name of the target container for upload
         :param filename: Location of file within storage container
         """
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     def list_containers(self) -> List[str]:
@@ -67,7 +67,7 @@ class BaseCloudContainerConnection(ABC):
 
         :return: A list of container names
         """
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     def list_objects(self) -> List[str]:
@@ -78,4 +78,4 @@ class BaseCloudContainerConnection(ABC):
         :param prefix: Filter for objects whose filenames begin with this value
         :return: A list of objects within a container
         """
-        pass
+        pass  # pragma: no cover

--- a/tests/cloud/test_cloud.py
+++ b/tests/cloud/test_cloud.py
@@ -220,7 +220,7 @@ def test_gcp_credential_manager_handle_expired_token(mock_gcp_creds, mock_gcp_re
     # credential manager when a new token is requested.
     assert credential_manager.get_project_id() is not None
     scoped_credentials = credential_manager.get_credential_object()
-    scoped_credentials == credential_manager.scoped_credentials
+    assert scoped_credentials == credential_manager.scoped_credentials
     assert credential_manager.project_id is not None
     _ = credential_manager.get_access_token()
     assert mock_gcp_requests.called

--- a/tests/cloud/test_cloud.py
+++ b/tests/cloud/test_cloud.py
@@ -3,6 +3,7 @@ import pathlib
 import pytest
 import io
 
+from azure.storage.blob import ContainerClient
 from datetime import datetime, timezone
 from unittest import mock
 from phdi.cloud.azure import (
@@ -161,6 +162,11 @@ def test_azure_credential_manager_force_refresh_token(mock_az_creds):
     assert access_token == az_access_token_str2
 
 
+def test_azure_need_new_token_without_token():
+    cred_manager = AzureCredentialManager("https://some-url")
+    assert cred_manager._need_new_token()
+
+
 @mock.patch("phdi.cloud.gcp.google.auth.transport.requests.Request")
 @mock.patch("phdi.cloud.gcp.google.auth.default")
 def test_gcp_credential_manager(mock_gcp_creds, mock_gcp_requests):
@@ -199,7 +205,6 @@ def test_gcp_credential_manager_handle_expired_token(mock_gcp_creds, mock_gcp_re
     # Set dummy project ID, access token, and scope values.
     project_id = "some-project"
     token = "some-token"
-    scope = ["some-scope"]
 
     # Make dummy GCP credentials object.
     credentials = mock.Mock()
@@ -209,11 +214,14 @@ def test_gcp_credential_manager_handle_expired_token(mock_gcp_creds, mock_gcp_re
 
     mock_gcp_creds.return_value = credentials, project_id
 
-    credential_manager = GcpCredentialManager(scope=scope)
+    credential_manager = GcpCredentialManager()
 
     # When invalid credentials are encountered they should be refreshed by the
     # credential manager when a new token is requested.
-    _ = credential_manager.get_credential_object()
+    assert credential_manager.get_project_id() is not None
+    scoped_credentials = credential_manager.get_credential_object()
+    scoped_credentials == credential_manager.scoped_credentials
+    assert credential_manager.project_id is not None
     _ = credential_manager.get_access_token()
     assert mock_gcp_requests.called
 
@@ -245,7 +253,7 @@ def test_gcp_credential_manager_handle_expired_credentials(
     assert mock_gcp_creds.call_count == 2
 
 
-@mock.patch.object(AzureCloudContainerConnection, "_get_container_client")
+@mock.patch.object(ContainerClient, "from_container_url")
 def test_upload_object(mock_get_client):
     mock_blob_client = mock.Mock()
 

--- a/tests/fhir/cloud/test_fhir_cloud.py
+++ b/tests/fhir/cloud/test_fhir_cloud.py
@@ -1,29 +1,22 @@
-import io
+import pytest
 
 from phdi.fhir.cloud.azure import download_from_fhir_export_response
 from unittest import mock
 
 
-@mock.patch("phdi.fhir.cloud.azure._download_export_blob")
-def test_download_from_export_response(mock_download_export_blob):
-    mock_download_export_blob.side_effect = [
-        io.TextIOWrapper(
-            io.BytesIO(
-                b'{"resourceType": "Patient", "id": "some-id"}\n'
-                + b'{"resourceType": "Patient", "id": "some-id2"}\n'
-            ),
-            encoding="utf-8",
-            newline="\n",
-        ),
-        io.TextIOWrapper(
-            io.BytesIO(
-                b'{"resourceType": "Observation", "id": "some-id"}\n'
-                + b'{"resourceType": "Observation", "id": "some-id2"}\n'
-            ),
-            encoding="utf-8",
-            newline="\n",
-        ),
-    ]
+@mock.patch("phdi.fhir.cloud.azure.download_blob_from_url")
+def test_download_from_export_response(mock_download_blob_from_url):
+    download_iterator = iter(
+        [
+            b'{"resourceType": "Patient", "id": "some-id"}\n'
+            + b'{"resourceType": "Patient", "id": "some-id2"}\n',
+            b'{"resourceType": "Observation", "id": "some-id"}\n'
+            + b'{"resourceType": "Observation", "id": "some-id2"}\n',
+        ]
+    )
+    mock_download_blob_from_url.side_effect = (
+        lambda blob_url, output, credential: output.write(next(download_iterator))
+    )
 
     export_response = {
         "output": [
@@ -38,31 +31,39 @@ def test_download_from_export_response(mock_download_export_blob):
     mock_cred_manager = mock.Mock()
     mock_cred_manager.get_access_token.return_value = "some-token"
 
+    patient_count = 0
+    observation_count = 0
     for type, output in download_from_fhir_export_response(
         cred_manager=mock_cred_manager, export_response=export_response
     ):
         if type == "Patient":
+            patient_count += 1
             assert (
                 output.read()
                 == '{"resourceType": "Patient", "id": "some-id"}\n'
                 + '{"resourceType": "Patient", "id": "some-id2"}\n'
             )
         elif type == "Observation":
+            observation_count += 1
             assert (
                 output.read()
                 == '{"resourceType": "Observation", "id": "some-id"}\n'
                 + '{"resourceType": "Observation", "id": "some-id2"}\n'
             )
 
-    mock_download_export_blob.assert_has_calls(
-        [
-            mock.call(
-                blob_url="https://export-download-url/_Patient",
-                cred_manager=mock_cred_manager,
-            ),
-            mock.call(
-                blob_url="https://export-download-url/_Observation",
-                cred_manager=mock_cred_manager,
-            ),
-        ]
+    assert patient_count == 1
+    assert observation_count == 1
+
+
+def test_download_from_export_response_empty():
+    export_response = {"output": []}
+
+    mock_cred_manager = mock.Mock()
+    mock_cred_manager.get_access_token.return_value = "some-token"
+
+    download_iterator = download_from_fhir_export_response(
+        cred_manager=mock_cred_manager, export_response=export_response
     )
+
+    with pytest.raises(StopIteration):
+        next(download_iterator)


### PR DESCRIPTION
# Description
* Abstract base class methods have comment to exclude them from code coverage.
* Add test case to validate AzureCredentialManager _need_new_token() returns true before token has been assigned
* Tweak test cases for GCP credential manager to test default scope, and `project_id` getter
* Test edge case in FHIR export download for downloading exports with no exported content.