### PR TITLE
Use cred manager for auth in tabulation

### DIFF
--- a/phdi/fhir/tabulation/tables.py
+++ b/phdi/fhir/tabulation/tables.py
@@ -114,7 +114,7 @@ def extract_data_from_fhir_search_incremental(
     headers = {}
     if cred_manager is not None:
         access_token = cred_manager.get_access_token()
-        headers={
+        headers = {
             "Authorization": f"Bearer {access_token}",
             "Accept": "application/fhir+json",
             "Content-Type": "application/fhir+json",

--- a/phdi/fhir/tabulation/tables.py
+++ b/phdi/fhir/tabulation/tables.py
@@ -111,13 +111,22 @@ def extract_data_from_fhir_search_incremental(
     # mandating a credential manager. Then replace the direct call to
     # http_request_with_reauth with fhir_server_get.
     # response = fhir_server_get(url=full_url, cred_manager=cred_manager)
+    headers = {}
+    if cred_manager is not None:
+        access_token = cred_manager.get_access_token()
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Accept": "application/fhir+json",
+            "Content-Type": "application/fhir+json",
+        }
+
     response = http_request_with_reauth(
         url=search_url,
         cred_manager=cred_manager,
         retry_count=2,
         request_type="GET",
         allowed_methods=["GET"],
-        headers={},
+        headers=headers,
     )
 
     if response.status_code != 200:  # pragma: no cover

--- a/tests/fhir/tabulation/test_fhir_tabulation.py
+++ b/tests/fhir/tabulation/test_fhir_tabulation.py
@@ -606,6 +606,54 @@ def test_extract_data_from_fhir_search_incremental(patch_query):
         + "http://localhost:8080/fhir/Patient"
     ) in str(warn[0].message)
 
+@mock.patch("phdi.fhir.tabulation.tables.http_request_with_reauth")
+def test_extract_data_from_fhir_search_incremental_auth(patch_query):
+    """Test that the header of the request passed to http_request_with_reauth is set 
+    appropriately when a credential manager is provided and when one is not."""
+
+    # Case 1: Credential manager is provided.
+    cred_manager = mock.Mock()
+    cred_manager.get_access_token.return_value = "my-access-token"
+    search_url = "some-fhir-search-url"
+
+    headers = {
+            "Authorization": f"Bearer {cred_manager.get_access_token.return_value}",
+            "Accept": "application/fhir+json",
+            "Content-Type": "application/fhir+json",
+        }
+
+    mocked_http_response = mock.Mock(spec=Response)
+    mocked_http_response.status_code = 200
+    mocked_http_response._content = json.dumps("").encode("utf-8")
+    patch_query.return_value = mocked_http_response
+
+    extract_data_from_fhir_search_incremental(
+        search_url=search_url, cred_manager=cred_manager
+    )
+
+    assert patch_query.called_with(
+        url=search_url,
+        cred_manager=cred_manager,
+        retry_count=2,
+        request_type="GET",
+        allowed_methods=["GET"],
+        headers=headers)
+
+    cred_manager = None
+
+    # Case 2: Credential manager is not provided.
+    extract_data_from_fhir_search_incremental(
+        search_url=search_url, cred_manager = cred_manager
+    )
+
+    assert patch_query.called_with(
+        url=search_url,
+        cred_manager=cred_manager,
+        retry_count=2,
+        request_type="GET",
+        allowed_methods=["GET"],
+        headers={})
+
 
 @mock.patch("phdi.fhir.tabulation.tables.http_request_with_reauth")
 def test_extract_data_from_fhir_search(patch_query):

--- a/tests/fhir/tabulation/test_fhir_tabulation.py
+++ b/tests/fhir/tabulation/test_fhir_tabulation.py
@@ -606,9 +606,10 @@ def test_extract_data_from_fhir_search_incremental(patch_query):
         + "http://localhost:8080/fhir/Patient"
     ) in str(warn[0].message)
 
+
 @mock.patch("phdi.fhir.tabulation.tables.http_request_with_reauth")
 def test_extract_data_from_fhir_search_incremental_auth(patch_query):
-    """Test that the header of the request passed to http_request_with_reauth is set 
+    """Test that the header of the request passed to http_request_with_reauth is set
     appropriately when a credential manager is provided and when one is not."""
 
     # Case 1: Credential manager is provided.
@@ -617,10 +618,10 @@ def test_extract_data_from_fhir_search_incremental_auth(patch_query):
     search_url = "some-fhir-search-url"
 
     headers = {
-            "Authorization": f"Bearer {cred_manager.get_access_token.return_value}",
-            "Accept": "application/fhir+json",
-            "Content-Type": "application/fhir+json",
-        }
+        "Authorization": f"Bearer {cred_manager.get_access_token.return_value}",
+        "Accept": "application/fhir+json",
+        "Content-Type": "application/fhir+json",
+    }
 
     mocked_http_response = mock.Mock(spec=Response)
     mocked_http_response.status_code = 200
@@ -637,13 +638,14 @@ def test_extract_data_from_fhir_search_incremental_auth(patch_query):
         retry_count=2,
         request_type="GET",
         allowed_methods=["GET"],
-        headers=headers)
+        headers=headers,
+    )
 
     cred_manager = None
 
     # Case 2: Credential manager is not provided.
     extract_data_from_fhir_search_incremental(
-        search_url=search_url, cred_manager = cred_manager
+        search_url=search_url, cred_manager=cred_manager
     )
 
     assert patch_query.called_with(
@@ -652,7 +654,8 @@ def test_extract_data_from_fhir_search_incremental_auth(patch_query):
         retry_count=2,
         request_type="GET",
         allowed_methods=["GET"],
-        headers={})
+        headers={},
+    )
 
 
 @mock.patch("phdi.fhir.tabulation.tables.http_request_with_reauth")


### PR DESCRIPTION
This PR fixes our use of credential mangers in tabulation to allow for authentication with FHIR servers when necessary.