### PR TITLE
Add patient identifier endpoint

### DIFF
--- a/containers/phdi-ingestion/app/routers/fhir_harmonization_standardization.py
+++ b/containers/phdi-ingestion/app/routers/fhir_harmonization_standardization.py
@@ -1,27 +1,17 @@
 from fastapi import APIRouter
-
 from pydantic import BaseModel, validator
 from typing import Literal, Optional
 
+from app.utils import check_for_fhir
+
 from phdi.fhir.harmonization.standardization import standardize_names
 from phdi.fhir.harmonization.standardization import standardize_phones
+
 
 router = APIRouter(
     prefix="/fhir/harmonization/standardization",
     tags=["fhir/harmonization"],
 )
-
-
-def check_for_fhir(value: dict) -> dict:
-    """
-    Check to see if the value provided for 'data' is a FHIR resource or bundle.
-    """
-
-    assert value.get("resourceType") not in [
-        None,
-        "",
-    ], "Must provide a FHIR resource or bundle"
-    return value
 
 
 class StandardizeNamesInput(BaseModel):

--- a/containers/phdi-ingestion/app/routers/fhir_linkage_link.py
+++ b/containers/phdi-ingestion/app/routers/fhir_linkage_link.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Response, status
 from pydantic import BaseModel, validator
-from typing import Optional, Literal
+from typing import Optional
 import os
 
 from phdi.fhir.linkage.link import add_patient_identifier_in_bundle

--- a/containers/phdi-ingestion/app/routers/fhir_linkage_link.py
+++ b/containers/phdi-ingestion/app/routers/fhir_linkage_link.py
@@ -1,6 +1,12 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Response, status
+from pydantic import BaseModel, validator
+from typing import Optional, Literal
+import os
 
-# from phdi.fhir.linkage.link import add_patient_identifier
+from phdi.fhir.linkage.link import add_patient_identifier_in_bundle
+
+from app.utils import check_for_environment_variables, check_for_fhir_bundle
+
 
 router = APIRouter(
     prefix="/fhir/linkage/link",
@@ -8,6 +14,37 @@ router = APIRouter(
 )
 
 
-@router.post("/add_patient_identifier")
-async def add_patient_identifier_endpoint(body):
-    return body
+class AddPatientIdentifierInBundleInput(BaseModel):
+    bundle: dict
+    salt_str: Optional[str] = ""
+    overwrite: Optional[bool] = True
+
+    _check_for_fhir = validator("bundle", allow_reuse=True)(check_for_fhir_bundle)
+
+
+@router.post("/add_patient_identifier_in_bundle", status_code=200)
+async def add_patient_identifier_in_bundle_endpoint(
+    input: AddPatientIdentifierInBundleInput, response: Response
+) -> dict:
+    """
+    Add a salted hash identifier to every patient resource in a FHIR bundle using. If
+    a salt is not provided in the request the value of the 'SALT_STR' environment
+    variable will be used. In the case where a salt is not provided and 'SALT_STR' is
+    not defined and HTTP 500 status code is returned.
+
+    :param input: A JSON formated request body with schema specified by the
+        AddPatientIdentifierInBundleInput model.
+    :return: A FHIR bundle where every patient resource contains a hashed identifier.
+    """
+
+    input = dict(input)
+
+    if input.get("salt_str") in [None, ""]:
+        check_result = check_for_environment_variables(["SALT_STR"])
+        if check_result["status_code"] == 500:
+            response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+            return check_result
+        else:
+            input["salt_str"] = os.environ.get("SALT_STR")
+
+    return add_patient_identifier_in_bundle(**input)

--- a/containers/phdi-ingestion/app/utils/__init__.py
+++ b/containers/phdi-ingestion/app/utils/__init__.py
@@ -1,0 +1,54 @@
+import os
+
+
+def check_for_fhir(value: dict) -> dict:
+    """
+    Check if the value provided is a valid FHIR resource or bundle by asserting that
+    a 'resourceType' key exists with a non-null value.
+
+    :param value: Dictionary to be tested for FHIR validity.
+    :return: The dictionary originally passed in as 'value'
+    """
+
+    assert value.get("resourceType") not in [
+        None,
+        "",
+    ], "Must provide a FHIR resource or bundle"
+    return value
+
+
+def check_for_fhir_bundle(value: dict) -> dict:
+    """
+    Check if the dictionary provided is a valid FHIR bundle by asserting that a
+    'resourceType' key exists with the value 'Bundle'.
+
+    :param value: Dictionary to be tested for FHIR validity.
+    :return: The dictionary originally passed in as 'value'
+    """
+
+    assert (
+        value.get("resourceType") == "Bundle"
+    ), "Must provide a FHIR resource or bundle"  # noqa
+    return value
+
+
+def check_for_environment_variables(environment_variables: list) -> dict:
+    """
+    Check that all environment variables in a given list are set.
+
+    :param environment_variables: A list of environment variables to check.
+    :return: A dictionary containing two keys: 'status_code' and 'message'.
+        'status_code' has value of 200 when all environment variables are found, and 500
+        when one or more are missing. 'message' is a string identifying the first
+        missing environment variable or indicating that all specified variables were
+        found.
+    """
+    for environment_variable in environment_variables:
+        if os.environ.get(environment_variable) is None:
+            error_message = (
+                "Environment variable '{}' not set. "
+                + "The environment variable must be set."
+            ).format(environment_variable)
+            return {"status_code": 500, "message": error_message}
+
+    return {"status_code": 200, "message": "All environment variables were found."}

--- a/containers/phdi-ingestion/tests/test_fhir_linkage_link.py
+++ b/containers/phdi-ingestion/tests/test_fhir_linkage_link.py
@@ -101,7 +101,7 @@ def test_add_patient_identifier_in_bundle_salt_from_env_missing(patched_environ)
 
     expected_response = {
         "status_code": 500,
-        "message": "Environment variable 'SALT_STR' not set. The environment variable must be set.", #noqa
+        "message": "Environment variable 'SALT_STR' not set. The environment variable must be set.",  # noqa
     }
     actual_response = client.post(
         "/fhir/linkage/link/add_patient_identifier_in_bundle", json=test_request

--- a/containers/phdi-ingestion/tests/test_fhir_linkage_link.py
+++ b/containers/phdi-ingestion/tests/test_fhir_linkage_link.py
@@ -1,6 +1,8 @@
 import pathlib
 import json
+import copy
 from fastapi.testclient import TestClient
+from unittest import mock
 
 from app.main import app
 
@@ -11,20 +13,97 @@ test_bundle = json.load(
 )
 
 
-# def test_add_patient_identifier_success():
+def test_add_patient_identifier_in_bundle_success():
 
-#     test_request = {"data": test_bundle, "salt_str": "test_hash"}
+    test_request = {"bundle": test_bundle, "salt_str": "test_hash"}
 
-#     expected_response = copy.deepcopy(test_bundle)
-#     expected_response["entry"][0]["resource"]["identifier"] = [
-#         {
-#             "system": "urn:ietf:rfc:3986",
-#             "use": "temp",
-#           "value": "699d8585efcf84d1a03eb58e84cd1c157bf7b718d9257d7436e2ff0bd14b2834",
-#         }
-#     ]
+    expected_response = copy.deepcopy(test_bundle)
+    expected_response["entry"][0]["resource"]["identifier"] = [
+        {
+            "system": "urn:ietf:rfc:3986",
+            "use": "temp",
+            "value": "699d8585efcf84d1a03eb58e84cd1c157bf7b718d9257d7436e2ff0bd14b2834",
+        }
+    ]
 
-#     actual_response = client.post(
-#         "/fhir/linkage/link/add_patient_identifier", json=test_request
-#     )
-#     assert actual_response.json() == expected_response
+    actual_response = client.post(
+        "/fhir/linkage/link/add_patient_identifier_in_bundle", json=test_request
+    )
+    assert actual_response.json() == expected_response
+
+
+def test_add_patient_identifier_in_bundle_missing_bundle():
+
+    actual_response = client.post(
+        "/fhir/linkage/link/add_patient_identifier_in_bundle", json={}
+    )
+    expected_response = {
+        "detail": [
+            {
+                "loc": ["body", "bundle"],
+                "msg": "field required",
+                "type": "value_error.missing",
+            }
+        ]
+    }
+    assert actual_response.json() == expected_response
+
+
+def test_add_patient_identifier_in_bundle_bad_parameter_types():
+
+    test_request = {"bundle": test_bundle, "salt_str": [], "overwrite": 123}
+    actual_response = client.post(
+        "/fhir/linkage/link/add_patient_identifier_in_bundle", json=test_request
+    )
+    expected_response = {
+        "detail": [
+            {
+                "loc": ["body", "salt_str"],
+                "msg": "str type expected",
+                "type": "type_error.str",
+            },
+            {
+                "loc": ["body", "overwrite"],
+                "msg": "value could not be parsed to a boolean",
+                "type": "type_error.bool",
+            },
+        ]
+    }
+    assert actual_response.json() == expected_response
+
+
+@mock.patch("app.routers.fhir_linkage_link.os.environ")
+def test_add_patient_identifier_in_bundle_salt_from_env(patched_environ):
+    patched_environ.get.return_value = "test_hash"
+
+    test_request = {"bundle": test_bundle}
+
+    expected_response = copy.deepcopy(test_bundle)
+    expected_response["entry"][0]["resource"]["identifier"] = [
+        {
+            "system": "urn:ietf:rfc:3986",
+            "use": "temp",
+            "value": "699d8585efcf84d1a03eb58e84cd1c157bf7b718d9257d7436e2ff0bd14b2834",
+        }
+    ]
+
+    actual_response = client.post(
+        "/fhir/linkage/link/add_patient_identifier_in_bundle", json=test_request
+    )
+    assert actual_response.json() == expected_response
+
+
+@mock.patch("app.routers.fhir_linkage_link.os.environ")
+def test_add_patient_identifier_in_bundle_salt_from_env_missing(patched_environ):
+    patched_environ.get.return_value = None
+
+    test_request = {"bundle": test_bundle}
+
+    expected_response = {
+        "status_code": 500,
+        "message": "Environment variable 'SALT_STR' not set. The environment variable must be set.", #noqa
+    }
+    actual_response = client.post(
+        "/fhir/linkage/link/add_patient_identifier_in_bundle", json=test_request
+    )
+    assert actual_response.json() == expected_response

--- a/containers/phdi-ingestion/tests/test_utils.py
+++ b/containers/phdi-ingestion/tests/test_utils.py
@@ -1,0 +1,52 @@
+from unittest import mock
+import pytest
+from app.utils import (
+    check_for_environment_variables,
+    check_for_fhir,
+    check_for_fhir_bundle,
+)
+
+
+@mock.patch("app.utils.os.environ")
+def test_check_for_environment_variables_success(patched_environ):
+    environment_variables = ["SOME-ENV-VAR"]
+    patched_environ.get.return_value = "some-value"
+    actual_response = check_for_environment_variables(environment_variables)
+    expected_response = {
+        "status_code": 200,
+        "message": "All environment variables were found.",
+    }
+    assert actual_response == expected_response
+
+
+@mock.patch("app.utils.os.environ")
+def test_check_for_environment_variables_failure(patched_environ):
+    environment_variables = ["SOME-ENV-VAR"]
+    patched_environ.get.return_value = None
+    actual_response = check_for_environment_variables(environment_variables)
+    expected_response = {
+        "status_code": 500,
+        "message": (
+            "Environment variable 'SOME-ENV-VAR' not set. "
+            "The environment variable must be set."
+        ),
+    }
+    assert actual_response == expected_response
+
+
+def test_check_for_fhir():
+    good_fhir = {"resourceType": "Patient"}
+    assert check_for_fhir(good_fhir) == good_fhir
+
+    bad_fhir = {}
+    with pytest.raises(AssertionError):
+        check_for_fhir(bad_fhir)
+
+
+def test_check_for_fhir_bundle():
+    good_fhir = {"resourceType": "Bundle"}
+    assert check_for_fhir_bundle(good_fhir) == good_fhir
+
+    bad_fhir = {"resourceType": "Patient"}
+    with pytest.raises(AssertionError):
+        check_for_fhir_bundle(bad_fhir)


### PR DESCRIPTION
This PR adds an endpoint for adding hashes to patient resources in a FHIR bundle. It also introduces a `utils` module for functionality that is shared across multiple endpoints.