### PR TITLE
Incorporate drop_invalid into tabulate_data

### DIFF
--- a/phdi/fhir/tabulation/tables.py
+++ b/phdi/fhir/tabulation/tables.py
@@ -192,6 +192,10 @@ def tabulate_data(data: List[dict], schema: dict) -> dict:
                     row.append(values)
 
             tabulated_data[table_name].append(row)
+
+    # Drop invalid values specified in the schema
+    tabulated_data = drop_invalid(tabulated_data, schema)
+
     return tabulated_data
 
 

--- a/tests/assets/tabulation_schema.yaml
+++ b/tests/assets/tabulation_schema.yaml
@@ -7,46 +7,37 @@ tables:
     columns:
       Patient ID:
         fhir_path: Patient.id
-        include_nulls: false
-        include_unknowns: false
+        invalid_values:
+          - null
+          - ""
         selection_criteria: first
       First Name:
         fhir_path: Patient.name.given
-        include_nulls: false
-        include_unknowns: false
+        invalid_values:
+          - null
+          - ""
+          - "Unknown"
         selection_criteria: first
       Last Name:
         fhir_path: Patient.name.family
-        include_nulls: false
-        include_unknowns: false
         selection_criteria: first
       Phone Number:
         fhir_path: Patient.telecom.where(system = 'phone').value
-        include_nulls: false
-        include_unknowns: false
         selection_criteria: first
   Physical Exams:
     resource_type: Patient
     columns:
       Last Name:
         fhir_path: Patient.name.family
-        include_nulls: false
-        include_unknowns: false
         selection_criteria: first
       City:
         fhir_path: Patient.address.city
-        include_nulls: false
-        include_unknowns: false
         selection_criteria: first
       Exam ID:
         fhir_path: Observation.id
-        include_nulls: false
-        include_unknowns: false
         selection_criteria: first
         reference_location: "reverse:Observation:subject"
       General Practitioner:
         fhir_path: Practitioner.name
-        include_nulls: false
-        include_unknowns: false
         selection_criteria: first
         reference_location: "forward:Patient:generalPractitioner"


### PR DESCRIPTION
Small PR to incorporate the `drop_invalid` function into tabulation and update the tabulation_schema file. Note: `drop_invalid` and `tabulate_data` function are still tested separately.