### PR TITLE
Add README file to alerts container image

### DIFF
--- a/containers/phdi-alerts/Dockerfile
+++ b/containers/phdi-alerts/Dockerfile
@@ -6,6 +6,7 @@ COPY ./requirements.txt /code/requirements.txt
 RUN pip install -r requirements.txt
 
 COPY ./main.py /code/main.py
+COPY ./README.md /code/README.md
 
 EXPOSE 8080
 CMD uvicorn main:api --host 0.0.0.0 --port 8080


### PR DESCRIPTION
FastAPI is failing to start because I forgot to add the README file to the container!