### PR TITLE
Implements functionality to read in schemas as JSON as well as YAML

### DIFF
--- a/phdi/tabulation/tables.py
+++ b/phdi/tabulation/tables.py
@@ -22,12 +22,11 @@ def load_schema(path: pathlib.Path) -> dict:
     :raises JSONDecodeError: If a JSON file is provided with invalid JSON.
     :return: A dict representing a schema read from the given path.
     """
-    path = str(path)
     try:
         with open(path, "r") as file:
-            if path.endswith(".yaml"):
+            if path.suffix == ".yaml":
                 schema = yaml.safe_load(file)
-            elif path.endswith(".json"):
+            elif path.suffix == ".json":
                 schema = json.load(file)
             else:
                 ftype = path.split(".")[-1].upper()

--- a/phdi/tabulation/tables.py
+++ b/phdi/tabulation/tables.py
@@ -29,7 +29,7 @@ def load_schema(path: pathlib.Path) -> dict:
             elif path.suffix == ".json":
                 schema = json.load(file)
             else:
-                ftype = path.split(".")[-1].upper()
+                ftype = path.suffix.replace(".", "").upper()
                 raise ValueError(f"Unsupported file type provided: {ftype}")
         return schema
     except FileNotFoundError:

--- a/phdi/tabulation/tables.py
+++ b/phdi/tabulation/tables.py
@@ -1,30 +1,46 @@
 import csv
 import os
 import pathlib
+import yaml
+import json
 import pyarrow as pa
 import pyarrow.parquet as pq
-import yaml
 
 from pathlib import Path
 from typing import Literal, List, Union
 
 
-def load_schema(path: str) -> dict:
+def load_schema(path: pathlib.Path) -> dict:
     """
     Given the path to a local YAML file containing a data schema,
     loads the file and return the resulting schema as a dictionary.
     If the file can't be found, raises an error.
 
     :param path: The file path to a YAML file holding a schema.
-    :raises Exception: If the file to be loaded could not be found.
+    :raises ValueError: If the provided path points to an unsupported file type.
+    :raises FileNotFoundError: If the file to be loaded could not be found.
+    :raises JSONDecodeError: If a JSON file is provided with invalid JSON.
     :return: A dict representing a schema read from the given path.
     """
+    path = str(path)
     try:
         with open(path, "r") as file:
-            schema = yaml.safe_load(file)
+            if path.endswith(".yaml"):
+                schema = yaml.safe_load(file)
+            elif path.endswith(".json"):
+                schema = json.load(file)
+            else:
+                ftype = path.split(".")[-1].upper()
+                raise ValueError(f"Unsupported file type provided: {ftype}")
         return schema
     except FileNotFoundError:
-        raise Exception("Could not find path to given file")
+        raise FileNotFoundError(
+            "The specified file does not exist at the path provided."
+        )
+    except json.decoder.JSONDecodeError as e:
+        raise json.decoder.JSONDecodeError(
+            "The specified file is not valid JSON.", e.doc, e.pos
+        )
 
 
 def write_table(

--- a/tests/assets/invalid_json.json
+++ b/tests/assets/invalid_json.json
@@ -1,0 +1,2 @@
+{'test': "I'm invalid!"
+}

--- a/tests/assets/test_schema.json
+++ b/tests/assets/test_schema.json
@@ -1,0 +1,34 @@
+{
+    "my_table": {
+        "Patient": {
+            "Patient ID": {
+                "fhir_path": "Patient.id",
+                "include_nulls": false,
+                "include_unknowns": false,
+                "selection_criteria": "first",
+                "new_name": "patient_id"
+            },
+            "First Name": {
+                "fhir_path": "Patient.name.given",
+                "include_nulls": false,
+                "include_unknowns": false,
+                "selection_criteria": "first",
+                "new_name": "first_name"
+            },
+            "Last Name": {
+                "fhir_path": "Patient.name.family",
+                "include_nulls": false,
+                "include_unknowns": false,
+                "selection_criteria": "first",
+                "new_name": "last_name"
+            },
+            "Phone Number": {
+                "fhir_path": "Patient.telecom.where(system = 'phone').value",
+                "include_nulls": false,
+                "include_unknowns": false,
+                "selection_criteria": "first",
+                "new_name": "phone_number"
+            }
+        }
+    }
+}

--- a/tests/tabulation/test_tables.py
+++ b/tests/tabulation/test_tables.py
@@ -1,9 +1,10 @@
 import csv
 import os
 import yaml
+import json
 import pathlib
-from unittest import mock
 import pytest
+from unittest import mock
 
 from phdi.tabulation import (
     load_schema,
@@ -19,9 +20,19 @@ def test_load_schema():
         open(pathlib.Path(__file__).parent.parent / "assets" / "test_schema.yaml")
     )
 
-    # Test invalid schema file path
-    with pytest.raises(Exception):
+    # Invalid schema file path
+    with pytest.raises(FileNotFoundError):
         load_schema("invalidPath")
+
+    # Invalid JSON
+    with pytest.raises(json.decoder.JSONDecodeError):
+        load_schema(
+            pathlib.Path(__file__).parent.parent / "assets" / "invalid_json.json"
+        )
+
+    # Invalid file format
+    with pytest.raises(ValueError):
+        load_schema(pathlib.Path(__file__).parent.parent / "assets" / "sample_hl7.hl7")
 
 
 @mock.patch("phdi.tabulation.tables.pq.ParquetWriter")

--- a/tests/tabulation/test_tables.py
+++ b/tests/tabulation/test_tables.py
@@ -20,6 +20,12 @@ def test_load_schema():
         open(pathlib.Path(__file__).parent.parent / "assets" / "test_schema.yaml")
     )
 
+    assert load_schema(
+        pathlib.Path(__file__).parent.parent / "assets" / "test_schema.json"
+    ) == json.load(
+        open(pathlib.Path(__file__).parent.parent / "assets" / "test_schema.json")
+    )
+
     # Invalid schema file path
     with pytest.raises(FileNotFoundError):
         load_schema("invalidPath")


### PR DESCRIPTION
# Description
This PR adds the ability for users to upload their schema as a JSON file instead of YAML. It relies on the last 5 characters of the file path to determine if it's JSON or YAML, and raises a `ValueError` if it's any other file extension. The code also raises an error if it fails to parse the JSON.

# Tests
I updated the tests to account for the new file type as well as the new Exception types.

# Feedback Requested
Testing for valid YAML seems pretty hard given that YAML is a dumpster fire of a data format. Any one have ideas on how we might check for that? We'd likely want that in a new ticket/PR related to schema validation, but wanted to raise it here in case anyone has a quick fix.