### PR TITLE
Add schema name to validation

### DIFF
--- a/containers/tabulation/tests/test_tabulation.py
+++ b/containers/tabulation/tests/test_tabulation.py
@@ -163,7 +163,7 @@ def test_tabulate_endpoint_invalid_cred_manager(patched_tabulate):
 def test_tabulate_endpoint_missing_schema_name(patched_tabulate):
     invalid_tabulate_request = copy.deepcopy(valid_tabulate_request)
     invalid_tabulate_request.pop("schema_name")
-    invalid_tabulate_request["schema"].pop("schema_name")
+    del invalid_tabulate_request["schema"]["metadata"]["schema_name"]
     actual_response = client.post("/tabulate", json=invalid_tabulate_request)
     assert actual_response.status_code == 400
     assert (

--- a/containers/tabulation/tests/test_tabulation.py
+++ b/containers/tabulation/tests/test_tabulation.py
@@ -163,6 +163,7 @@ def test_tabulate_endpoint_invalid_cred_manager(patched_tabulate):
 def test_tabulate_endpoint_missing_schema_name(patched_tabulate):
     invalid_tabulate_request = copy.deepcopy(valid_tabulate_request)
     invalid_tabulate_request.pop("schema_name")
+    invalid_tabulate_request["schema"].pop("schema_name")
     actual_response = client.post("/tabulate", json=invalid_tabulate_request)
     assert actual_response.status_code == 400
     assert (

--- a/phdi/tabulation/validation_schema.json
+++ b/phdi/tabulation/validation_schema.json
@@ -2,7 +2,15 @@
     "type": "object",
     "properties": {
         "metadata": {
-            "type": "object"
+            "type": "object",
+            "properties": {
+                "schema_name": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "schema_name"
+            ]
         },
         "tables": {
             "$ref": "#/$defs/tables"
@@ -73,12 +81,12 @@
                     ]
                 },
                 "data_type": {
-                  "type": "string",
-                  "enum": [
-                    "string",
-                    "number",
-                    "boolean"
-                  ]
+                    "type": "string",
+                    "enum": [
+                        "string",
+                        "number",
+                        "boolean"
+                    ]
                 }
             },
             "patternProperties": {

--- a/tests/assets/tabulation_schema.yaml
+++ b/tests/assets/tabulation_schema.yaml
@@ -1,5 +1,6 @@
 metadata:
   results_per_page: 1000
+  schema_name: "validation_schema"
 tables:
   Patients:
     resource_type: Patient

--- a/tests/assets/valid_schema.json
+++ b/tests/assets/valid_schema.json
@@ -1,6 +1,7 @@
 {
     "metadata": {
-        "results_per_page": 1000
+        "results_per_page": 1000,
+        "schema_name": "valid_schema"
     },
     "tables": {
         "table 1A": {
@@ -41,9 +42,9 @@
                     "selection_criteria": "first"
                 },
                 "Building Number": {
-                  "fhir_path": "Patient.address.buidingNumber",
-                  "selection_criteria": "first",
-                  "data_type": "number"
+                    "fhir_path": "Patient.address.buidingNumber",
+                    "selection_criteria": "first",
+                    "data_type": "number"
                 }
             }
         },

--- a/tests/assets/valid_schema.yaml
+++ b/tests/assets/valid_schema.yaml
@@ -1,5 +1,6 @@
 metadata:
   results_per_page: 1000
+  schema_name: "valid_schema"
 tables:
   table 1A:
     resource_type: Patient

--- a/tests/tabulation/test_tables.py
+++ b/tests/tabulation/test_tables.py
@@ -262,6 +262,13 @@ def test_validate_schema():
         validate_schema(schema=invalid_data_type_declaraction)
     assert "'foo' is not one of ['string', 'number', 'boolean']" in str(e.value)
 
+    # Missing schema_name
+    missing_schema = copy.deepcopy(valid_schema)
+    del missing_schema["metadata"]["schema_name"]
+    with pytest.raises(jsonschema.exceptions.ValidationError) as e:
+        validate_schema(schema=missing_schema)
+    assert "'schema_name' is a required property" in str(e.value)
+
 
 def test_convert_list_to_string():
     array_source = [

--- a/tutorials/tabulation-tutorial.md
+++ b/tutorials/tabulation-tutorial.md
@@ -12,6 +12,7 @@ Data schemas are designed around the FHIR data format, and the first step to ext
 metadata:
   # Parameters that specify metadata applying to all tables in the schema
   results_per_page: 1000
+  schema_name: "Schema Name" # Required
 tables:
   Patient Information:  # All tables must have a name
     # Properties specific to this table
@@ -59,7 +60,7 @@ tables:
         reference_location: "forward:Observation:derivedFrom"
 ```
 
-**Metadata**: A schema file begins by specifying any metadata that relates to all tables in the schema (since a schema can specify more than one table). The most relevant parameter of this group is `results_per_page`, which specifies how many results the FHIR server should return at a time when using an incremental, paginated search approach (so as to not make memory costs prohibitively high). If this parameter is omitted, the default value of 1000 is used when paginating results.
+**Metadata**: A schema file begins by specifying any metadata that relates to all tables in the schema (since a schema can specify more than one table). The most relevant parameters of this group are `schema_name` and `results_per_page`. `schema_name` is a required parameter and specific to the schema not table(s) within a schema. `results_per_page` specifies how many results the FHIR server should return at a time when using an incremental, paginated search approach (so as to not make memory costs prohibitively high). If this parameter is omitted, the default value of 1000 is used when paginating results.
 
 **Tables**: The next section in the schema file is the `Tables` field, which specifies how many tables the schema holds as well as the properties of those tables. A single schema file can hold as many tables as a user desires, but importantly, even if a schema defines only a single table, the `Tables` field must still exist (it will just have one member element).
 


### PR DESCRIPTION
This PR adds `schema_name` as a required field for schema metadata, tests the requirement, and updates the documentation to reflect the addition of `schema_name`. The need for `schema_name` comes from testing the tabulation endpoint in which having a `schema_name` included in the schema made for easier implementation.