### PR TITLE
Fix test_generate_table_fail

### DIFF
--- a/tests/fhir/tabulation/test_fhir_tabulation.py
+++ b/tests/fhir/tabulation/test_fhir_tabulation.py
@@ -136,7 +136,11 @@ def test_generate_table_success(patch_query, patch_write):
 @mock.patch("phdi.fhir.tabulation.tables.fhir_server_get")
 def test_generate_table_fail(patch_query, patch_write):
 
-    schema = {}
+    schema = yaml.safe_load(
+        open(
+            pathlib.Path(__file__).parent.parent.parent / "assets" / "test_schema.yaml"
+        )
+    )
 
     output_path = mock.Mock()
     output_path.__truediv__ = (  # Redefine division operator to prevent failure.
@@ -152,8 +156,7 @@ def test_generate_table_fail(patch_query, patch_write):
     mock_cred_manager = mock.Mock()
     mock_cred_manager.get_access_token.return_value = mock_access_token
 
-    response = mock.Mock()
-    response.status_code = 400
+    response = mock.Mock(status_code=400)
     patch_query.return_value = response
 
     generate_table(
@@ -163,6 +166,8 @@ def test_generate_table_fail(patch_query, patch_write):
         fhir_url,
         mock_cred_manager,
     )
+
+    patch_query.assert_called()
     patch_write.assert_not_called()
 
 


### PR DESCRIPTION
# Description
This test relied on an assertion that a function, `write_table()` was never called, with the assumption that it wasn't called because the HTTP  status code from the request was 400 instead of 200. The reason the test passed is because `schema` was set to an empty dictionary, which bypassed the entire `for` loop in `generate_table`. As a result, the function was indeed never called, but not for the reason expected.

# Solution
1. Read in an actual schema file from the `assets` library.
2. Add an additional assertion that checks that `fhir_server_get` was actually called, ensuring that the reason `write_table` isn't called is because of the returned `status_code`.

# Test Plan
The following image should demonstrate that this fix is achieving the results we need.

![image](https://user-images.githubusercontent.com/97973748/190243639-3a14c53b-4362-4d7c-989b-c4a8ad9170b9.png)
