### PR TITLE
Tabulation bugs: search_url & referenced_anchor

### DIFF
--- a/containers/phdi-ingestion/requirements.txt
+++ b/containers/phdi-ingestion/requirements.txt
@@ -1,4 +1,4 @@
-fastapi
+fastapi==0.88.0
 uvicorn
 phdi
 httpx

--- a/phdi/fhir/tabulation/tables.py
+++ b/phdi/fhir/tabulation/tables.py
@@ -702,7 +702,7 @@ def generate_tables(
 
             # Return set of incremental results and next URL to query
             incremental_results, next = extract_data_from_fhir_search_incremental(
-                search_url=urllib.parse.urljoin(fhir_url, search_url),
+                search_url=urllib.parse.urljoin(fhir_url, next),
                 cred_manager=cred_manager,
             )
             # Tabulate data for set of incremental results

--- a/phdi/fhir/tabulation/tables.py
+++ b/phdi/fhir/tabulation/tables.py
@@ -379,8 +379,7 @@ def _build_reference_dicts(data: List[dict], directions_by_table: dict) -> dict:
                 referenced_anchor = _extract_value_with_resource_path(
                     resource, ref_path
                 )
-                referenced_anchor = referenced_anchor.split("/")[-1]  # HAPI servers
-                referenced_anchor = referenced_anchor.split(":")[-1]  # Azure servers
+                referenced_anchor = referenced_anchor.split("/")[-1]
 
                 # There could be a many-to-one relationship with reverse pointers,
                 # so store them in a list

--- a/phdi/fhir/tabulation/tables.py
+++ b/phdi/fhir/tabulation/tables.py
@@ -379,7 +379,8 @@ def _build_reference_dicts(data: List[dict], directions_by_table: dict) -> dict:
                 referenced_anchor = _extract_value_with_resource_path(
                     resource, ref_path
                 )
-                referenced_anchor = referenced_anchor.split("/")[-1]
+                referenced_anchor = referenced_anchor.split("/")[-1]  # HAPI servers
+                referenced_anchor = referenced_anchor.split(":")[-1]  # Azure servers
 
                 # There could be a many-to-one relationship with reverse pointers,
                 # so store them in a list


### PR DESCRIPTION
This PR fixes two issues we found while testing the tabulation endpoint:

1. The `search_url` was never passed the `next` url and thus was not updating. Now it is!
2. Azure servers (when unable to use the FHIR Patient id like `Patient/XXXX`), assign a uuid like xxx:xxx:xxxx. To get the correct `referenced_anchor` in this case, we must split on `:` instead of `/`. In the future, we may wish to do a more comprehensive check for server type but since the `referenced_anchor` formats do not overlap, it is safe to do two splits.