### PR TITLE
Moved Credential Manager functionality out of FHIR Upload BB into Utils

### DIFF
--- a/containers/phdi-ingestion/app/routers/fhir_transport_http.py
+++ b/containers/phdi-ingestion/app/routers/fhir_transport_http.py
@@ -2,18 +2,18 @@ from fastapi import APIRouter, Response, status
 from pydantic import BaseModel, validator
 from typing import Literal, Optional
 
-from app.utils import check_for_fhir_bundle, search_for_required_values
+from app.utils import (
+    check_for_fhir_bundle,
+    search_for_required_values,
+    get_credential_manager,
+)
 
-from phdi.cloud.azure import AzureCredentialManager
-from phdi.cloud.gcp import GcpCredentialManager
 from phdi.fhir.transport import upload_bundle_to_fhir_server
 
 router = APIRouter(
     prefix="/fhir/transport/http",
     tags=["fhir/transport"],
 )
-
-credential_managers = {"azure": AzureCredentialManager, "gcp": GcpCredentialManager}
 
 
 class UploadBundleToFhirServerInput(BaseModel):
@@ -45,7 +45,9 @@ def upload_bundle_to_fhir_server_endpoint(
         response.status_code = status.HTTP_400_BAD_REQUEST
         return search_result
 
-    input["credential_manager"] = credential_managers[input["credential_manager"]]
+    input["credential_manager"] = get_credential_manager(
+        credential_manager=input["credential_manager"]
+    )
 
     fhir_server_response = upload_bundle_to_fhir_server(**input)
     fhir_server_response_body = fhir_server_response.json()

--- a/containers/phdi-ingestion/app/utils.py
+++ b/containers/phdi-ingestion/app/utils.py
@@ -1,4 +1,7 @@
+from typing import Any
 from app.config import get_settings
+from phdi.cloud.azure import AzureCredentialManager
+from phdi.cloud.gcp import GcpCredentialManager
 
 
 def check_for_fhir(value: dict) -> dict:
@@ -65,3 +68,18 @@ def search_for_required_values(input: dict, required_values: list) -> str:
         )
 
     return message
+
+
+def get_credential_manager(credential_manager: str) -> Any:
+    """
+    Return a credential manager for different cloud providers depending upon which
+    one the user requests via the parameter.
+
+    :param credential_manager: A string identifying which cloud credential
+    manager is desired.
+    :return: Either a Google Cloud Credential Manager or an Azure Credential Manager
+    depending upon the value passed in.
+    """
+    credential_managers = {"azure": AzureCredentialManager, "gcp": GcpCredentialManager}
+    result = credential_managers.get(credential_manager)
+    return result

--- a/containers/phdi-ingestion/tests/test_fhir_transport_http.py
+++ b/containers/phdi-ingestion/tests/test_fhir_transport_http.py
@@ -21,10 +21,9 @@ fhir_server_response_body = json.load(
 
 
 @mock.patch("app.routers.fhir_transport_http.upload_bundle_to_fhir_server")
-@mock.patch("app.routers.fhir_transport_http.credential_managers")
-@mock.patch("app.routers.fhir_transport_http.AzureCredentialManager")
+@mock.patch("app.routers.fhir_transport_http.get_credential_manager")
 def test_upload_bundle_to_fhir_server_request_params_success(
-    patched_azure_cred_manager, patched_cred_managers, patched_bundle_upload
+    patched_azure_cred_manager, patched_bundle_upload
 ):
     test_request = {
         "bundle": test_bundle,
@@ -32,9 +31,11 @@ def test_upload_bundle_to_fhir_server_request_params_success(
         "fhir_url": "some-FHIR-server-URL",
     }
 
-    patched_cred_managers.__getitem__.side_effect = {
-        "azure": patched_azure_cred_manager
-    }.__getitem__
+    # patched_cred_managers.__getitem__.side_effect = {
+    #     "azure": patched_azure_cred_manager
+    # }.__getitem__
+
+    patched_azure_cred_manager.return_value = mock.Mock()
 
     fhir_server_response = mock.Mock()
     fhir_server_response.status_code = 200
@@ -47,7 +48,7 @@ def test_upload_bundle_to_fhir_server_request_params_success(
 
     patched_bundle_upload.assert_called_with(
         bundle=test_bundle,
-        credential_manager=patched_azure_cred_manager,
+        credential_manager=patched_azure_cred_manager(),
         fhir_url=test_request["fhir_url"],
     )
     assert actual_response.status_code == 200
@@ -62,18 +63,19 @@ def test_upload_bundle_to_fhir_server_request_params_success(
 
 
 @mock.patch("app.routers.fhir_transport_http.upload_bundle_to_fhir_server")
-@mock.patch("app.routers.fhir_transport_http.credential_managers")
-@mock.patch("app.routers.fhir_transport_http.AzureCredentialManager")
+@mock.patch("app.routers.fhir_transport_http.get_credential_manager")
 def test_upload_bundle_to_fhir_server_env_params_success(
-    patched_azure_cred_manager, patched_cred_managers, patched_bundle_upload
+    patched_azure_cred_manager, patched_bundle_upload
 ):
     test_request = {
         "bundle": test_bundle,
     }
 
-    patched_cred_managers.__getitem__.side_effect = {
-        "azure": patched_azure_cred_manager
-    }.__getitem__
+    # patched_cred_managers.__getitem__.side_effect = {
+    #     "azure": patched_azure_cred_manager
+    # }.__getitem__
+
+    patched_azure_cred_manager.return_value = mock.Mock()
 
     os.environ["CREDENTIAL_MANAGER"] = "azure"
     os.environ["FHIR_URL"] = "some-FHIR-server-URL"
@@ -90,7 +92,7 @@ def test_upload_bundle_to_fhir_server_env_params_success(
 
     patched_bundle_upload.assert_called_with(
         bundle=test_bundle,
-        credential_manager=patched_azure_cred_manager,
+        credential_manager=patched_azure_cred_manager(),
         fhir_url="some-FHIR-server-URL",
     )
     assert actual_response.status_code == 200
@@ -105,10 +107,9 @@ def test_upload_bundle_to_fhir_server_env_params_success(
 
 
 @mock.patch("app.routers.fhir_transport_http.upload_bundle_to_fhir_server")
-@mock.patch("app.routers.fhir_transport_http.credential_managers")
-@mock.patch("app.routers.fhir_transport_http.AzureCredentialManager")
+@mock.patch("app.routers.fhir_transport_http.get_credential_manager")
 def test_upload_bundle_to_fhir_server_missing_params(
-    patched_azure_cred_manager, patched_cred_managers, patched_bundle_upload
+    patched_azure_cred_manager, patched_bundle_upload
 ):
     test_request = {
         "bundle": test_bundle,
@@ -117,6 +118,8 @@ def test_upload_bundle_to_fhir_server_missing_params(
     os.environ.pop("CREDENTIAL_MANAGER", None)
     os.environ.pop("FHIR_URL", None)
     get_settings.cache_clear()
+
+    patched_azure_cred_manager.return_value = mock.Mock()
 
     fhir_server_response = mock.Mock()
     fhir_server_response.status_code = 200
@@ -137,16 +140,17 @@ def test_upload_bundle_to_fhir_server_missing_params(
 
 
 @mock.patch("app.routers.fhir_transport_http.upload_bundle_to_fhir_server")
-@mock.patch("app.routers.fhir_transport_http.credential_managers")
-@mock.patch("app.routers.fhir_transport_http.AzureCredentialManager")
+@mock.patch("app.routers.fhir_transport_http.get_credential_manager")
 def test_upload_bundle_to_fhir_server_bad_response_from_server(
-    patched_azure_cred_manager, patched_cred_managers, patched_bundle_upload
+    patched_azure_cred_manager, patched_bundle_upload
 ):
     test_request = {
         "bundle": test_bundle,
         "credential_manager": "azure",
         "fhir_url": "some-FHIR-server-URL",
     }
+
+    patched_azure_cred_manager.return_value = mock.Mock()
 
     fhir_server_response = mock.Mock()
     fhir_server_response.status_code = 400
@@ -165,10 +169,9 @@ def test_upload_bundle_to_fhir_server_bad_response_from_server(
 
 
 @mock.patch("app.routers.fhir_transport_http.upload_bundle_to_fhir_server")
-@mock.patch("app.routers.fhir_transport_http.credential_managers")
-@mock.patch("app.routers.fhir_transport_http.AzureCredentialManager")
+@mock.patch("app.routers.fhir_transport_http.get_credential_manager")
 def test_upload_bundle_to_fhir_server_partial_success(
-    patched_azure_cred_manager, patched_cred_managers, patched_bundle_upload
+    patched_azure_cred_manager, patched_bundle_upload
 ):
     test_request = {
         "bundle": test_bundle,
@@ -176,9 +179,11 @@ def test_upload_bundle_to_fhir_server_partial_success(
         "fhir_url": "some-FHIR-server-URL",
     }
 
-    patched_cred_managers.__getitem__.side_effect = {
-        "azure": patched_azure_cred_manager
-    }.__getitem__
+    # patched_cred_managers.__getitem__.side_effect = {
+    #     "azure": patched_azure_cred_manager
+    # }.__getitem__
+
+    patched_azure_cred_manager.return_value = mock.Mock()
 
     partial_success_response_body = copy.deepcopy(fhir_server_response_body)
     partial_success_response_body["entry"][0]["response"]["status"] = "some issue"
@@ -194,7 +199,7 @@ def test_upload_bundle_to_fhir_server_partial_success(
 
     patched_bundle_upload.assert_called_with(
         bundle=test_bundle,
-        credential_manager=patched_azure_cred_manager,
+        credential_manager=patched_azure_cred_manager(),
         fhir_url=test_request["fhir_url"],
     )
 

--- a/containers/phdi-ingestion/tests/test_utils.py
+++ b/containers/phdi-ingestion/tests/test_utils.py
@@ -1,9 +1,12 @@
 import os
+from phdi.cloud.azure import AzureCredentialManager
+from phdi.cloud.gcp import GcpCredentialManager
 import pytest
 from app.utils import (
     check_for_fhir,
     check_for_fhir_bundle,
     search_for_required_values,
+    get_credential_manager,
 )
 from app.config import get_settings
 
@@ -55,3 +58,21 @@ def test_check_for_fhir_bundle():
     bad_fhir = {"resourceType": "Patient"}
     with pytest.raises(AssertionError):
         check_for_fhir_bundle(bad_fhir)
+
+
+def test_get_credential_manager_azure():
+    expected_result = AzureCredentialManager
+    actual_result = get_credential_manager("azure")
+    assert actual_result == expected_result
+
+
+def test_get_credential_manager_gcp():
+    expected_result = GcpCredentialManager
+    actual_result = get_credential_manager("gcp")
+    assert actual_result == expected_result
+
+
+def test_get_credential_manager_invalid():
+    expected_result = None
+    actual_result = get_credential_manager("myown")
+    assert actual_result == expected_result


### PR DESCRIPTION
Added tests and fixed other tests

This PR Includes the following:
1- Utils now has a function to get a credential manager based upon the value passed in by the user
2- FHIR Bundle Transport BB has been updated to use this new utility
3- Tests for the FHIR Bundle Transport BB have been updated to mock this new utils function
4- Added util tests for this new function
5- Updated comments/documentation within the Utils 