### PR TITLE
Migrate PHDI to use containerized conversion solution

### DIFF
--- a/phdi/fhir/conversion/convert.py
+++ b/phdi/fhir/conversion/convert.py
@@ -71,7 +71,7 @@ def convert_to_fhir(
     }
 
     if cred_manager:
-        access_token = cred_manager.get_access_token().token
+        access_token = cred_manager.get_access_token()
         headers["Authorization"] = f"Bearer {access_token}"
         response = http_request_with_reauth(
             cred_manager=cred_manager,

--- a/phdi/fhir/conversion/convert.py
+++ b/phdi/fhir/conversion/convert.py
@@ -100,28 +100,24 @@ def convert_to_fhir(
 
 def _get_fhir_conversion_settings(message: str, use_default_ccda=False) -> dict:
     """
-        Determines which settings to use with the FHIR server to facilitate message
-        conversion by attempting to identify which data type the input has (HL7 or XML)
-        and determine the appropriate FHIR converter root template to use. Raises
-        an exception if the user opts to not use the default CCDA root template for
-        an unsupported input resouece and a message's extracted LOINC code doesn't
-        correspond to an existing CCDA template.
+    Determines which settings to use with the FHIR server to facilitate message
+    conversion by attempting to identify which data type the input has (HL7 or XML)
+    and determine the appropriate FHIR converter root template to use. Raises
+    an exception if the user opts to not use the default CCDA root template for
+    an unsupported input resouece and a message's extracted LOINC code doesn't
+    correspond to an existing CCDA template.
 
-        More information about the required templates and settings can be found here:
+    More information about the required templates and settings can be found here:
 
-        https://docs.microsoft.com/en-us/azure/healthcare-apis/azure-api-for-fhir/convert-data
+    https://docs.microsoft.com/en-us/azure/healthcare-apis/azure-api-for-fhir/convert-data
 
-        :param message: The incoming message.
-        :param use_default_ccda: Whether to default to the
-          base "CCD" root template if a resource's LOINC code doesn't
-    <<<<<<< HEAD
-          map to a specific supported template. Default: `False`
-    =======
-          map to a specific supported template. Default is No.
-        :raises ConversionError: If conversion settings cannot be derived.
-    >>>>>>> 4922a52 (Create ConversionError)
-        :return: A dictionary holding the settings of parameters to-be
-          set when converting the input to FHIR.
+    :param message: The incoming message.
+    :param use_default_ccda: Whether to default to the
+      base "CCD" root template if a resource's LOINC code doesn't
+      map to a specific supported template. Default: `False`
+    :raises ConversionError: If conversion settings cannot be derived.
+    :return: A dictionary holding the settings of parameters to-be
+      set when converting the input to FHIR.
     """
     # Some streams (e.g. ELR, VXU) are HL7v2 encoded
     if message[:3] == "MSH":

--- a/phdi/transport/http.py
+++ b/phdi/transport/http.py
@@ -48,6 +48,7 @@ def http_request_with_retry(
     )
     adapter = HTTPAdapter(max_retries=retry_strategy)
     http = requests.Session()
+    http.mount("http://", adapter)
     http.mount("https://", adapter)
 
     # Now, actually try to complete the API request

--- a/tests/fhir/test_conversion.py
+++ b/tests/fhir/test_conversion.py
@@ -71,10 +71,8 @@ def test_convert_to_fhir_success_cred_manager(mock_requests_session):
     )
 
     mock_access_token_value = "some-token"
-    mock_access_token = mock.Mock()
-    mock_access_token.token = mock_access_token_value
     mock_cred_manager = mock.Mock()
-    mock_cred_manager.get_access_token.return_value = mock_access_token
+    mock_cred_manager.get_access_token.return_value = mock_access_token_value
 
     message = ""
     with open(pathlib.Path(__file__).parent.parent / "assets" / "sample_hl7.hl7") as fp:

--- a/tests/fhir/test_conversion.py
+++ b/tests/fhir/test_conversion.py
@@ -40,7 +40,7 @@ def test_get_fhir_conversion_settings():
     settings = _get_fhir_conversion_settings(message)
     assert settings == {
         "root_template": "ProcedureNote",
-        "input_type": "Ccda",
+        "input_type": "ccda",
     }
 
     # CCDA case (using an adpated example found at
@@ -56,7 +56,7 @@ def test_get_fhir_conversion_settings():
     settings = _get_fhir_conversion_settings(message=message, use_default_ccda=True)
     assert settings == {
         "root_template": "CCD",
-        "input_type": "Ccda",
+        "input_type": "ccda",
     }
 
 

--- a/tutorials/conversion-tutorial.md
+++ b/tutorials/conversion-tutorial.md
@@ -8,14 +8,14 @@ In the design of our building blocks, we have modules to be used specifically wi
 FHIR is a widely used standard designed for storing and interacting with healthcare data. There is significant overlap between healthcare and public health domains. In addition, FHIR standard maintainers have focused on keeping the FHIR data format general so it can be applied to areas like public health. Primary goals of promoting a common format like FHIR include allowing the PHDI tools to help a wider array of public health agencies, and facilitating inter-agency data exchange.
 
 ## Pre-requisites
-Currently, the solution depends on an Azure FHIR Server instance to convert HL7 v2 or CCDA to FHIR. 
+Currently, PHDI depends on a containerized [Azure FHIR Converter](https://github.com/microsoft/FHIR-Converter) to convert HL7 v2 or CCDA to FHIR. The docker container build artifacts are currently located [here](https://github.com/CDCgov/phdi-google-cloud/tree/main/cloud-run/fhir-converter).
+
+[//]: # (TODO The cloud converter containerized solution and its documentation will move to the PHDI library, but this migration hasn't been completed yet. Once the container has been migrated, this will need to be updated to point to the correct location.)
 
 ## The Basics: How to Convert
-This package contains the process of converting HL7 v2 or CCDA into FHIR (JSON). As a part of our library, we encourage the use of the FHIR data type for all of our functions. This package aims to help easily convert other common healthcare data formats to FHIR. 
+This package contains the process of converting HL7 v2 or CCDA into FHIR (JSON). We encourage the use of the FHIR data type for all of our functions. This package aims to easily convert other common healthcare data formats to FHIR. 
 
 With a valid HL7 v2 message, you can pass in the data to the `convert_to_fhir` function as a string. 
-
-In addition to an HL7 v2 message, you need to have a FHIR server and credential manager set up.
 
 Ensure that you are logged in to Azure so that your credentials are recognized by the credential manager. For more information, see cloud-tutorial.md 
 
@@ -28,11 +28,37 @@ PID|1||PATID1234^5^M11^ADT1^MR^GOOD HEALTH HOSPITAL~123456789^^^USSSA^SS||EVERYM
 NK1|1|NUCLEAR^NELDA^W|SPO^SPOUSE||||NK^NEXT OF KIN
 PV1|1|I|2000^2012^01||||004777^ATTEND^AARON^A|||SUR||||ADM|A0|"""
 
-url = "https://azure_fhir_url.com"
+url = "https://fhir_converter_url.com"
 
-cred_manager = AzureCredentialManager(url)
-convert_to_fhir(message, cred_manager, url)
+convert_to_fhir(message, url)
 >>>{...converted fhir version of the the HL7 v2...}
 ```
 
-After using the `convert_to_fhir` method, you will have your data in FHIR format
+The `convert_to_fhir` method returns your data in FHIR format.
+
+## Authentication
+The FHIR converter supports authentication via several cloud providers, as well as direct authentication (Basic, Bearer, etc) by directly specifying an http header. Each authentication method is described in more detail below.
+
+### Cloud Authentication
+To authenticate using cloud credentials, simply create a Credential Manager as described in the [cloud tutorial](cloud-tutorial.md). The Credential Manager can then be passed as a parameter to the the convert_to_fhir function.
+
+```python
+# message and url input parameter assignment omitted for brevity
+
+cred_manager = AzureCredentialManager("https://resource-url")
+
+convert_to_fhir(message, url, cred_manager=cred_manager)
+```
+
+### HTTP Authentication
+You can also control authentication at the HTTP header level.  Simply build your http header as a `dict`, and pass it to the function in the `headers` parameter.
+
+```python
+# message and url input parameter assignment omitted for brevity
+
+import base64
+basic_credentials = base64.b64encode(b"myusername:mypassword")  # Direct password assignment shown for simplicity. Passwords should not be directly placed in code.
+basic_auth_header = {"Authorization": f"Basic {basic_credentials}"}
+
+convert_to_fhir(message, url, headers=basic_auth_header)
+```


### PR DESCRIPTION
# Description
The conversion code has been updated to consume the containerized solution created by the cloud implementation team. Related documentation has also been added.

# Testing
In addition to standard unit tests, tests were additionally run against the containerized solution itself.  After installing Docker, the solution can be run from a shell using:

```bash
docker run -p 8080:8080 docker.io/gskathol/fhir-converter
```

An HL7 test can be performed using:
```python
import phdi.fhir.conversion

hl7_message = open("tests/assets/FileSingleMessageSimple.hl7").read()
phdi.fhir.conversion.convert_to_fhir(hl7_message,"http://0.0.0.0:8080/convert-to-fhir").json()
```

```python
import phdi.fhir.conversion

ccda_message = open("tests/assets/ccda_sample.xml").read()
phdi.fhir.conversion.convert_to_fhir(ccda_message,"http://0.0.0.0:8080/convert-to-fhir").json()
```

# Additional notes
A few TODOs were added to update documentation pointing to the containerized solution after it's been moved to the PHDI library.