### PR TITLE
Remove whiteout file from fhir-converter container

### DIFF
--- a/containers/fhir-converter/Dockerfile
+++ b/containers/fhir-converter/Dockerfile
@@ -4,6 +4,7 @@ FROM mcr.microsoft.com/dotnet/sdk:3.1 as build
 RUN git clone https://github.com/microsoft/FHIR-Converter.git --branch v5.0.4 --single-branch /build/FHIR-Converter
 WORKDIR /build/FHIR-Converter
 RUN echo test > src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/TestData/DecompressedFiles/VXU_V04.liquid
+RUN rm src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/TestData/DecompressedFiles/.wh.VXU_V04.liquid
 RUN mkdir bin && \
     wget https://github.com/deislabs/oras/releases/download/v0.12.0/oras_0.12.0_windows_amd64.tar.gz -O ./bin/oras.tar.gz && \
     tar -xvf ./bin/oras.tar.gz -C ./bin


### PR DESCRIPTION
Needed to add this line to avoid an error associated with this file when pushing the image to Azure Container Registry.