### PR TITLE
Create extract data from schema function

### DIFF
--- a/phdi/fhir/tabulation/tables.py
+++ b/phdi/fhir/tabulation/tables.py
@@ -4,7 +4,7 @@ import random
 import pathlib
 
 from functools import cache
-from typing import Any, Callable, Literal, List, Tuple
+from typing import Any, Callable, Dict, Literal, List, Tuple
 from urllib.parse import parse_qs, urlencode
 
 from phdi.cloud.core import BaseCredentialManager
@@ -173,7 +173,7 @@ def generate_all_tables_in_schema(
 
 def extract_data_from_fhir_search_incremental(
     search_url: str, cred_manager: BaseCredentialManager = None
-) -> Tuple[dict, str]:
+) -> Tuple[List[dict], str]:
     """
     Performs a FHIR search for a single page of data and returns a dictionary containing
     the data and a next URL. If there is no next URL (this is the last page of data),
@@ -181,7 +181,8 @@ def extract_data_from_fhir_search_incremental(
 
     :param search_url: The URL to a FHIR server with search criteria.
     :param cred_manager: The credential manager used to authenticate to the FHIR server.
-    :return: Tuple containing single page of data as a dictionary and the next URL.
+    :return: Tuple containing single page of data as a list of FHIR resources
+      and the next URL.
     """
 
     # TODO: Modify fhir_server_get (and http_request_with_reauth) to function without
@@ -229,6 +230,30 @@ def extract_data_from_fhir_search(
             search_url=next, cred_manager=cred_manager
         )
         results.extend(incremental_results)
+
+    return results
+
+
+def extract_data_from_schema(
+    schema: dict, fhir_url: str, cred_manager: BaseCredentialManager = None
+) -> Dict[str, dict]:
+    """
+    Performs a full FHIR search for each table in `schema`, and returns a dictionary
+    mapping the table name to corresponding search results.
+
+    :param schema: The schema that defines the extraction to perform.
+    :param cred_manager: The credential manager used to authenticate to the FHIR server.
+    :return: A dictionary mapping table name to a list of FHIR resources returned from
+      the search.
+    """
+
+    search_urls = _generate_search_urls(schema=schema)
+
+    results = {}
+    for table_name, search_url in search_urls.items():
+        results[table_name] = extract_data_from_fhir_search(
+            search_url=f"{fhir_url}/{search_url}", cred_manager=cred_manager
+        )
 
     return results
 

--- a/tests/assets/valid_schema.yaml
+++ b/tests/assets/valid_schema.yaml
@@ -37,18 +37,8 @@ tables:
         include_nulls: false
         include_unknowns: false
         selection_criteria: first
-      First Name:
-        fhir_path: Patient.name.given
-        include_nulls: false
-        include_unknowns: false
-        selection_criteria: first
-      Last Name:
-        fhir_path: Patient.name.family
-        include_nulls: false
-        include_unknowns: false
-        selection_criteria: first
-      Phone Number:
-        fhir_path: Patient.telecom.where(system = 'phone').value
+      Observation Subject:
+        fhir_path: Observation.subject.reference
         include_nulls: false
         include_unknowns: false
         selection_criteria: first

--- a/tests/fhir/tabulation/test_fhir_tabulation.py
+++ b/tests/fhir/tabulation/test_fhir_tabulation.py
@@ -478,16 +478,26 @@ def test_extract_data_from_schema(patch_search, patch_gen_urls):
 
     data = {
         "Table 1A": [
-            ["Patient ID", "First Name", "Last Name", "Phone Number"],
-            ["pid1", "John", "Doe", "111-222-3333"],
-            ["pid2", "Jane", "Smith", "111-222-4444"],
-            ["pid3", "Pat", "Cranston", "111-222-5555"],
+            {
+                "resourceType": "Patient",
+                "id": "pid1",
+                "name": {"given": ["John"], "family": "Doe"},
+            },
+            {
+                "resourceType": "Patient",
+                "id": "pid1",
+                "name": {"given": ["Jane"], "family": "Smith"},
+            },
+            {
+                "resourceType": "Patient",
+                "id": "pid1",
+                "name": {"given": ["Pat"], "family": "Cranston"},
+            },
         ],
         "Table 2A": [
-            ["Observation ID", "Observation Subject"],
-            ["oid1", "Patient/pid1"],
-            ["oid2", "Patient/pid1"],
-            ["oid3", "Patient/pid2"],
+            {"resourceType": "Observation", "id": "obs1", "subject": "pid1"},
+            {"resourceType": "Observation", "id": "obs2", "subject": "pid1"},
+            {"resourceType": "Observation", "id": "obs3", "subject": "pid2"},
         ],
     }
 

--- a/tests/fhir/tabulation/test_fhir_tabulation.py
+++ b/tests/fhir/tabulation/test_fhir_tabulation.py
@@ -16,7 +16,7 @@ from phdi.fhir.tabulation.tables import (
     _generate_search_urls,
     extract_data_from_fhir_search_incremental,
     extract_data_from_fhir_search,
-    extract_data_from_fhir_schema,
+    extract_data_from_schema,
 )
 
 
@@ -464,7 +464,7 @@ def test_extract_data_from_fhir_search(patch_query):
 
 @mock.patch("phdi.fhir.tabulation.tables._generate_search_urls")
 @mock.patch("phdi.fhir.tabulation.tables.extract_data_from_fhir_search")
-def test_extract_data_from_fhir_schema(patch_search, patch_gen_urls):
+def test_extract_data_from_schema(patch_search, patch_gen_urls):
     patch_gen_urls.return_value = {
         "Table 1A": "table_1a_search_string",
         "Table 2A": "table_2a_search_string",
@@ -499,7 +499,7 @@ def test_extract_data_from_fhir_schema(patch_search, patch_gen_urls):
 
     fhir_url = "http://some-fhir-url?some-query-url"
 
-    search_results = extract_data_from_fhir_schema(schema=schema, fhir_url=fhir_url)
+    search_results = extract_data_from_schema(schema=schema, fhir_url=fhir_url)
 
     assert search_results == data
 


### PR DESCRIPTION
# Description
This PR creates a new function that accepts a tabulation schema, and extracts resources based on the derived search string.

# Additional Changes
The method signature for `extract_data_from_fhir_search_incremental` was updated to specify the correct return type, and the return docstring was also updated.