### PR TITLE
quick fix to re-use parquet writer for each increment of tabulated data

### DIFF
--- a/phdi/fhir/tabulation/tables.py
+++ b/phdi/fhir/tabulation/tables.py
@@ -686,7 +686,7 @@ def generate_tables(
     search_urls = _generate_search_urls(schema=schema)
 
     for table_name, search_url in search_urls.items():
-        pq_writer = output_params[table_name].get("pq_writer", None)
+        pq_writer = None
         next = search_url
         while next is not None:
 
@@ -707,6 +707,8 @@ def generate_tables(
                 filename=output_params[table_name].get("filename"),
                 output_type=output_params[table_name].get("output_type"),
                 db_file=output_params[table_name].get("db_file", None),
-                db_tablename=output_params[table_name].get("db_filename", None),
+                db_tablename=output_params[table_name].get("db_tablename", None),
                 pq_writer=pq_writer,
             )
+        if pq_writer is not None:
+            pq_writer.close()  # pragma: no cover

--- a/phdi/fhir/tabulation/tables.py
+++ b/phdi/fhir/tabulation/tables.py
@@ -686,6 +686,7 @@ def generate_tables(
     search_urls = _generate_search_urls(schema=schema)
 
     for table_name, search_url in search_urls.items():
+        pq_writer = output_params[table_name].get("pq_writer", None)
         next = search_url
         while next is not None:
 
@@ -700,12 +701,12 @@ def generate_tables(
             )
 
             # Write set of tabulated incremental data
-            write_data(
+            pq_writer = write_data(
                 tabulated_data=tabulated_incremental_data,
                 directory=output_params[table_name].get("directory"),
                 filename=output_params[table_name].get("filename"),
                 output_type=output_params[table_name].get("output_type"),
                 db_file=output_params[table_name].get("db_file", None),
                 db_tablename=output_params[table_name].get("db_filename", None),
-                pq_writer=output_params[table_name].get("pq_writer", None),
+                pq_writer=pq_writer,
             )


### PR DESCRIPTION
Per @DanielPaseltiner's catch, I updated `generate_tables` to re-use the same parquet writer for each incremental result of tabulated data. With this update, we now check once to see if the user has passed in a writer and if yes, return the same writer for re-use on each subsequent incremental chunk of tabulated data.