### PR TITLE
Fix failing tests and tests that were running too long

### DIFF
--- a/containers/fhir-converter/test_FHIR-Converter.py
+++ b/containers/fhir-converter/test_FHIR-Converter.py
@@ -181,9 +181,11 @@ def test_health_check():
 @mock.patch("main.json.load")
 @mock.patch("main.open")
 @mock.patch("main.subprocess.run")
-def test_convert_valid_request(patched_subprocess_run, patched_open, patched_json_load):
+@mock.patch("main.Path")
+def test_convert_valid_request(patched_file_path, patched_subprocess_run, patched_open, patched_json_load):
     patched_subprocess_run.return_value = mock.Mock(returncode=0)
     patched_json_load.return_value = valid_response
+    patched_file_path = mock.Mock()
     actual_response = client.post(
         "/convert-to-fhir",
         json=valid_request,
@@ -195,11 +197,14 @@ def test_convert_valid_request(patched_subprocess_run, patched_open, patched_jso
 @mock.patch("main.json.load")
 @mock.patch("main.open")
 @mock.patch("main.subprocess.run")
+@mock.patch("main.Path")
 def test_convert_conversion_failure(
-    patched_subprocess_run, patched_open, patched_json_load
+    patched_file_path, patched_subprocess_run, patched_open, patched_json_load
 ):
     patched_subprocess_run.return_value = mock.Mock(returncode=1)
     patched_json_load.return_value = valid_response
+    patched_file_path = mock.Mock()
+
     actual_response = client.post(
         "/convert-to-fhir",
         json=valid_request,

--- a/containers/fhir-converter/test_FHIR-Converter.py
+++ b/containers/fhir-converter/test_FHIR-Converter.py
@@ -182,7 +182,9 @@ def test_health_check():
 @mock.patch("main.open")
 @mock.patch("main.subprocess.run")
 @mock.patch("main.Path")
-def test_convert_valid_request(patched_file_path, patched_subprocess_run, patched_open, patched_json_load):
+def test_convert_valid_request(
+    patched_file_path, patched_subprocess_run, patched_open, patched_json_load
+):
     patched_subprocess_run.return_value = mock.Mock(returncode=0)
     patched_json_load.return_value = valid_response
     patched_file_path = mock.Mock()

--- a/containers/phdi-ingestion/tests/test_fhir_geospatial.py
+++ b/containers/phdi-ingestion/tests/test_fhir_geospatial.py
@@ -3,6 +3,7 @@ import os
 import json
 from unittest import mock
 from fastapi.testclient import TestClient
+from fastapi import Response, status
 from app.main import app
 from app.config import get_settings
 
@@ -14,8 +15,9 @@ test_bundle = json.load(
     open(pathlib.Path(__file__).parent / "assets" / "single_patient_bundle.json")
 )
 
-
-def test_geocode_bundle_bad_smarty_creds():
+@mock.patch("app.routers.fhir_geospatial.SmartyFhirGeocodeClient")
+@mock.patch("app.routers.fhir_geospatial.geocode_bundle_endpoint")
+def test_geocode_bundle_bad_smarty_creds(patched_geocode, patched_smarty_client):
 
     test_request = {
         "bundle": test_bundle,
@@ -23,12 +25,17 @@ def test_geocode_bundle_bad_smarty_creds():
         "auth_id": "test_id",
         "auth_token": "test_token",
     }
-    expected_response = 400
+    error = ""
+    expected_response = Response
+    expected_response.status_code = status.HTTP_400_BAD_REQUEST
+    expected_response.json = {"error": error}
+    patched_smarty_client.return_value.geocode_bundle = expected_response
+    patched_geocode.geocode_client = patched_smarty_client
     actual_response = client.post(
         "/fhir/geospatial/geocode/geocode_bundle", json=test_request
     )
-
-    assert actual_response.status_code == expected_response
+    
+    assert actual_response.status_code == expected_response.status_code
 
 
 @mock.patch("app.routers.fhir_geospatial.CensusFhirGeocodeClient")
@@ -118,8 +125,9 @@ def test_geocode_bundle_smarty_no_auth_token():
     )
     assert actual_response.json() == expected_response
 
-
-def test_geocode_bundle_bad_smarty_creds_env():
+@mock.patch("app.routers.fhir_geospatial.SmartyFhirGeocodeClient")
+@mock.patch("app.routers.fhir_geospatial.geocode_bundle_endpoint")
+def test_geocode_bundle_bad_smarty_creds_env(patched_geocode, patched_smarty_client):
     test_request = {
         "bundle": test_bundle,
         "geocode_method": "smarty",
@@ -129,11 +137,16 @@ def test_geocode_bundle_bad_smarty_creds_env():
     os.environ["AUTH_ID"] = "test_id"
     os.environ["AUTH_TOKEN"] = "test_token"
     get_settings.cache_clear()
-    expected_response = 400
+    error = ""
+    expected_response = Response
+    expected_response.status_code = status.HTTP_400_BAD_REQUEST
+    expected_response.json = {"error": error}
+    patched_smarty_client.return_value.geocode_bundle = expected_response
+    patched_geocode.geocode_client = patched_smarty_client
     actual_response = client.post(
         "/fhir/geospatial/geocode/geocode_bundle", json=test_request
     )
 
-    assert actual_response.status_code == expected_response
+    assert actual_response.status_code == expected_response.status_code
     os.environ.pop("AUTH_ID", None)
     os.environ.pop("AUTH_TOKEN", None)

--- a/containers/phdi-ingestion/tests/test_fhir_geospatial.py
+++ b/containers/phdi-ingestion/tests/test_fhir_geospatial.py
@@ -15,6 +15,7 @@ test_bundle = json.load(
     open(pathlib.Path(__file__).parent / "assets" / "single_patient_bundle.json")
 )
 
+
 @mock.patch("app.routers.fhir_geospatial.SmartyFhirGeocodeClient")
 @mock.patch("app.routers.fhir_geospatial.geocode_bundle_endpoint")
 def test_geocode_bundle_bad_smarty_creds(patched_geocode, patched_smarty_client):
@@ -34,7 +35,7 @@ def test_geocode_bundle_bad_smarty_creds(patched_geocode, patched_smarty_client)
     actual_response = client.post(
         "/fhir/geospatial/geocode/geocode_bundle", json=test_request
     )
-    
+  
     assert actual_response.status_code == expected_response.status_code
 
 
@@ -124,6 +125,7 @@ def test_geocode_bundle_smarty_no_auth_token():
         "/fhir/geospatial/geocode/geocode_bundle", json=test_request
     )
     assert actual_response.json() == expected_response
+
 
 @mock.patch("app.routers.fhir_geospatial.SmartyFhirGeocodeClient")
 @mock.patch("app.routers.fhir_geospatial.geocode_bundle_endpoint")

--- a/containers/phdi-ingestion/tests/test_fhir_geospatial.py
+++ b/containers/phdi-ingestion/tests/test_fhir_geospatial.py
@@ -35,7 +35,7 @@ def test_geocode_bundle_bad_smarty_creds(patched_geocode, patched_smarty_client)
     actual_response = client.post(
         "/fhir/geospatial/geocode/geocode_bundle", json=test_request
     )
-  
+
     assert actual_response.status_code == expected_response.status_code
 
 


### PR DESCRIPTION
This PR addresses the following issues:

1- In the container.phdi-ingestion section of PHDI the test_geospatial.py there were two tests that were passing, but were making actual calls to the Smarty third-party application, slowing the tests and not properly utilizing mocking capabilities.  The mocking has been updated so the unit test still performs proper testing, but no longer calls Smarty.
2- In the container.fhir-converter section of PHDI there were two tests that were expecting to find a path and file that weren't available on local machines.  To fix this, the Path capabilities were mocked, which fixed the issue.