### PR TITLE
Refactor generate_tables for incremental approach

### DIFF
--- a/tests/assets/tabulation_schema.yaml
+++ b/tests/assets/tabulation_schema.yaml
@@ -1,5 +1,5 @@
 metadata:
-  incremental_query_count: 1000
+  results_per_page: 1000
 tables:
   Patients:
     resource_type: Patient
@@ -40,4 +40,4 @@ tables:
       General Practitioner:
         fhir_path: Practitioner.name
         selection_criteria: first
-        reference_location: "forward:Patient:general-practitioner"
+        reference_location: "forward:Patient:generalPractitioner"

--- a/tests/assets/tabulation_schema.yaml
+++ b/tests/assets/tabulation_schema.yaml
@@ -40,4 +40,4 @@ tables:
       General Practitioner:
         fhir_path: Practitioner.name
         selection_criteria: first
-        reference_location: "forward:Patient:generalPractitioner"
+        reference_location: "forward:Patient:general-practitioner"

--- a/tests/assets/valid_schema.yaml
+++ b/tests/assets/valid_schema.yaml
@@ -32,7 +32,7 @@ tables:
   table 2A:
     resource_type: Observation
     query_params:
-      category: http://hl7.org/fhir/ValueSet/observation-category|laboratory
+      category: laboratory
     columns:
       Observation ID:
         fhir_path: Observation.id

--- a/tests/fhir/tabulation/test_fhir_tabulation.py
+++ b/tests/fhir/tabulation/test_fhir_tabulation.py
@@ -412,11 +412,7 @@ def test_generate_search_urls(patch_generate_search_url):
 
     assert search_urls == {
         "table 1A": "Patient||1000||2020-01-01T00:00:00",
-        "table 2A": "Observation?category="
-        + urllib.parse.quote(
-            "http://hl7.org/fhir/ValueSet/observation-category|laboratory", safe=""
-        )
-        + urllib.parse.quote("||1000||None", safe="|"),
+        "table 2A": "Observation?category=laboratory||1000||None",
     }
 
 
@@ -453,7 +449,7 @@ def test_merge_include_query_params():
         query_params = _merge_include_query_params_for_location(query_params, r)
 
     assert query_params == {
-        "_include": ["some-reference", "Patient:generalPractitioner"],
+        "_include": ["some-reference", "Patient:general-practitioner"],
         "_revinclude": ["Observation:subject"],
     }
 
@@ -697,103 +693,103 @@ def test_extract_data_from_schema(patch_search, patch_gen_urls):
     )
 
 
-@mock.patch("phdi.fhir.tabulation.tables.extract_data_from_schema")
-def test_generate_tables(patch_schema_extraction):
-    # Set up
-    schema_path = (
-        pathlib.Path(__file__).parent.parent.parent
-        / "assets"
-        / "tabulation_schema.yaml"
-    )
-    output_params = json.load(
-        open(
-            pathlib.Path(__file__).parent.parent.parent
-            / "assets"
-            / "tabulation_schema_output_data.json"
-        )
-    )
-    fhir_url = "https://some_fhir_server_url"
-    cred_manager = None
+# @mock.patch("phdi.fhir.tabulation.tables.extract_data_from_schema")
+# def test_generate_tables(patch_schema_extraction):
+#     # Set up
+#     schema_path = (
+#         pathlib.Path(__file__).parent.parent.parent
+#         / "assets"
+#         / "tabulation_schema.yaml"
+#     )
+#     output_params = json.load(
+#         open(
+#             pathlib.Path(__file__).parent.parent.parent
+#             / "assets"
+#             / "tabulation_schema_output_data.json"
+#         )
+#     )
+#     fhir_url = "https://some_fhir_server_url"
+#     cred_manager = None
 
-    mock_extracted_data = json.load(
-        open(
-            pathlib.Path(__file__).parent.parent.parent
-            / "assets"
-            / "FHIR_server_extracted_data.json"
-        )
-    )
+#     mock_extracted_data = json.load(
+#         open(
+#             pathlib.Path(__file__).parent.parent.parent
+#             / "assets"
+#             / "FHIR_server_extracted_data.json"
+#         )
+#     )
 
-    # Mocks for extract_data_from_schema
-    patch_schema_extraction.return_value = mock_extracted_data["entry"]
+#     # Mocks for extract_data_from_schema
+#     patch_schema_extraction.return_value = mock_extracted_data["entry"]
 
-    generate_tables(
-        schema_path=schema_path,
-        output_params=output_params,
-        fhir_url=fhir_url,
-        cred_manager=cred_manager,
-    )
+#     generate_tables(
+#         schema_path=schema_path,
+#         output_params=output_params,
+#         fhir_url=fhir_url,
+#         cred_manager=cred_manager,
+#     )
 
-    patch_schema_extraction.assert_called()
+#     patch_schema_extraction.assert_called()
 
-    patients_path = os.path.join(
-        output_params["Patients"]["directory"], output_params["Patients"]["filename"]
-    )
-    # Test that file was created
-    assert os.path.exists(patients_path) is True
+#     patients_path = os.path.join(
+#         output_params["Patients"]["directory"], output_params["Patients"]["filename"]
+#     )
+#     # Test that file was created
+#     assert os.path.exists(patients_path) is True
 
-    # Test that file content match expected content
-    with open(
-        (
-            pathlib.Path(__file__).parent.parent.parent
-            / "assets"
-            / "tabulated_patients.csv"
-        ),
-        "r",
-    ) as e:
-        csvreader = csv.reader(e)
-        expected_content = [row for row in csvreader]
+#     # Test that file content match expected content
+#     with open(
+#         (
+#             pathlib.Path(__file__).parent.parent.parent
+#             / "assets"
+#             / "tabulated_patients.csv"
+#         ),
+#         "r",
+#     ) as e:
+#         csvreader = csv.reader(e)
+#         expected_content = [row for row in csvreader]
 
-    with open(patients_path, "r") as csv_file:
-        reader = csv.reader(csv_file, dialect="excel")
-        line = 0
-        for row in reader:
-            for i in range(len(row)):
-                assert row[i] == str(expected_content[line][i])
-            line += 1
-        assert line == 4
+#     with open(patients_path, "r") as csv_file:
+#         reader = csv.reader(csv_file, dialect="excel")
+#         line = 0
+#         for row in reader:
+#             for i in range(len(row)):
+#                 assert row[i] == str(expected_content[line][i])
+#             line += 1
+#         assert line == 4
 
-    # Remove file after testing is complete
-    if os.path.isfile(patients_path):  # pragma: no cover
-        os.remove(patients_path)
+#     # Remove file after testing is complete
+#     if os.path.isfile(patients_path):  # pragma: no cover
+#         os.remove(patients_path)
 
-    physical_exams_path = os.path.join(
-        output_params["Physical Exams"]["directory"],
-        output_params["Physical Exams"]["filename"],
-    )
-    # Test that file was created
-    assert os.path.exists(physical_exams_path) is True
+#     physical_exams_path = os.path.join(
+#         output_params["Physical Exams"]["directory"],
+#         output_params["Physical Exams"]["filename"],
+#     )
+#     # Test that file was created
+#     assert os.path.exists(physical_exams_path) is True
 
-    # Test that file content match expected content
-    with open(
-        (
-            pathlib.Path(__file__).parent.parent.parent
-            / "assets"
-            / "tabulated_physical_exam.csv"
-        ),
-        "r",
-    ) as e:
-        csvreader = csv.reader(e)
-        expected_content = [row for row in csvreader]
+#     # Test that file content match expected content
+#     with open(
+#         (
+#             pathlib.Path(__file__).parent.parent.parent
+#             / "assets"
+#             / "tabulated_physical_exam.csv"
+#         ),
+#         "r",
+#     ) as e:
+#         csvreader = csv.reader(e)
+#         expected_content = [row for row in csvreader]
 
-    with open(physical_exams_path, "r") as csv_file:
-        reader = csv.reader(csv_file, dialect="excel")
-        line = 0
-        for row in reader:
-            for i in range(len(row)):
-                assert row[i] == str(expected_content[line][i])
-            line += 1
-        assert line == 4
+#     with open(physical_exams_path, "r") as csv_file:
+#         reader = csv.reader(csv_file, dialect="excel")
+#         line = 0
+#         for row in reader:
+#             for i in range(len(row)):
+#                 assert row[i] == str(expected_content[line][i])
+#             line += 1
+#         assert line == 4
 
-    # Remove file after testing is complete
-    if os.path.isfile(physical_exams_path):  # pragma: no cover
-        os.remove(physical_exams_path)
+#     # Remove file after testing is complete
+#     if os.path.isfile(physical_exams_path):  # pragma: no cover
+#         os.remove(physical_exams_path)

--- a/tests/fhir/tabulation/test_fhir_tabulation.py
+++ b/tests/fhir/tabulation/test_fhir_tabulation.py
@@ -693,103 +693,108 @@ def test_extract_data_from_schema(patch_search, patch_gen_urls):
     )
 
 
-# @mock.patch("phdi.fhir.tabulation.tables.extract_data_from_schema")
-# def test_generate_tables(patch_schema_extraction):
-#     # Set up
-#     schema_path = (
-#         pathlib.Path(__file__).parent.parent.parent
-#         / "assets"
-#         / "tabulation_schema.yaml"
-#     )
-#     output_params = json.load(
-#         open(
-#             pathlib.Path(__file__).parent.parent.parent
-#             / "assets"
-#             / "tabulation_schema_output_data.json"
-#         )
-#     )
-#     fhir_url = "https://some_fhir_server_url"
-#     cred_manager = None
+@mock.patch("phdi.fhir.tabulation.tables.extract_data_from_fhir_search_incremental")
+def test_generate_tables(patch_search_incremental):
+    # Set up
+    schema_path = (
+        pathlib.Path(__file__).parent.parent.parent
+        / "assets"
+        / "tabulation_schema.yaml"
+    )
 
-#     mock_extracted_data = json.load(
-#         open(
-#             pathlib.Path(__file__).parent.parent.parent
-#             / "assets"
-#             / "FHIR_server_extracted_data.json"
-#         )
-#     )
+    output_params = json.load(
+        open(
+            pathlib.Path(__file__).parent.parent.parent
+            / "assets"
+            / "tabulation_schema_output_data.json"
+        )
+    )
+    fhir_url = "https://some_fhir_server_url"
+    cred_manager = None
 
-#     # Mocks for extract_data_from_schema
-#     patch_schema_extraction.return_value = mock_extracted_data["entry"]
+    mock_extracted_data = json.load(
+        open(
+            pathlib.Path(__file__).parent.parent.parent
+            / "assets"
+            / "FHIR_server_extracted_data.json"
+        )
+    )
+    mock_next_url = None
 
-#     generate_tables(
-#         schema_path=schema_path,
-#         output_params=output_params,
-#         fhir_url=fhir_url,
-#         cred_manager=cred_manager,
-#     )
+    # Mocks for extract_data_from_schema
+    patch_search_incremental.return_value = (
+        mock_extracted_data["entry"],
+        mock_next_url,
+    )
 
-#     patch_schema_extraction.assert_called()
+    generate_tables(
+        schema_path=schema_path,
+        output_params=output_params,
+        fhir_url=fhir_url,
+        cred_manager=cred_manager,
+    )
 
-#     patients_path = os.path.join(
-#         output_params["Patients"]["directory"], output_params["Patients"]["filename"]
-#     )
-#     # Test that file was created
-#     assert os.path.exists(patients_path) is True
+    patch_search_incremental.assert_called()
 
-#     # Test that file content match expected content
-#     with open(
-#         (
-#             pathlib.Path(__file__).parent.parent.parent
-#             / "assets"
-#             / "tabulated_patients.csv"
-#         ),
-#         "r",
-#     ) as e:
-#         csvreader = csv.reader(e)
-#         expected_content = [row for row in csvreader]
+    patients_path = os.path.join(
+        output_params["Patients"]["directory"], output_params["Patients"]["filename"]
+    )
+    # Test that file was created
+    assert os.path.exists(patients_path) is True
 
-#     with open(patients_path, "r") as csv_file:
-#         reader = csv.reader(csv_file, dialect="excel")
-#         line = 0
-#         for row in reader:
-#             for i in range(len(row)):
-#                 assert row[i] == str(expected_content[line][i])
-#             line += 1
-#         assert line == 4
+    # Test that file content match expected content
+    with open(
+        (
+            pathlib.Path(__file__).parent.parent.parent
+            / "assets"
+            / "tabulated_patients.csv"
+        ),
+        "r",
+    ) as e:
+        csvreader = csv.reader(e)
+        expected_content = [row for row in csvreader]
 
-#     # Remove file after testing is complete
-#     if os.path.isfile(patients_path):  # pragma: no cover
-#         os.remove(patients_path)
+    with open(patients_path, "r") as csv_file:
+        reader = csv.reader(csv_file, dialect="excel")
+        line = 0
+        for row in reader:
+            for i in range(len(row)):
+                assert row[i] == str(expected_content[line][i])
+            line += 1
+        assert line == 4
 
-#     physical_exams_path = os.path.join(
-#         output_params["Physical Exams"]["directory"],
-#         output_params["Physical Exams"]["filename"],
-#     )
-#     # Test that file was created
-#     assert os.path.exists(physical_exams_path) is True
+    # Remove file after testing is complete
+    if os.path.isfile(patients_path):  # pragma: no cover
+        os.remove(patients_path)
 
-#     # Test that file content match expected content
-#     with open(
-#         (
-#             pathlib.Path(__file__).parent.parent.parent
-#             / "assets"
-#             / "tabulated_physical_exam.csv"
-#         ),
-#         "r",
-#     ) as e:
-#         csvreader = csv.reader(e)
-#         expected_content = [row for row in csvreader]
+    physical_exams_path = os.path.join(
+        output_params["Physical Exams"]["directory"],
+        output_params["Physical Exams"]["filename"],
+    )
+    # Test that file was created
+    assert os.path.exists(physical_exams_path) is True
 
-#     with open(physical_exams_path, "r") as csv_file:
-#         reader = csv.reader(csv_file, dialect="excel")
-#         line = 0
-#         for row in reader:
-#             for i in range(len(row)):
-#                 assert row[i] == str(expected_content[line][i])
-#             line += 1
-#         assert line == 4
+    # Test that file content match expected content
+    with open(
+        (
+            pathlib.Path(__file__).parent.parent.parent
+            / "assets"
+            / "tabulated_physical_exam.csv"
+        ),
+        "r",
+    ) as e:
+        csvreader = csv.reader(e)
+        expected_content = [row for row in csvreader]
 
-#     # Remove file after testing is complete
-#     if os.path.isfile(physical_exams_path):  # pragma: no cover
-#         os.remove(physical_exams_path)
+    with open(physical_exams_path, "r") as csv_file:
+        reader = csv.reader(csv_file, dialect="excel")
+        line = 0
+        for row in reader:
+            for i in range(len(row)):
+                assert row[i] == str(expected_content[line][i])
+            line += 1
+        assert line == 4
+
+    # Remove file after testing is complete
+    if os.path.isfile(physical_exams_path):  # pragma: no cover
+        os.remove(physical_exams_path)


### PR DESCRIPTION
This PR refactors the `generate_tables` function to work incrementally, as outlined in the general approach of this [ticket](https://app.clickup.com/t/3pc6e55). Instead of extracting, tabulating, and writing each table into memory, we are extracting, tabualting, and writing each _incremental_ piece of each table so that we do not overwhelm memory in the case of a large table.