### PR TITLE
Fixed Azure Cred Manager and Cloud Storage Provide Class instantiation issue

### DIFF
--- a/containers/phdi-ingestion/app/config.py
+++ b/containers/phdi-ingestion/app/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     auth_token: Optional[str]
     cloud_provider: Optional[Literal["azure", "gcp"]]
     bucket_name: Optional[str]
+    storage_account_url: Optional[str]
 
 
 @lru_cache()

--- a/containers/phdi-ingestion/app/routers/cloud_storage.py
+++ b/containers/phdi-ingestion/app/routers/cloud_storage.py
@@ -17,6 +17,7 @@ class WriteBlobToStorageInput(BaseModel):
     cloud_provider: Optional[Literal["azure", "gcp"]]
     bucket_name: Optional[str]
     file_name: str
+    storage_account_url: Optional[str] = None
 
 
 @router.post("/write_blob_to_storage", status_code=200)
@@ -38,9 +39,18 @@ def write_blob_to_cloud_storage_endpoint(
     if search_result != "All values were found.":
         response.status_code = status.HTTP_400_BAD_REQUEST
         return search_result
+    if input["cloud_provider"] == "azure":
+        azure_required_values = ["storage_account_url"]
+        azure_search_result = search_for_required_values(
+            input, required_values=azure_required_values
+        )
+        if azure_search_result != "All values were found.":
+            response.status_code = status.HTTP_400_BAD_REQUEST
+            return azure_search_result
 
     cloud_provider_connection = get_cloud_provider_storage_connection(
-        cloud_provider=input["cloud_provider"]
+        cloud_provider=input["cloud_provider"],
+        storage_account_url=input["storage_account_url"],
     )
 
     full_file_name = input["file_name"] + str(int(time.time()))

--- a/containers/phdi-ingestion/app/routers/fhir_transport_http.py
+++ b/containers/phdi-ingestion/app/routers/fhir_transport_http.py
@@ -45,7 +45,9 @@ def upload_bundle_to_fhir_server_endpoint(
         response.status_code = status.HTTP_400_BAD_REQUEST
         return search_result
 
-    input["cred_manager"] = get_cred_manager(cred_manager=input["cred_manager"])
+    input["cred_manager"] = get_cred_manager(
+        cred_manager=input["cred_manager"], location_url=input["fhir_url"]
+    )
 
     fhir_server_response = upload_bundle_to_fhir_server(**input)
     fhir_server_response_body = fhir_server_response.json()

--- a/containers/phdi-ingestion/app/utils.py
+++ b/containers/phdi-ingestion/app/utils.py
@@ -1,6 +1,6 @@
-from typing import Any
 from app.config import get_settings
 from phdi.cloud.azure import AzureCloudContainerConnection, AzureCredentialManager
+from phdi.cloud.core import BaseCredentialManager
 from phdi.cloud.gcp import GcpCloudStorageConnection, GcpCredentialManager
 
 
@@ -77,7 +77,9 @@ def search_for_required_values(input: dict, required_values: list) -> str:
     return message
 
 
-def get_cred_manager(cred_manager: str) -> Any:
+def get_cred_manager(
+    cred_manager: str, location_url: str = None
+) -> BaseCredentialManager:
     """
     Return a credential manager for different cloud providers depending upon which
     one the user requests via the parameter.
@@ -87,11 +89,21 @@ def get_cred_manager(cred_manager: str) -> Any:
     :return: Either a Google Cloud Credential Manager or an Azure Credential Manager
     depending upon the value passed in.
     """
-    result = cred_managers.get(cred_manager)
+    cred_manager_class = cred_managers.get(cred_manager)
+    result = None
+    # if the cred_manager_class is not none then instantiate an instance of it
+    if cred_manager_class is not None:
+        if cred_manager == "azure":
+            result = cred_manager_class(resource_location=location_url)
+        else:
+            result = cred_manager_class()
+
     return result
 
 
-def get_cloud_provider_storage_connection(cloud_provider: str) -> Any:
+def get_cloud_provider_storage_connection(
+    cloud_provider: str, storage_account_url: str = None
+) -> BaseCredentialManager:
     """
     Return a cloud provider storage connection for different cloud providers
     depending upon which one the user requests via the parameter.
@@ -100,5 +112,17 @@ def get_cloud_provider_storage_connection(cloud_provider: str) -> Any:
     :return: Either a Google Cloud Storage Connection or an Azure Storage
     Connection depending upon the value passed in.
     """
-    result = cloud_providers.get(cloud_provider)
+    cloud_provider_class = cloud_providers.get(cloud_provider)
+    result = None
+    # if the cloud_provider_class is not none then instantiate an instance of it
+    if cloud_provider_class is not None:
+        if cloud_provider == "azure":
+            cred_manager = get_cred_manager(
+                cred_manager=cloud_provider, location_url=storage_account_url
+            )
+            result = cloud_provider_class(
+                storage_account_url=storage_account_url, cred_manager=cred_manager
+            )
+        else:
+            result = cloud_provider_class()
     return result

--- a/containers/phdi-ingestion/tests/test_config.py
+++ b/containers/phdi-ingestion/tests/test_config.py
@@ -12,6 +12,7 @@ def test_get_settings_success():
     os.environ["AUTH_TOKEN"] = "test_token"
     os.environ["CLOUD_PROVIDER"] = "azure"
     os.environ["BUCKET_NAME"] = "my_bucket"
+    os.environ["STORAGE_ACCOUNT_URL"] = "storage_url"
     get_settings.cache_clear()
     assert get_settings() == {
         "cred_manager": "azure",
@@ -21,12 +22,14 @@ def test_get_settings_success():
         "auth_token": "test_token",
         "cloud_provider": "azure",
         "bucket_name": "my_bucket",
+        "storage_account_url": "storage_url",
     }
     os.environ.pop("CRED_MANAGER", None)
     os.environ.pop("CLOUD_PROVIDER", None)
     os.environ.pop("AUTH_ID", None)
     os.environ.pop("AUTH_TOKEN", None)
     os.environ.pop("BUCKET_NAME", None)
+    os.environ.pop("STORAGE_ACCOUNT_URL", None)
 
 
 def test_get_settings_failure_creds():

--- a/containers/phdi-ingestion/tests/test_fhir_transport_http.py
+++ b/containers/phdi-ingestion/tests/test_fhir_transport_http.py
@@ -4,7 +4,6 @@ import json
 import copy
 from fastapi.testclient import TestClient
 from unittest import mock
-
 from app.main import app
 from app.config import get_settings
 
@@ -25,10 +24,12 @@ fhir_server_response_body = json.load(
 def test_upload_bundle_to_fhir_server_request_params_success(
     patched_azure_cred_manager, patched_bundle_upload
 ):
+    manager = "azure"
+    fhir_url = "some-FHIR-server-URL"
     test_request = {
         "bundle": test_bundle,
-        "cred_manager": "azure",
-        "fhir_url": "some-FHIR-server-URL",
+        "cred_manager": manager,
+        "fhir_url": fhir_url,
     }
 
     patched_azure_cred_manager.return_value = mock.Mock()

--- a/containers/phdi-ingestion/tests/test_utils.py
+++ b/containers/phdi-ingestion/tests/test_utils.py
@@ -1,6 +1,4 @@
 import os
-from phdi.cloud.azure import AzureCloudContainerConnection, AzureCredentialManager
-from phdi.cloud.gcp import GcpCloudStorageConnection, GcpCredentialManager
 import pytest
 from app.utils import (
     check_for_fhir,
@@ -67,15 +65,17 @@ def test_check_for_fhir_bundle():
 
 
 def test_get_cred_manager_azure():
-    expected_result = AzureCredentialManager
-    actual_result = get_cred_manager("azure")
-    assert actual_result == expected_result
+    fhir_url = "Some URL"
+    actual_result = get_cred_manager("azure", fhir_url)
+    assert hasattr(actual_result, "__class__")
+    assert hasattr(actual_result, "resource_location")
+    assert hasattr(actual_result, "access_token")
 
 
 def test_get_cred_manager_gcp():
-    expected_result = GcpCredentialManager
     actual_result = get_cred_manager("gcp")
-    assert actual_result == expected_result
+    assert hasattr(actual_result, "__class__")
+    assert hasattr(actual_result, "scoped_credentials")
 
 
 def test_get_cred_manager_invalid():
@@ -85,15 +85,17 @@ def test_get_cred_manager_invalid():
 
 
 def test_get_cloud_provider_azure():
-    expected_result = AzureCloudContainerConnection
-    actual_result = get_cloud_provider_storage_connection("azure")
-    assert actual_result == expected_result
+    storage_url = "Storage URL"
+
+    actual_result = get_cloud_provider_storage_connection("azure", storage_url)
+    assert hasattr(actual_result, "__class__")
+    assert hasattr(actual_result, "storage_account_url")
 
 
 def test_get_cloud_provider_gcp():
-    expected_result = GcpCloudStorageConnection
     actual_result = get_cloud_provider_storage_connection("gcp")
-    assert actual_result == expected_result
+    assert hasattr(actual_result, "__class__")
+    assert hasattr(actual_result, "_get_storage_client")
 
 
 def test_get_cloud_provider_invalid():


### PR DESCRIPTION
Utils was only passing back a class and never instantiated an instance of the classes.  Azure also requires certain parameters when constructing a Provider and Cred Manager class.  I have added those parameters to all the functions where necessary, as well as the proper checks.  I also added tests and fixed the existing failing tests with this updated functionality.