### PR TITLE
Add entry search feature

### DIFF
--- a/phdi/fhir/tabulation/tables.py
+++ b/phdi/fhir/tabulation/tables.py
@@ -144,9 +144,16 @@ def tabulate_data(data: List[dict], schema: dict) -> dict:
 
         # Second pass over just the anchor data, since that
         # defines the table's rows
-        for anchor_resource in (
+        for anchor_resource, is_result_because in (
             ref_dicts.get(table_name, {}).get(anchor_type, {}).values()
         ):
+
+            # Resources that aren't matches to the original criteria
+            # don't generate rows because they were included via a
+            # reference
+            if is_result_because != "match":
+                continue
+
             row = []
 
             for _, column_params in column_items:
@@ -418,10 +425,13 @@ def _build_reference_dicts(data: List[dict], directions_by_table: dict) -> dict:
                     reference_dicts[table_name][current_resource_type] = {}
 
                 # Forward pointers are easy: just use the resource's ID, since
-                # that's what the anchor will reference
+                # that's what the anchor will reference; store as a tuple since
+                # it's possible for an anchor resource to reference another
+                # resource of the same type without the reference needing
+                # to generate a row
                 reference_dicts[table_name][current_resource_type][
                     resource.get("id", "")
-                ] = resource
+                ] = (resource, entry.get("search", {}).get("mode", ""))
 
             if current_resource_type in resource_directions["reverse"]:
                 if current_resource_type not in reference_dicts[table_name]:
@@ -484,7 +494,7 @@ def _dereference_included_resource(
         # The requested resource may not exist
         if referenced_id not in ref_dicts[table_name][referenced_type]:
             return None
-        resource_to_use = ref_dicts[table_name][referenced_type][referenced_id]
+        resource_to_use = ref_dicts[table_name][referenced_type][referenced_id][0]
 
     # Another resource references our anchor resource
     else:

--- a/tests/assets/FHIR_server_extracted_data.json
+++ b/tests/assets/FHIR_server_extracted_data.json
@@ -250,6 +250,9 @@
                     "reference": "doc2",
                     "type": "Practitioner"
                 }
+            },
+            "search": {
+                "mode": "match"
             }
         },
         {
@@ -318,6 +321,9 @@
                         "system": "email"
                     }
                 ]
+            },
+            "search": {
+                "mode": "match"
             }
         },
         {

--- a/tests/assets/FHIR_server_observation_data.json
+++ b/tests/assets/FHIR_server_observation_data.json
@@ -1,0 +1,115 @@
+{
+    "resourceType": "Bundle",
+    "id": "06644b6371b61344be86600f2d0f4cd7",
+    "meta": {
+        "lastUpdated": "2022-06-07T14:13:02.511737+00:00"
+    },
+    "entry": [
+        {
+            "fullUrl": "some-url-1",
+            "resource": {
+                "resourceType": "Observation",
+                "id": "obs1",
+                "category": "vital-signs",
+                "value": {
+                    "valueCodeableConcept": "BMI",
+                    "valueInteger": 26
+                },
+                "hasMember": {
+                    "reference": "obs3",
+                    "type": "Observation"
+                },
+                "derivedFrom": {
+                    "reference": "obs5",
+                    "type": "Observation"
+                }
+            },
+            "search": {
+                "mode": "match"
+            }
+        },
+        {
+            "fullUrl": "some-url-2",
+            "resource": {
+                "resourceType": "Observation",
+                "id": "obs2",
+                "category": "vital-signs",
+                "value": {
+                    "valueCodeableConcept": "BMI",
+                    "valueInteger": 34
+                },
+                "hasMember": {
+                    "reference": "obs4",
+                    "type": "Observation"
+                },
+                "derivedFrom": {
+                    "reference": "obs6",
+                    "type": "Observation"
+                }
+            },
+            "search": {
+                "mode": "match"
+            }
+        },
+        {
+            "fullUrl": "some-url-3",
+            "resource": {
+                "resourceType": "Observation",
+                "id": "obs3",
+                "category": "vital-signs",
+                "value": {
+                    "valueCodeableConcept": "Height",
+                    "valueInteger": 70
+                }
+            },
+            "search": {
+                "mode": "include"
+            }
+        },
+        {
+            "fullUrl": "some-url-4",
+            "resource": {
+                "resourceType": "Observation",
+                "id": "obs4",
+                "category": "vital-signs",
+                "value": {
+                    "valueCodeableConcept": "Height",
+                    "valueInteger": 63
+                }
+            },
+            "search": {
+                "mode": "include"
+            }
+        },
+        {
+            "fullUrl": "some-url-5",
+            "resource": {
+                "resourceType": "Observation",
+                "id": "obs5",
+                "category": "vital-signs",
+                "value": {
+                    "valueCodeableConcept": "Weight",
+                    "valueInteger": 187
+                }
+            },
+            "search": {
+                "mode": "include"
+            }
+        },
+        {
+            "fullUrl": "some-url-6",
+            "resource": {
+                "resourceType": "Observation",
+                "id": "obs6",
+                "category": "vital-signs",
+                "value": {
+                    "valueCodeableConcept": "Weight",
+                    "valueInteger": 132
+                }
+            },
+            "search": {
+                "mode": "include"
+            }
+        }
+    ]
+}

--- a/tests/assets/observation_reference_schema.yaml
+++ b/tests/assets/observation_reference_schema.yaml
@@ -1,0 +1,28 @@
+metadata:
+  incremental_query_count: 1000
+tables:
+  BMI Values:
+    resource_type: Observation
+    columns:
+      Base Observation ID:
+        fhir_path: Observation.id
+        include_nulls: false
+        include_unknowns: false
+        selection_criteria: first
+      BMI:
+        fhir_path: Observation.value.valueInteger
+        include_nulls: false
+        include_unknowns: false
+        selection_criteria: first
+      Patient Height:
+        fhir_path: Observation.value.valueInteger
+        include_nulls: false
+        include_unknowns: false
+        selection_criteria: first
+        reference_location: "forward:Observation:hasMember"
+      Patient Weight:
+        fhir_path: Observation.value.valueInteger
+        include_nulls: false
+        include_unknowns: false
+        selection_criteria: first
+        reference_location: "forward:Observation:derivedFrom"

--- a/tests/fhir/tabulation/test_fhir_tabulation.py
+++ b/tests/fhir/tabulation/test_fhir_tabulation.py
@@ -175,6 +175,48 @@ def test_tabulate_data():
             tests_run += 1
             assert found_match
 
+    # Now test case where the anchor resource type references other
+    # resources of the same type that shouldn't generate rows
+    schema = yaml.safe_load(
+        open(
+            pathlib.Path(__file__).parent.parent.parent
+            / "assets"
+            / "observation_reference_schema.yaml"
+        )
+    )
+    extracted_data = json.load(
+        open(
+            pathlib.Path(__file__).parent.parent.parent
+            / "assets"
+            / "FHIR_server_observation_data.json"
+        )
+    )
+
+    tabulated_data = tabulate_data(extracted_data["entry"], schema)
+    assert set(tabulated_data["BMI Values"][0]) == {
+        "Base Observation ID",
+        "BMI",
+        "Patient Height",
+        "Patient Weight",
+    }
+
+    row_sets = [
+        {"obs1", 26, 70, 187},
+        {"obs2", 34, 63, 132},
+    ]
+    assert len(tabulated_data["BMI Values"][1:]) == 2
+    tests_run = 0
+    for row in row_sets:
+        found_match = False
+        for table_row in tabulated_data["BMI Values"][1:]:
+            print(table_row)
+            if set(table_row) == row:
+                found_match = True
+                break
+        if tests_run <= 1:
+            tests_run += 1
+            assert found_match
+
 
 @mock.patch("phdi.fhir.tabulation.tables.write_table")
 @mock.patch("phdi.fhir.tabulation.tables.fhir_server_get")


### PR DESCRIPTION
This PR adds the functionality specified in this ticket https://app.clickup.com/t/3rgqa07 . Previously, it was possible for the FHIR server to return referenced resources that happened to share the same type as a table anchor, and these referenced resources would then incorrectly generate new rows in the table. With the changes in this PR, this no longer happens. Now, only resources that match the _original_ FHIR server query criteria generate rows in the table, while "include" resources are used to fill out desired column values.