### PR TITLE
Integrate Double Metaphone into Name Standardization

### DIFF
--- a/phdi/fhir/harmonization/standardization.py
+++ b/phdi/fhir/harmonization/standardization.py
@@ -126,6 +126,8 @@ def standardize_names(
         resource = _standardize_names_in_resource(
             resource, trim, case, remove_numbers, overwrite
         )
+        # Add double metaphone data to patient name after standardizing it
+        double_metaphone_patient(patient=resource, dmeta=None, overwrite=overwrite)
 
     if "entry" not in data:
         return bundle.get("entry", [{}])[0].get("resource", {})

--- a/phdi/fhir/harmonization/standardization.py
+++ b/phdi/fhir/harmonization/standardization.py
@@ -101,6 +101,8 @@ def standardize_names(
     Standardizes all names contained in a given FHIR bundle or a FHIR resource. The
     default standardization behavior is our defined non-numeric, space-trimming, full
     capitalization standardization, but other modes may be specified.
+    Names are also assigned a double metaphone encoding after standardization is
+    complete.
 
     :param data: A FHIR-formatted JSON dict.
     :param trim: Whether leading/trailing whitespace should be removed. Default: `True`
@@ -126,11 +128,14 @@ def standardize_names(
         resource = _standardize_names_in_resource(
             resource, trim, case, remove_numbers, overwrite
         )
-        # Add double metaphone data to patient name after standardizing it
-        double_metaphone_patient(patient=resource, dmeta=None, overwrite=overwrite)
 
     if "entry" not in data:
         return bundle.get("entry", [{}])[0].get("resource", {})
+
+    # Add double metaphone data to bundle after the names have been
+    # standardized
+    double_metaphone_bundle(bundle=bundle, overwrite=overwrite)
+
     return bundle
 
 

--- a/tests/fhir/harmonization/test_fhir_harmonization.py
+++ b/tests/fhir/harmonization/test_fhir_harmonization.py
@@ -143,20 +143,47 @@ def test_standardize_names():
             / "patient_bundle.json"
         )
     )
+    raw_bundle2 = json.load(
+        open(
+            pathlib.Path(__file__).parent.parent.parent
+            / "assets"
+            / "patient_bundle.json"
+        )
+    )
 
     # Case where we pass in a whole FHIR bundle
     standardized_bundle = copy.deepcopy(raw_bundle)
     patient = standardized_bundle["entry"][1]["resource"]
     patient["name"][0]["family"] = "DOE"
     patient["name"][0]["given"] = ["JOHN", "DANGER"]
-    assert standardize_names(raw_bundle) == standardized_bundle
+    patient["name"][0]["extension"] = [
+        {
+            "url": "https://xlinux.nist.gov/dads/HTML/doubleMetaphone.html",
+            "extension": [
+                {"url": "familyName", "valueString": ["T", ""]},
+                {"url": "givenName", "valueString": [["JN", "AN"], ["TNJR", "TNKR"]]},
+            ],
+        }
+    ]
+    result = standardize_names(raw_bundle)
+    assert result == standardized_bundle
 
     # Case when we don't want to overwrite the data for a bundle
-    standardized_bundle = copy.deepcopy(raw_bundle)
+    standardized_bundle = copy.deepcopy(raw_bundle2)
     patient = standardized_bundle["entry"][1]["resource"]
     patient["name"][0]["family"] = "DOE"
     patient["name"][0]["given"] = ["JOHN", "DANGER"]
-    assert standardize_names(raw_bundle, overwrite=True) == standardized_bundle
+    patient["name"][0]["extension"] = [
+        {
+            "url": "https://xlinux.nist.gov/dads/HTML/doubleMetaphone.html",
+            "extension": [
+                {"url": "familyName", "valueString": ["T", ""]},
+                {"url": "givenName", "valueString": [["JN", "AN"], ["TNJR", "TNKR"]]},
+            ],
+        }
+    ]
+    result = standardize_names(raw_bundle2, overwrite=True)
+    assert result == standardized_bundle
 
     # Case where we provide only a single resource
     patient_resource = raw_bundle["entry"][1]["resource"]


### PR DESCRIPTION
This PR essentially adds Double Metaphone encoding into the Name Standardization SDK Building block, by default, but provides the ability to opt out of performing the DM for patient names.  This will ensure that after the name standardization is complete the DM will then be added to the patient.name resource.element as an extension to ensure this data is stored with the patient name in the persistence layer.  This makes sure our record linkage process can utilize the DM data.