### PR TITLE
Add workflow to run tests then tag a new release if tests are green

### DIFF
--- a/.github/workflows/tagRelease.yaml
+++ b/.github/workflows/tagRelease.yaml
@@ -1,0 +1,30 @@
+name: Test and Tag Release
+on:
+  workflow_dispatch:
+    inputs:
+      custom_tag:
+        description: "Enter version number for release tag below. Don't forget the v! Example: v2.23.9"
+        type: string
+        required: true
+  push:
+    branches: gordon/automated-release-workflow
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yaml
+
+  create-tagged-release:
+    needs: test
+    permissions:
+      contents: write
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+
+      - name: Update version and push tag
+        uses: anothrNick/github-tag-action@1.55.0 # Don't use @master unless you're happy to test the latest version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CUSTOM_TAG: ${{ github.event.inputs.custom_tag }}

--- a/.github/workflows/tagRelease.yaml
+++ b/.github/workflows/tagRelease.yaml
@@ -6,8 +6,6 @@ on:
         description: "Enter version number for release tag below. Don't forget the v! Example: v2.23.9"
         type: string
         required: true
-  push:
-    branches: gordon/automated-release-workflow
 
 jobs:
   test:


### PR DESCRIPTION
Does what it says on the tin!

This is a workflow triggered manually from the actions tab on github. A user must input a custom string version number for it to run.

Part 1 of the full auto release process.