### PR TITLE
Create generate search url function

### DIFF
--- a/examples/FHIR-to-tables/example_schema.yaml
+++ b/examples/FHIR-to-tables/example_schema.yaml
@@ -4,7 +4,7 @@ table_1:
     Patient ID:
       fhir_path: Patient.id
       include_nulls: false
-      include_unknowns: false
+      include_unknowns: false 
       selection_criteria: first
       new_name: patient_id
     Identifier:

--- a/phdi/fhir/tabulation/tables.py
+++ b/phdi/fhir/tabulation/tables.py
@@ -186,7 +186,7 @@ def _get_fhirpathpy_parser(fhirpath_expression: str) -> Callable:
 
 def _generate_search_url(
     url_with_querystring: str, default_count: int = None, default_since: str = None
-):
+) -> str:
     """
     Generates a FHIR query string using the supplied search string, defaulting values
     for `_count` and `_since`, if given and not already set in the

--- a/phdi/fhir/tabulation/tables.py
+++ b/phdi/fhir/tabulation/tables.py
@@ -5,6 +5,7 @@ import pathlib
 
 from functools import cache
 from typing import Any, Callable, Literal, List
+from urllib.parse import parse_qs, urlencode
 
 from phdi.cloud.core import BaseCredentialManager
 from phdi.fhir.transport import fhir_server_get
@@ -181,3 +182,40 @@ def _get_fhirpathpy_parser(fhirpath_expression: str) -> Callable:
       at `fhirpath_expression`.
     """
     return fhirpathpy.compile(fhirpath_expression)
+
+
+def _generate_search_url(
+    url_with_querystring: str, default_count: int = None, default_since: str = None
+):
+    """
+    Generates a FHIR query string using the supplied search string, defaulting values
+    for `_count` and `_since`, if given and not already set in the
+    `url_with_querystring`.
+
+    :param url_with_querystring: The search URL with querystring. The search URL
+      may contain the base URL, or may start with the resource name.
+    :param default_count: If set, and querystring does not specify `_count`, the
+      `_count` parameter is added to the query string with this value. Default: `None`
+    :param default_since: If set, and querystring does not specify `_since`, the
+      `_since` parameter is added to the query string with this value. Default: `None`
+    :return: The `url_with_querystring` including any defaulted values.
+    """
+    if "?" in url_with_querystring:
+        search_url_prefix, search_query_string = url_with_querystring.split("?", 1)
+    else:
+        # Split will generate a ValueError if the delimiter is not found
+        # in the string, so handle this as an edge case.
+        search_url_prefix, search_query_string = (url_with_querystring, "")
+
+    query_string_dict = parse_qs(search_query_string)
+    if default_count is not None and query_string_dict.get("_count") is None:
+        query_string_dict["_count"] = [default_count]
+
+    if default_since is not None and query_string_dict.get("_since") is None:
+        query_string_dict["_since"] = [default_since]
+
+    updated_query_string = urlencode(query_string_dict, doseq=True)
+    if not updated_query_string:
+        return search_url_prefix
+
+    return "?".join((search_url_prefix, urlencode(query_string_dict, doseq=True)))

--- a/tests/fhir/tabulation/test_fhir_tabulation.py
+++ b/tests/fhir/tabulation/test_fhir_tabulation.py
@@ -1,5 +1,6 @@
 import json
 import pathlib
+import urllib.parse
 import yaml
 
 from unittest import mock
@@ -9,6 +10,7 @@ from phdi.fhir.tabulation.tables import (
     apply_schema_to_resource,
     generate_all_tables_in_schema,
     generate_table,
+    _generate_search_url,
 )
 
 
@@ -222,4 +224,56 @@ def test_generate_all_tables_schema(patched_load_schema, patched_make_table):
         output_format,
         fhir_url,
         mock_cred_manager,
+    )
+
+
+def test_generate_search_url():
+    base_fhir_url = "https://fhir-host/r4"
+
+    test_search_url_1 = urllib.parse.quote(
+        "Patient?birtdate=2000-01-01T00:00:00", safe="/?="
+    )
+    assert (
+        _generate_search_url(f"{base_fhir_url}/{test_search_url_1}")
+        == f"{base_fhir_url}/{test_search_url_1}"
+    )
+    assert _generate_search_url(f"/{test_search_url_1}") == f"/{test_search_url_1}"
+    assert _generate_search_url(f"{test_search_url_1}") == f"{test_search_url_1}"
+    assert (
+        _generate_search_url(f"{test_search_url_1}", default_count=5)
+        == f"{test_search_url_1}&_count=5"
+    )
+    assert (
+        _generate_search_url(f"{test_search_url_1}&_count=10", default_count=5)
+        == f"{test_search_url_1}&_count=10"
+    )
+    assert (
+        _generate_search_url(
+            f"{test_search_url_1}&_count=10", default_since="2022-01-01T00:00:00"
+        )
+        == f"{test_search_url_1}"
+        + f"{urllib.parse.quote('&_count=10&_since=2022-01-01T00:00:00', safe='&=')}"
+    )
+
+    test_search_url_2 = "Patient"
+    assert (
+        _generate_search_url(f"{base_fhir_url}/{test_search_url_2}")
+        == f"{base_fhir_url}/{test_search_url_2}"
+    )
+    assert _generate_search_url(f"/{test_search_url_2}") == f"/{test_search_url_2}"
+    assert _generate_search_url(f"{test_search_url_2}") == f"{test_search_url_2}"
+    assert (
+        _generate_search_url(f"{test_search_url_2}", default_count=5)
+        == f"{test_search_url_2}?_count=5"
+    )
+    assert (
+        _generate_search_url(f"{test_search_url_2}?_count=10", default_count=5)
+        == f"{test_search_url_2}?_count=10"
+    )
+    assert (
+        _generate_search_url(
+            f"{test_search_url_2}?_count=10", default_since="2022-01-01T00:00:00"
+        )
+        == f"{test_search_url_2}"
+        + f"{urllib.parse.quote('?_count=10&_since=2022-01-01T00:00:00', safe='?&=')}"
     )


### PR DESCRIPTION
# Description
This PR defines the _generate_search_string function to create initial search URLs for performing FHIR searches based on input from schemas.

