### PR TITLE
Bug fix for referenced_anchor

### DIFF
--- a/phdi/fhir/tabulation/tables.py
+++ b/phdi/fhir/tabulation/tables.py
@@ -370,6 +370,7 @@ def _build_reference_dicts(data: List[dict], directions_by_table: dict) -> dict:
                 referenced_anchor = _extract_value_with_resource_path(
                     resource, ref_path
                 )
+                referenced_anchor = referenced_anchor.split("/")[-1]
 
                 # There could be a many-to-one relationship with reverse pointers,
                 # so store them in a list


### PR DESCRIPTION
This PR is a quick fix for how we store the anchored_reference during tabulation. We need to store only the final number in a referneced_anchor, e.g., `1062` so that we can search the reference_dictionary by the id directly. Before we were storing the equivalent of `Patient/1062` so we could not do a proper look up by `1062`. 

@bamader if you're able to take a quick look to see if this matches our discussion today, that would be great.