### PR TITLE
Refactor tabulate to single table

### DIFF
--- a/phdi/fhir/tabulation/tables.py
+++ b/phdi/fhir/tabulation/tables.py
@@ -135,7 +135,7 @@ def extract_data_from_schema(
     return results
 
 
-def tabulate_data(data: List[dict], schema: dict, table_name: str) -> dict:
+def tabulate_data(data: List[dict], schema: dict, table_name: str) -> List[list]:
     """
     Transforms a list of bundle entries into a tabular format (given by
     a list of lists) using a user-defined schema of the columns of
@@ -174,11 +174,11 @@ def tabulate_data(data: List[dict], schema: dict, table_name: str) -> dict:
 
     # Get the columns from the schema so we always iterate through
     # them in a consistent order
-    table_params = schema.get("tables", {}).get(table_name, {})
-    column_items = table_params.get("columns", {}).items()
+    table_params = schema["tables"][table_name]
+    column_items = table_params["columns"].items()
     headers = [column_name for column_name, _ in column_items]
     tabulated_data = [headers]
-    anchor_type = schema.get("tables", {}).get(table_name, {}).get("resource_type", "")
+    anchor_type = schema["tables"][table_name]["resource_type"]
 
     # Second pass over just the anchor data, since that
     # defines the table's rows

--- a/tests/fhir/tabulation/test_fhir_tabulation.py
+++ b/tests/fhir/tabulation/test_fhir_tabulation.py
@@ -177,7 +177,6 @@ def test_tabulate_data():
     for row in row_sets:
         found_match = False
         for table_row in tabulated_data[1:]:
-            print(table_row)
             if set(table_row) == row:
                 found_match = True
                 break

--- a/tests/tabulation/test_tables.py
+++ b/tests/tabulation/test_tables.py
@@ -54,8 +54,7 @@ def test_write_data_csv():
     )
     extracted_data = extracted_data.get("entry", {})
 
-    tabulated_data = tabulate_data(extracted_data, schema)
-    table_to_use = tabulated_data["Physical Exams"]
+    table_to_use = tabulate_data(extracted_data, schema, "Physical Exams")
     batch_1 = table_to_use[:2]
     batch_2 = [table_to_use[0]] + table_to_use[2:]
     file_location = "./"
@@ -110,8 +109,7 @@ def test_write_data_parquet(patched_pa_table, patched_writer):
     )
     extracted_data = extracted_data.get("entry", {})
 
-    tabulated_data = tabulate_data(extracted_data, schema)
-    table_to_use = tabulated_data["Physical Exams"]
+    table_to_use = tabulate_data(extracted_data, schema, "Physical Exams")
     batch_1 = table_to_use[:2]
     batch_2 = [table_to_use[0]] + table_to_use[2:]
     file_location = "./"
@@ -154,8 +152,7 @@ def test_write_data_sql():
     )
     extracted_data = extracted_data.get("entry", {})
 
-    tabulated_data = tabulate_data(extracted_data, schema)
-    table_to_use = tabulated_data["Physical Exams"]
+    table_to_use = tabulate_data(extracted_data, schema, "Physical Exams")
     batch_1 = table_to_use[:2]
     batch_2 = [table_to_use[0]] + table_to_use[2:]
     file_location = "./"


### PR DESCRIPTION
This PR addresses the scope of work defined in this ticket https://app.clickup.com/t/3rxqzu2 . The `tabulate_data` function is converted from operating on all tables in the given schema to a single table, as specified by the user, in order to be compatible with the `extraction` functions further up the pipeline.