### PR TITLE
Merge inc loc  derive include search parameters

### DIFF
--- a/phdi/fhir/tabulation/tables.py
+++ b/phdi/fhir/tabulation/tables.py
@@ -722,8 +722,12 @@ def _merge_include_query_params_for_location(
       result in the original input parameter if called with a variable
       or the return value.
     """
+
     direction, field_location = reference_location.split(":", 1)
 
+    # Search term is _include for forward searchs, _revinclude for reverse searches.
+    # In addition, we must add an :iterate modifier if the reference is relative to
+    # another included resource
     query_param_name = None
     if direction == "forward":
         query_param_name = "_include" if relates_to_anchor else "_include:iterate"
@@ -737,8 +741,15 @@ def _merge_include_query_params_for_location(
 
     query_param_includes = query_params.get(query_param_name)
 
+    # Handle the case where the search term (_include or _revinclude)
+    # is not specified or is specified as a list.
     if query_param_includes is None:
         query_param_includes = []
+        query_params[query_param_name] = query_param_includes
+    elif isinstance(query_param_includes, str):
+        # Convert query_param_includes from str to list, and make sure
+        # the query_params dict references the new object.
+        query_param_includes = [query_param_includes]
         query_params[query_param_name] = query_param_includes
 
     if field_location not in query_param_includes:

--- a/tests/assets/reference_location_test_schema.yaml
+++ b/tests/assets/reference_location_test_schema.yaml
@@ -61,6 +61,6 @@ tables:
     columns:
       Patient ID:
         fhir_path: Patient.id
-      Case Organizaiton:
+      Case Organization:
         fhir_path: Practitioner.id
         reference_location: [reverse:Composition:subject, forward:Composition:custodian] 

--- a/tests/fhir/tabulation/test_fhir_tabulation.py
+++ b/tests/fhir/tabulation/test_fhir_tabulation.py
@@ -805,7 +805,7 @@ def test_merge_include_query_params_for_location():
     )
 
     assert schema_table["metadata"].get("query_params", {}) == {
-        "_include": ["Observation.subject"]
+        "_revinclude": ["Observation.subject"]
     }
 
     # Test forward reference with existing _include query parameter
@@ -821,7 +821,7 @@ def test_merge_include_query_params_for_location():
 
     assert schema_table["metadata"].get("query_params", {}) == {
         "test": "value",
-        "_include": ["existing value", "Observation.subject"],
+        "_include": ["existing value", "Patient.generalPractitioner"],
     }
 
     # Test forward reference with existing multi-value _include query parameter
@@ -837,7 +837,11 @@ def test_merge_include_query_params_for_location():
 
     assert schema_table["metadata"].get("query_params", {}) == {
         "test": "value",
-        "_include": ["existing value", "existing value2", "Observation.subject"],
+        "_include": [
+            "existing value",
+            "existing value2",
+            "Patient.generalPractitioner",
+        ],
     }
 
     # Test chained reverse then forward reference
@@ -845,14 +849,21 @@ def test_merge_include_query_params_for_location():
 
     schema_table["metadata"]["query_params"] = _merge_include_query_params_for_location(
         query_params=schema_table["metadata"].get("query_params", {}),
-        reference_location=schema_table["columns"]["General Practitioner"][
+        reference_location=schema_table["columns"]["Case Organization"][
             "reference_location"
-        ],
+        ][0],
         relates_to_anchor=True,
+    )
+    schema_table["metadata"]["query_params"] = _merge_include_query_params_for_location(
+        query_params=schema_table["metadata"].get("query_params", {}),
+        reference_location=schema_table["columns"]["Case Organization"][
+            "reference_location"
+        ][1],
+        relates_to_anchor=False,
     )
 
     assert schema_table["metadata"].get("query_params", {}) == {
         "test": "value",
         "_revinclude": ["Composition:subject"],
-        "_include:iterate": ["Composition:subject"],
+        "_include:iterate": ["Composition:custodian"],
     }


### PR DESCRIPTION
# Description
This change is part of an effort to support multi-resource tables in the PHDI tabulation framework.  It provides foundational support for augmenting search parameters with `_include` and `_revinclude` directives to ensure that data required for multi-resource joins is available in search results.