### PR TITLE
Fix bugs in gcpGloudStorageConnection

### DIFF
--- a/containers/phdi-ingestion/Dockerfile
+++ b/containers/phdi-ingestion/Dockerfile
@@ -2,6 +2,10 @@ FROM python:3.10-slim-buster
 
 WORKDIR /code
 
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y git
+
 COPY ./requirements.txt /code/requirements.txt
 RUN pip install -r requirements.txt
 

--- a/containers/phdi-ingestion/requirements.txt
+++ b/containers/phdi-ingestion/requirements.txt
@@ -1,4 +1,4 @@
 fastapi
 uvicorn
-phdi @ git+https://github.com/CDCgov/phdi.git@dan/fix-GcpCloudStorageConnection
+phdi
 httpx

--- a/containers/phdi-ingestion/requirements.txt
+++ b/containers/phdi-ingestion/requirements.txt
@@ -1,4 +1,4 @@
 fastapi
 uvicorn
-phdi
+phdi @ git+https://github.com/CDCgov/phdi.git@dan/fix-GcpCloudStorageConnection
 httpx

--- a/phdi/cloud/gcp.py
+++ b/phdi/cloud/gcp.py
@@ -1,4 +1,5 @@
-from typing import List
+from typing import List, Union
+import json
 from .core import BaseCredentialManager, BaseCloudStorageConnection
 import google.auth
 import google.auth.transport.requests
@@ -100,7 +101,7 @@ class GcpCloudStorageConnection(BaseCloudStorageConnection):
         """
 
         self.__storage_client = None
-        
+
     def _get_storage_client(self) -> storage.Client:
         """
         Obtains a client connected to an GCP storage container by
@@ -132,7 +133,7 @@ class GcpCloudStorageConnection(BaseCloudStorageConnection):
 
     def upload_object(
         self,
-        message: str,
+        message: Union[str, dict],
         container_name: str,
         filename: str,
         content_type="application/json",
@@ -142,7 +143,7 @@ class GcpCloudStorageConnection(BaseCloudStorageConnection):
         The message can be passed either as a raw string or as JSON.
 
         :param message: The contents of a message, encoded either as a
-          string or in a JSON format.
+          string or in a JSON-formatted dictionary.
         :param container_name: The name of the target bucket for upload.
         :param filename: The location of file within GCP blob storage.
         """
@@ -151,6 +152,10 @@ class GcpCloudStorageConnection(BaseCloudStorageConnection):
         bucket = storage_client.bucket(container_name)
 
         blob = bucket.blob(filename)
+
+        if isinstance(message, dict):
+            message = json.dumps(message).encode("utf-8")
+
         blob.upload_from_string(data=message, content_type=content_type)
 
     def list_containers(self) -> List[str]:

--- a/phdi/cloud/gcp.py
+++ b/phdi/cloud/gcp.py
@@ -94,6 +94,13 @@ class GcpCloudStorageConnection(BaseCloudStorageConnection):
     def storage_client(self) -> storage.Client:
         return self.__storage_client
 
+    def __init__(self):
+        """
+        Creates a new GcpCloudContainerConnection object.
+        """
+
+        self.__storage_client = None
+        
     def _get_storage_client(self) -> storage.Client:
         """
         Obtains a client connected to an GCP storage container by

--- a/tests/cloud/test_cloud.py
+++ b/tests/cloud/test_cloud.py
@@ -11,6 +11,7 @@ from phdi.cloud.azure import (
     AzureCloudContainerConnection,
 )
 from phdi.cloud.gcp import GcpCloudStorageConnection, GcpCredentialManager
+import google.cloud
 
 
 @mock.patch("phdi.cloud.azure.DefaultAzureCredential")
@@ -440,6 +441,13 @@ def test_azure_list_objects(mock_get_client):
 
     assert blob_list == ["blob1", "blob2"]
 
+def test_gcp_storage_connect_init():
+    phdi_container_client = GcpCloudStorageConnection()
+    assert phdi_container_client._GcpCloudStorageConnection__storage_client is None
+
+def test_gcp_get_storage_client():
+    phdi_container_client = GcpCloudStorageConnection()
+    assert isinstance(phdi_container_client._get_storage_client(), google.cloud.storage.client.Client)
 
 @mock.patch.object(GcpCloudStorageConnection, "_get_storage_client")
 def test_gcp_upload_object(mock_get_client):

--- a/tests/cloud/test_cloud.py
+++ b/tests/cloud/test_cloud.py
@@ -441,13 +441,18 @@ def test_azure_list_objects(mock_get_client):
 
     assert blob_list == ["blob1", "blob2"]
 
+
 def test_gcp_storage_connect_init():
     phdi_container_client = GcpCloudStorageConnection()
     assert phdi_container_client._GcpCloudStorageConnection__storage_client is None
 
+
 def test_gcp_get_storage_client():
     phdi_container_client = GcpCloudStorageConnection()
-    assert isinstance(phdi_container_client._get_storage_client(), google.cloud.storage.client.Client)
+    assert isinstance(
+        phdi_container_client._get_storage_client(), google.cloud.storage.client.Client
+    )
+
 
 @mock.patch.object(GcpCloudStorageConnection, "_get_storage_client")
 def test_gcp_upload_object(mock_get_client):

--- a/tests/cloud/test_cloud.py
+++ b/tests/cloud/test_cloud.py
@@ -11,7 +11,6 @@ from phdi.cloud.azure import (
     AzureCloudContainerConnection,
 )
 from phdi.cloud.gcp import GcpCloudStorageConnection, GcpCredentialManager
-import google.cloud
 
 
 @mock.patch("phdi.cloud.azure.DefaultAzureCredential")

--- a/tests/cloud/test_cloud.py
+++ b/tests/cloud/test_cloud.py
@@ -254,7 +254,7 @@ def test_gcp_credential_manager_handle_expired_credentials(
 
 
 @mock.patch.object(ContainerClient, "from_container_url")
-def test_upload_object(mock_get_client):
+def test_azure_upload_object(mock_get_client):
     mock_blob_client = mock.Mock()
 
     mock_container_client = mock.Mock()
@@ -296,7 +296,7 @@ def test_upload_object(mock_get_client):
 
 
 @mock.patch.object(AzureCloudContainerConnection, "_get_container_client")
-def test_download_object(mock_get_client):
+def test_azure_download_object(mock_get_client):
     mock_blob_client = mock.Mock()
 
     mock_container_client = mock.Mock()
@@ -333,7 +333,7 @@ def test_download_object(mock_get_client):
 
 
 @mock.patch.object(AzureCloudContainerConnection, "_get_container_client")
-def test_download_object_cp1252(mock_get_client):
+def test_azure_download_object_cp1252(mock_get_client):
     mock_blob_client = mock.Mock()
 
     mock_container_client = mock.Mock()
@@ -380,7 +380,7 @@ def test_download_object_cp1252(mock_get_client):
 
 
 @mock.patch("phdi.cloud.azure.BlobServiceClient")
-def test_list_containers(mock_service_client):
+def test_azure_list_containers(mock_service_client):
     mock_service_client_instance = mock_service_client.return_value
     item1 = mock.Mock()
     item1.name = "container1"
@@ -411,7 +411,7 @@ def test_list_containers(mock_service_client):
 
 
 @mock.patch.object(AzureCloudContainerConnection, "_get_container_client")
-def test_list_objects(mock_get_client):
+def test_azure_list_objects(mock_get_client):
     item1 = mock.Mock()
     item1.name = "blob1"
     item2 = mock.Mock()

--- a/tests/cloud/test_cloud.py
+++ b/tests/cloud/test_cloud.py
@@ -446,6 +446,7 @@ def test_gcp_storage_connect_init():
     phdi_container_client = GcpCloudStorageConnection()
     assert phdi_container_client._GcpCloudStorageConnection__storage_client is None
 
+
 @mock.patch("phdi.cloud.gcp.storage")
 def test_gcp_get_storage_client(patched_storage):
     phdi_container_client = GcpCloudStorageConnection()

--- a/tests/cloud/test_cloud.py
+++ b/tests/cloud/test_cloud.py
@@ -446,12 +446,11 @@ def test_gcp_storage_connect_init():
     phdi_container_client = GcpCloudStorageConnection()
     assert phdi_container_client._GcpCloudStorageConnection__storage_client is None
 
-
-def test_gcp_get_storage_client():
+@mock.patch("phdi.cloud.gcp.storage")
+def test_gcp_get_storage_client(patched_storage):
     phdi_container_client = GcpCloudStorageConnection()
-    assert isinstance(
-        phdi_container_client._get_storage_client(), google.cloud.storage.client.Client
-    )
+    phdi_container_client._get_storage_client()
+    assert patched_storage.Client.called
 
 
 @mock.patch.object(GcpCloudStorageConnection, "_get_storage_client")


### PR DESCRIPTION
This PR addresses two problems that were discovered in `gcpGloudStorageConnection`. 

1. The `__storage_client` attribute is now initialized before we attempt to use it.
2. The `upload_object` method now supports both strings and dicts.

Tests have been updated as well to account for these changes.