### PR TITLE
Modify GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yaml
@@ -1,5 +1,5 @@
 name: Bug Report
-description: File a bug report to help us improve PHDI
+description: "File a bug report to help us improve PHDI."
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/01_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yaml
@@ -1,67 +1,70 @@
 name: Bug Report
-description: File a bug report to help us improve
+description: File a bug report to help us improve PHDI
 body:
   - type: markdown
     attributes:
       value: |
-        Before opening a bug report, please search for the behavior in the existing issues.
+        Before opening a bug report, search for the behavior in the existing [issues](https://github.com/CDCgov/phdi/issues).
 
         ---
         
-        Thank you for taking the time to file a bug report. To address this bug as fast as possible, we need some information.
-  - type: dropdown
-    id: os
+        Thank you for taking the time to file a bug report. To address this bug as quickly as possible, we need some information.
+  - type: textarea
+    id: environment
     attributes:
-      label: Operating System
-      description: "What opererating system are you using?"
-      options:
-        - Windows
-        - MacOS
-        - Linux
+      label: Environment
+      description: "Let us know about your environment."
+      placeholder: |
+        Operating System and Version:
+        Python Version:
+        Additional Environmental Information:
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: description
     attributes:
       label: Description
-      description: "Please provide a clear and concise description of what feature is not working."
-      placeholder: "Example: The geocode_from_str() function in the geospatial.smarty module is returning a 401 error even though I have provided my license."
+      description: "Provide a clear and concise description of what feature isn't working."
+      placeholder: "Example: The geocode_from_str() function in the geospatial.smarty module is returning a 401 error even though I've provided my license."
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: impact
     attributes:
       label: Impact
-      description: "Please describe the impact this bug is causing to you and/or your organization."
-      placeholder: "Example: We are at risk of failing to meet our reporting requirements because we are unable to add the necessary lat/lon data."
+      description: "Describe the impact this bug is causing to you and/or your organization."
+      placeholder: "Example: We're at risk of failing to meet our reporting requirements because we're unable to add the necessary lat/long data."
     validations:
-      required: true
-  - type: input
+      required: false
+  - type: textarea
     id: replication
     attributes:
       label: Steps to Reproduce
-      description: "Please provide the steps to reproduce the behavior"
+      description: "Provide the steps to reproduce the behavior."
       placeholder: |
         1. Import the geocoding functionality by running "import phdi.geospatial"
         2. Create a new variable called address and set it to "123 Main St Washington, DC"
-        3. Create a new SmartyGeocodeClient by running "client = SmartyGeocodeClient(auth_id=..., auth_token=...)"
+        3. Create a new CensusGeocodeClient by running "client = CensusGeocodeClient(auth_id=..., auth_token=...)"
         4. Attempt to geocode the address by running "client.geocode_from_str(address)"
-        5. Observe that it does not complete the request
+        5. Observe that it doesn't complete the request
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: expectation
     attributes:
       label: Expected Behavior
-      description: "Please provide a clear and concise description of what you expected to happen."
-      placeholder: "Example: The function should return a standardized address with lat and lon."
+      description: "Provide a clear and concise description of what you expected to happen."
+      placeholder: "Example: The function should return a standardized address with lat and long."
     validations:
       required: true
   - type: textarea
     id: context
     attributes:
       label: Additional Context
-      description: "Please add any other context about the problem here."
-      placeholder: "Example: This was working yesterday, and just started acting up today."
+      description: |
+        Add any other context about the problem here.
+
+        Tip: You can attach images and other supported file types by selecting this text box, and dragging and dropping or pasting files into it."
+      placeholder: "Example: This was working yesterday and just started acting up today."
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/01_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yaml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: Environment
       description: "Let us know about your environment."
-      placeholder: |
+      value: |
         Operating System and Version:
         Python Version:
         Additional Environmental Information:
@@ -42,6 +42,7 @@ body:
       label: Steps to Reproduce
       description: "Provide the steps to reproduce the behavior."
       placeholder: |
+        Example:
         1. Import the geocoding functionality by running "import phdi.geospatial"
         2. Create a new variable called address and set it to "123 Main St Washington, DC"
         3. Create a new CensusGeocodeClient by running "client = CensusGeocodeClient(auth_id=..., auth_token=...)"

--- a/.github/ISSUE_TEMPLATE/02_feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.yaml
@@ -1,49 +1,52 @@
 name: Feature Request
-description: Recommend features for PHDI to implement
+description: “Recommend features to implement in PHDI.”
 body:
   - type: markdown
     attributes:
       value: |
-        Before submitting a feature request, please search for existing requests in the issues. 
+        Before submitting a feature request, search for existing requests in the [issues](https://github.com/CDCgov/phdi/issues).
         
         ---
         
-        Thank you for taking the time to suggest how we can improve. To identify the feasibility of this feature as best as possible, we need some information.
-  - type: input
+        Thank you for taking the time to suggest how we can improve PHDI. To evaluate and prioritize this feature, we need some information.
+  - type: textarea
     id: description
     attributes:
       label: Description
-      description: "Please provide a clear and concise description of the feature you would like to see implemented."
-      placeholder: "Example: I should be able to define any number of fields that I want to use for create a Patient hash."
+      description: "Provide a clear and concise description of the feature you would like to see implemented."
+      placeholder: "Example: I should be able to supply hash key data as a list to create a Patient hash."
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: problem
     attributes:
       label: Related Problem(s)
-      description: "Is this feature request related to an existing problem you're having?"
-      placeholder: "Example: Because I'm unable to do this, I am forced to use name, address, and date of birth, which provides an unreliable hash making the data unusable."
+      description: "Describe any problems you might be having related to this feature request.”
+      placeholder: "Example: Because I'm unable to do this, I'm forced to concatenate name, address, and date of birth manually, which resulted in failed matches due to inconsistent use of delimiters."
     validations:
       required: false
-  - type: input
+  - type: textarea
     id: solution
     attributes:
       label: Desired Solution
-      description: "Plese provide a clear and concise description of what you want to happen."
+      description: "Provide a clear and concise description of what you want to happen."
       placeholder: "Example: When I call generate_hash_str(), I should be able to pass a list of fields to use, instead of a concatenated string."
     validations:
       required: false
-  - type: input
+  - type: textarea
     id: alternatives
     attributes:
       label: Alternatives
-      description: "Please describe any alternative approaches you've considered."
-      placeholder: "Example: I could just concatenate the fields I want to use myself, but it would be easier to just pass them to the function."
+      description: "Describe alternative approaches you've considered."
+      placeholder: "Example: I could just concatenate the fields I want to use myself, but it would be easier to pass them to the function as a list."
     validations:
       required: false
   - type: textarea
     id: context
     attributes:
       label: Additional Context
-      description: "Please add any other context about the requested feature here."
-      placeholder: "Example: It's expected that this feature will improve our ability to link Patients at scale."
+      description: |
+Add any other context about the requested feature here.
+
+Tip: You can attach images and other supported file types by selecting this text box, and dragging and dropping or pasting files into it."
+      placeholder: "Example: It's expected that this feature will improve our ability to link patients at scale."

--- a/.github/ISSUE_TEMPLATE/02_feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.yaml
@@ -1,5 +1,5 @@
 name: Feature Request
-description: “Recommend features to implement in PHDI.”
+description: "Recommend features to implement in PHDI."
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/02_feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.yaml
@@ -21,7 +21,7 @@ body:
     id: problem
     attributes:
       label: Related Problem(s)
-      description: "Describe any problems you might be having related to this feature request.”
+      description: "Describe any problems you might be having related to this feature request."
       placeholder: "Example: Because I'm unable to do this, I'm forced to concatenate name, address, and date of birth manually, which resulted in failed matches due to inconsistent use of delimiters."
     validations:
       required: false
@@ -46,7 +46,7 @@ body:
     attributes:
       label: Additional Context
       description: |
-Add any other context about the requested feature here.
+        Add any other context about the requested feature here.
 
-Tip: You can attach images and other supported file types by selecting this text box, and dragging and dropping or pasting files into it."
+        Tip: You can attach images and other supported file types by selecting this text box, and dragging and dropping or pasting files into it."
       placeholder: "Example: It's expected that this feature will improve our ability to link patients at scale."

--- a/.github/ISSUE_TEMPLATE/03_support_and_maintenance.yaml
+++ b/.github/ISSUE_TEMPLATE/03_support_and_maintenance.yaml
@@ -1,5 +1,5 @@
 name: Support and Maintenance
-description: “Ask questions and make requests related to support and maintenance.”
+description: "Ask questions and make requests related to support and maintenance."
 body:
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/03_support_and_maintenance.yaml
+++ b/.github/ISSUE_TEMPLATE/03_support_and_maintenance.yaml
@@ -1,19 +1,19 @@
 name: Support and Maintenance
-description: Questions and requests related to organizational support and maintenance
+description: “Ask questions and make requests related to support and maintenance.”
 body:
   - type: textarea
     id: description
     attributes:
       label: Description
-      description: "What type of help do you need?"
-      placeholder: "Example: I am interested in using the PHDI SDK, but I cannot figure out how to install it."
+      description: "Describe your problem."
+      placeholder: "Example: I'm interested in using the PHDI SDK, but I can't figure out how to install it."
     validations:
       required: true
   - type: textarea
     id: solution
     attributes:
       label: Desired Help
-      description: "Please describe how you'd like us to help."
-      placeholder: "Example: Can you please point me to any documentation you have on how to get started with your tools?"
+      description: "Describe how you'd like us to help."
+      placeholder: "Example: Can you point me to any documentation you have on how to get started with your tools?"
     validations:
       required: true


### PR DESCRIPTION
# Description
Crowdsourced changes to GitHub issue templates.

# Testing
I'm not sure how to test issue templates on this repo without merging to `main`, so I set up a repo that mirrors these templates:
https://github.com/spencer-skylight/issue-template-validation/issues/new/choose

You can use these issues to validate the issue form content.