### PR TITLE
Implement blocking function for data from DB

### DIFF
--- a/phdi/linkage/__init__.py
+++ b/phdi/linkage/__init__.py
@@ -5,6 +5,8 @@ from phdi.linkage.link import (
     feature_match_exact,
     feature_match_fuzzy_string,
     eval_perfect_match,
+    block,
+    _generate_block_query,
 )
 
 __all__ = [
@@ -14,4 +16,6 @@ __all__ = [
     "feature_match_exact",
     "feature_match_fuzzy_string",
     "eval_perfect_match",
+    "block",
+    "_generate_block_query",
 ]

--- a/phdi/linkage/link.py
+++ b/phdi/linkage/link.py
@@ -272,7 +272,7 @@ def block(db_name: str, table_name: str, block_data: Dict) -> List[list]:
     """
     conn = sqlite3.connect(db_name)
     cursor = conn.cursor()
-    conn.row_factory = lambda cursor, row: [i for i in row]
+    cursor.row_factory = lambda c, row: [i for i in row]
 
     query = _generate_block_query(table_name, block_data)  # Generate SQL query
     cursor.execute(query)  # Execute query

--- a/phdi/linkage/link.py
+++ b/phdi/linkage/link.py
@@ -266,9 +266,8 @@ def block(db_name: str, table_name: str, block_data: Dict) -> List[list]:
     :param table_name: Table name.
     :param block_data: Dictionary containing key value pairs for the column name you for
       blocking and the data for the incoming record, e.g., ["ZIP"]: "90210".
-    :return: A list of records to that are within in the block, e.g., records that all
+    :return: A list of records that are within in the block, e.g., records that all
       have 90210 as their ZIP.
-
 
     """
     conn = sqlite3.connect(db_name)
@@ -297,7 +296,10 @@ def _generate_block_query(table_name: str, block_data: Dict) -> str:
     """
     query_stub = f"SELECT * FROM {table_name} WHERE "
     block_query = " AND ".join(
-        [key + f" = '{str(value)}'" for key, value in block_data.items()]
+        [
+            key + f" = '{value}'" if type(value) == str else (key + f" = {value}")
+            for key, value in block_data.items()
+        ]
     )
     query = query_stub + block_query
     return query

--- a/phdi/linkage/link.py
+++ b/phdi/linkage/link.py
@@ -2,6 +2,7 @@ import hashlib
 import pandas as pd
 from phdi.harmonization.utils import compare_strings
 from typing import List, Callable, Dict
+import sqlite3
 
 
 def generate_hash_str(linking_identifier: str, salt_str: str) -> str:
@@ -25,7 +26,7 @@ def match_within_block(
     block: List[List],
     feature_funcs: dict[int, Callable],
     match_eval: Callable,
-    **kwargs
+    **kwargs,
 ) -> List[tuple]:
     """
     Performs matching on all candidate pairs of records within a given block
@@ -84,7 +85,7 @@ def _match_within_block_cluster_ratio(
     cluster_ratio: float,
     feature_funcs: dict[int, Callable],
     match_eval: Callable,
-    **kwargs
+    **kwargs,
 ) -> List[set]:
     """
     A matching function for statistically testing the impact of membership
@@ -141,7 +142,7 @@ def _eval_record_in_cluster(
     cluster_ratio: float,
     feature_funcs: dict[int, Callable],
     match_eval: Callable,
-    **kwargs
+    **kwargs,
 ):
     """
     A helper function used to evaluate whether a given incoming record
@@ -239,7 +240,7 @@ def block_parquet_data(path: str, blocks: List) -> Dict:
     distinct list of lists containing the data for a given block.
 
     :param path: Path to parquet file containing data that needs to be linked.
-    :param blocks: List of columns to be used in blocks.
+    :param blocks: List of columns to be used in blocking.
     :return: A dictionary of with the keys as the blocks and the values as the data
     within each block, stored as a list of lists.
     """
@@ -252,3 +253,51 @@ def block_parquet_data(path: str, blocks: List) -> Dict:
         blocked_data[block] = df.values.tolist()
 
     return blocked_data
+
+
+def block(db_name: str, table_name: str, block_data: Dict) -> List[list]:
+    """
+    Returns a list of lists containing records from the database that match on the
+    incoming record's block values. If blocking on 'ZIP' and the incoming record's zip
+    code is '90210', the resulting block of data would contain records that all have the
+    same zip code of 90210.
+
+    :param db_name: Database name.
+    :param table_name: Table name.
+    :param block_data: Dictionary containing key value pairs for the column name you for
+      blocking and the data for the incoming record, e.g., ["ZIP"]: "90210".
+    :return: A list of records to that are within in the block, e.g., records that all
+      have 90210 as their ZIP.
+
+
+    """
+    conn = sqlite3.connect(db_name)
+    cursor = conn.cursor()
+    conn.row_factory = lambda cursor, row: [i for i in row]
+
+    query = _generate_block_query(table_name, block_data)  # Generate SQL query
+    cursor.execute(query)  # Execute query
+    block = cursor.fetchall()  # Fetch data from query
+    conn.commit()
+    conn.close()
+
+    return block
+
+
+def _generate_block_query(table_name: str, block_data: Dict) -> str:
+    """
+    Generates a query for selecting block of data from `table_name` per the block_data
+    parameters.
+
+    :param table_name: Table name.
+    :param block_data: Dictionary containing key value pairs for the column name you for
+      blocking and the data for the incoming record, e.g., ["ZIP"]: "90210".
+    :return: Query to select block of data base on `block_data` parameters.
+
+    """
+    query_stub = f"SELECT * FROM {table_name} WHERE "
+    block_query = " AND ".join(
+        [key + f" = '{str(value)}'" for key, value in block_data.items()]
+    )
+    query = query_stub + block_query
+    return query

--- a/tests/linkage/test_linkage.py
+++ b/tests/linkage/test_linkage.py
@@ -1,5 +1,6 @@
 import os
 import pandas as pd
+import random
 from phdi.linkage import (
     generate_hash_str,
     block_parquet_data,
@@ -11,6 +12,7 @@ from phdi.linkage import (
     _generate_block_query,
 )
 from phdi.linkage.link import _match_within_block_cluster_ratio
+import pathlib
 
 
 def test_generate_hash():
@@ -204,3 +206,29 @@ def test_generate_block_query():
         type(list(block_data.values())[0]) != str
         and "'" not in correct_query.split("= ")[1]
     )  # Non-string types should not be enclosed in quotes
+
+
+def test_blocking_data():
+    db_name = (
+        pathlib.Path(__file__).parent.parent.parent
+        / "examples"
+        / "MPI-sample-data"
+        / "synthetic_patient_mpi_db"
+    )
+
+    table_name = "synthetic_patient_mpi"
+    block_data = {"ZIP": 90265, "City": "Malibu"}
+
+    blocked_data = block(db_name, table_name, block_data)
+
+    # Assert data is returned
+    assert len(blocked_data) > 0
+    # Assert returned data is in the correct format
+    assert type(blocked_data[0]) == list
+    # Assert returned data match the block_data parameters
+    assert (
+        blocked_data[random.randint(0, len(blocked_data) - 1)][10] == block_data["City"]
+    )
+    assert (
+        blocked_data[random.randint(0, len(blocked_data) - 1)][-5] == block_data["ZIP"]
+    )

--- a/tests/linkage/test_linkage.py
+++ b/tests/linkage/test_linkage.py
@@ -7,6 +7,8 @@ from phdi.linkage import (
     feature_match_fuzzy_string,
     eval_perfect_match,
     match_within_block,
+    block,
+    _generate_block_query,
 )
 from phdi.linkage.link import _match_within_block_cluster_ratio
 
@@ -177,3 +179,8 @@ def test_block_parquet_data():
     # Clean up
     if os.path.isfile("./test.parquet"):  # pragma: no cover
         os.remove("./test.parquet")
+
+
+def test_generate_block_query():
+    tablename = "test_table"
+    block_data = {"ZIP": 90210, "City": "Los Angeles"}

--- a/tests/linkage/test_linkage.py
+++ b/tests/linkage/test_linkage.py
@@ -182,5 +182,25 @@ def test_block_parquet_data():
 
 
 def test_generate_block_query():
-    tablename = "test_table"
+    table_name = "test_table"
     block_data = {"ZIP": 90210, "City": "Los Angeles"}
+    correct_query = (
+        f"SELECT * FROM {table_name} WHERE "
+        + f"{list(block_data.keys())[0]} = {list(block_data.values())[0]} "
+        + f"AND {list(block_data.keys())[1]} = '{list(block_data.values())[1]}'"
+    )
+
+    query = _generate_block_query(table_name, block_data)
+
+    assert query == correct_query
+
+    # Tests for appropriate data type handling in query generation
+    assert (
+        type(list(block_data.values())[1]) == str
+        and "'" in correct_query.split("= ")[-1]
+    )  # String types should be enclosed in quotes
+
+    assert (
+        type(list(block_data.values())[0]) != str
+        and "'" not in correct_query.split("= ")[1]
+    )  # Non-string types should not be enclosed in quotes


### PR DESCRIPTION
This PR returns a single block of data (list of lists) for a given input. This function operates very similarly to the `block_parquet_data` function with the exception that the new function accepts a dictionary containing information from an incoming record (in theory) for the block of data that we need to retrieve for that record. In `block_parquet_data` the input required a list of columns to block on, e.g., ZIP, and returned _all_ blocks for every ZIP. The new function, `block` assumes you only want to return one block for a particular incoming record. 

As an example, if a new record comes in where ZIP is 90210, the `block` function returns only the records where ZIP is also 90210. I did this in preparation for streaming and thinking that holding all blocks in memory would be potentially risky but if we go with batching, I would be happy to re-arrange such that the function returns all blocks applicable to the incoming batch of records rather than a single record. Let me know what you think!