### PR TITLE
Install gcc in Docker images for Fuzzy

### DIFF
--- a/containers/ingestion/Dockerfile
+++ b/containers/ingestion/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
 COPY ./requirements.txt /code/requirements.txt
 RUN pip install -r requirements.txt
 
-RUN apt-get remove -y git gcc && \
+RUN apt-get remove -y git && \
     apt-get autoremove -y
 
 COPY ./app /code/app

--- a/containers/ingestion/Dockerfile
+++ b/containers/ingestion/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /code
 
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y git gcc
+    apt-get install -y git
 
 COPY ./requirements.txt /code/requirements.txt
 RUN pip install -r requirements.txt

--- a/containers/ingestion/Dockerfile
+++ b/containers/ingestion/Dockerfile
@@ -4,10 +4,13 @@ WORKDIR /code
 
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y git
+    apt-get install -y git gcc
 
 COPY ./requirements.txt /code/requirements.txt
 RUN pip install -r requirements.txt
+
+RUN apt-get remove -y git gcc && \
+    apt-get autoremove -y
 
 COPY ./app /code/app
 

--- a/containers/tabulation/Dockerfile
+++ b/containers/tabulation/Dockerfile
@@ -4,10 +4,15 @@ WORKDIR /code
 
 # Install git.
 # TODO: remove this step when a PyPi release of PHDI is available that includes Tabulation.
-RUN apt-get -y update && apt-get -y install git
+RUN apt-get -y update && \
+    apt-get upgrade -y && \
+    apt-get -y install git gcc
 
 COPY ./requirements.txt /code/requirements.txt
 RUN pip install -r requirements.txt
+
+RUN apt-get -y remove git gcc && \
+    apt-get -y autoremove
 
 COPY ./app /code/app
 COPY ./description.md /code/description.md


### PR DESCRIPTION
This will allow the `tabulation` and `ingestion` images to build properly. We can remove the installation of gcc if we find an alternative to the `Fuzzzy` package at a later date.