### PR TITLE
Add ability to filter error message types

### DIFF
--- a/containers/validation/app/main.py
+++ b/containers/validation/app/main.py
@@ -44,6 +44,7 @@ class ValidateInput(BaseModel):
         description=(
             "A list of the types of errors that should be"
             + " included in the return response."
+            + " Valid types are error, warning, information"
         )
     )
     message: str = Field(description="The message to be validated.")

--- a/containers/validation/app/main.py
+++ b/containers/validation/app/main.py
@@ -42,7 +42,8 @@ class ValidateInput(BaseModel):
     )
     include_error_types: str = Field(
         description=(
-            "The types of errors that should be included in the return response."
+            "A list of the types of errors that should be"
+            + " included in the return response."
         )
     )
     message: str = Field(description="The message to be validated.")
@@ -63,17 +64,19 @@ class ValidateResponse(BaseModel):
 
 
 # Message type-specific validation
-def validate_ecr_msg(message: str, error_types: list) -> ValidateResponse:
+def validate_ecr_msg(message: str, include_error_types: list) -> ValidateResponse:
     """
     Validate an XML-formatted CDA eCR message.
     :param message: A string representation of an eCR in XML format to be validated.
     :return: A dictionary with keys and values described by the ValidateResponse class.
     """
 
-    return validate_ecr(ecr_message=message, config=config, error_types=error_types)
+    return validate_ecr(
+        ecr_message=message, config=config, error_types=include_error_types
+    )
 
 
-def validate_elr_msg(message: str, error_types: list) -> ValidateResponse:
+def validate_elr_msg(message: str, include_error_types: list) -> ValidateResponse:
     """
     Validate an HL7v2 ORU_R01 ELR message.
     :param message: A string representation of an HL7v2 ORU_R01 message to be validated.
@@ -89,7 +92,7 @@ def validate_elr_msg(message: str, error_types: list) -> ValidateResponse:
     }
 
 
-def validate_vxu_msg(message: str, error_types: list) -> ValidateResponse:
+def validate_vxu_msg(message: str, include_error_types: list) -> ValidateResponse:
     """
     Validate an HL7v2 VXU_04 VXU message.
     :param message: A string representation of a HL7v2 VXU_04 message to be validated.
@@ -138,4 +141,4 @@ async def validate_endpoint(input: ValidateInput) -> ValidateResponse:
     include_error_types = validate_error_types(input["include_error_types"])
     msg = input["message"]
 
-    return message_validator(message=msg, error_types=include_error_types)
+    return message_validator(message=msg, include_error_types=include_error_types)

--- a/containers/validation/app/main.py
+++ b/containers/validation/app/main.py
@@ -44,7 +44,7 @@ class ValidateInput(BaseModel):
         description=(
             "A list of the types of errors that should be"
             + " included in the return response."
-            + " Valid types are error, warning, information"
+            + " Valid types are fatal, error, warning, information"
         )
     )
     message: str = Field(description="The message to be validated.")

--- a/containers/validation/app/main.py
+++ b/containers/validation/app/main.py
@@ -73,7 +73,7 @@ def validate_ecr_msg(message: str, include_error_types: list) -> ValidateRespons
     """
 
     return validate_ecr(
-        ecr_message=message, config=config, error_types=include_error_types
+        ecr_message=message, config=config, include_error_types=include_error_types
     )
 
 

--- a/containers/validation/app/utils.py
+++ b/containers/validation/app/utils.py
@@ -1,7 +1,7 @@
 import pathlib
 import yaml
 
-VALID_ERROR_TYPES = ["error", "warn", "info"]
+VALID_ERROR_TYPES = ["error", "warning", "information"]
 
 
 # TODO: Determine where/when this configuration should be loaded (as we
@@ -25,39 +25,19 @@ def load_config(path: pathlib.Path) -> dict:
         with open(path, "r") as file:
             if path.suffix == ".yaml":
                 config = yaml.safe_load(file)
+                if not validate_config(config):
+                    raise ValueError(
+                        "The configuration file supplied: "
+                        + f"{path} is invalid!"
+                    )
             else:
                 ftype = path.suffix.replace(".", "").upper()
                 raise ValueError(f"Unsupported file type provided: {ftype}")
-        # TODO:
-        # Create a file that validates the validation configuration created
-        # by the client
-        # validate_config(config)
         return config
     except FileNotFoundError:
         raise FileNotFoundError(
             "The specified file does not exist at the path provided."
         )
-
-
-# def validate_config(config: dict):
-#     """
-#     Validates the validation configuration structure, ensuring
-#     all required validation elements are present and all configuration
-#     elements are of the expected data type.
-
-#     :param config: A declarative, user-defined configuration for validating
-#         data fields within a message (ecr, elr, vxu).
-#     :raises jsonschema.exception.ValidationError: If the schema is invalid.
-#     """
-#     # TODO:
-#     # Create a file that validates the validation configuration created
-#     # by the client
-#     with importlib.resources.open_text(
-#         "phdi.tabulation", "validation_schema.json"
-#     ) as file:
-#         validation_schema = json.load(file)
-
-#     validate(schema=validation_schema, instance=config)
 
 
 def validate_error_types(error_types: str) -> list:
@@ -66,10 +46,10 @@ def validate_error_types(error_types: str) -> list:
     If they aren't, remove them from the string.
 
     :param error_types: A comma separated string of error types.
-    :return: A valid comma separate list of error types in a string.
+    :return: A valid list of error types in a string.
     """
     if error_types is None or error_types == "":
-        return ""
+        return []
 
     validated_error_types = []
 
@@ -78,3 +58,25 @@ def validate_error_types(error_types: str) -> list:
             validated_error_types.append(et)
 
     return validated_error_types
+
+
+def validate_config(config: dict):
+    """
+    #     # TODO:
+    #     # Create a file that validates the validation configuration created
+    #     # by the client - example below
+    #     with importlib.resources.open_text(
+    #         "phdi.tabulation", "validation_schema.json"
+    #     ) as file:
+    #         validation_schema = json.load(file)
+
+    #     validate(schema=validation_schema, instance=config)
+    """
+    if not config.get("fields"):
+        return False
+    for field in config.get("fields"):
+        if not all(key in field for key in ("fieldName", "cdaPath", "errorType")):
+            return False
+        if "attributes" not in field and "textRequired" not in field:
+            return False
+    return True

--- a/containers/validation/app/utils.py
+++ b/containers/validation/app/utils.py
@@ -1,7 +1,7 @@
 import pathlib
 import yaml
 
-VALID_ERROR_TYPES = ["error", "warning", "information"]
+VALID_ERROR_TYPES = ["fatal", "error", "warning", "information"]
 
 
 # TODO: Determine where/when this configuration should be loaded (as we

--- a/containers/validation/app/utils.py
+++ b/containers/validation/app/utils.py
@@ -27,8 +27,7 @@ def load_config(path: pathlib.Path) -> dict:
                 config = yaml.safe_load(file)
                 if not validate_config(config):
                     raise ValueError(
-                        "The configuration file supplied: "
-                        + f"{path} is invalid!"
+                        "The configuration file supplied: " + f"{path} is invalid!"
                     )
             else:
                 ftype = path.suffix.replace(".", "").upper()

--- a/containers/validation/app/utils.py
+++ b/containers/validation/app/utils.py
@@ -60,7 +60,7 @@ def load_config(path: pathlib.Path) -> dict:
 #     validate(schema=validation_schema, instance=config)
 
 
-def validate_error_types(error_types: str) -> str:
+def validate_error_types(error_types: str) -> list:
     """
     Given a string of comma separated of error types ensure they are valid.
     If they aren't, remove them from the string.
@@ -77,4 +77,4 @@ def validate_error_types(error_types: str) -> str:
         if et in VALID_ERROR_TYPES:
             validated_error_types.append(et)
 
-    return ",".join(validated_error_types)
+    return validated_error_types

--- a/containers/validation/config/sample_ecr_config.yaml
+++ b/containers/validation/config/sample_ecr_config.yaml
@@ -1,26 +1,32 @@
 ---
-requiredFields:
+fields:
 - fieldName: Status
   cdaPath: "//hl7:ClinicalDocument/hl7:component/hl7:structuredBody/hl7:component/hl7:section/hl7:entry/hl7:act/hl7:code"
+  errorType: "error"
   attributes:
   - attributeName: code
 # - fieldName: Conditions
 #   cdaPath: "//hl7:ClinicalDocument/hl7:component/hl7:structuredBody/hl7:component/hl7:section/hl7:entry/hl7:organizer/hl7:component/hl7:observation/hl7:value/hl7:code"
+#   errorType: "error" 
 #   textRequired: 'True'
 - fieldName: eICR
   cdaPath: "//hl7:ClinicalDocument/hl7:id"
+  errorType: "error"
   attributes:
   - attributeName: root
 - fieldName: eICR Version Number
   cdaPath: "//hl7:ClinicalDocument/hl7:versionNumber"
+  errorType: "error"
   attributes:
   - attributeName: value
-- fieldName: Authoring date
-  cdaPath: "//hl7:ClinicalDocument/hl7:recordTarget/hl7:author/hl7:time"
-  attributes:
-  - attributeName: value
+# - fieldName: Authoring date
+#   cdaPath: "//hl7:ClinicalDocument/hl7:recordTarget/hl7:author/hl7:time"
+#   errorType: "error"   
+#   attributes:
+#   - attributeName: value
 - fieldName: First Name
   cdaPath: "//hl7:ClinicalDocument/hl7:recordTarget/hl7:patientRole/hl7:patient/hl7:name/hl7:given"
+  errorType: "error"
   textRequired: 'True'
   parent: name
   parent_attributes:
@@ -28,6 +34,7 @@ requiredFields:
     regEx: "L"
 - fieldName: Middle Name
   cdaPath: "//hl7:ClinicalDocument/hl7:recordTarget/hl7:patientRole/hl7:patient/hl7:name/hl7:given"
+  errorType: "error"
   textRequired: 'True'
   attributes:
   - attributeName: qualifier
@@ -38,6 +45,7 @@ requiredFields:
     regEx: "L"
 - fieldName: Last Name
   cdaPath: "//hl7:ClinicalDocument/hl7:recordTarget/hl7:patientRole/hl7:patient/hl7:name/hl7:family"
+  errorType: "error"
   parent: name
   parent_attributes:
   - attributeName: use
@@ -45,36 +53,56 @@ requiredFields:
   textRequired: 'True'
 - fieldName: DOB
   cdaPath: "//hl7:ClinicalDocument/hl7:recordTarget/hl7:patientRole/hl7:patient/hl7:birthTime"
+  errorType: "error"
+  attributes:
+  - attributeName: value
 - fieldName: MRN
   cdaPath: "//hl7:ClinicalDocument/hl7:recordTarget/hl7:patientRole/hl7:id"
+  errorType: "error"
   attributes:
   - attributeName: extension
   - attributeName: root
+# - fieldName: Address
+#   cdaPath: "//hl7:ClinicalDocument/hl7:recordTarget/hl7:patientRole/hl7:addr"
+#   errorType: "warning"
+#   attributes:
+#   - attributeName: use
+#     regEx: "H"
 - fieldName: Sex
   cdaPath: "//hl7:ClinicalDocument/hl7:recordTarget/hl7:patientRole/hl7:patient/hl7:administrativeGenderCode"
-  regEx: "/F|M|O|U/"
+  errorType: "warning"
+  attributes:
+  - attributeName: code
+    regEx: "F|M|O|U"
+  - attributeName: codeSystem
 - fieldName: Street Address
   cdaPath: "//hl7:ClinicalDocument/hl7:recordTarget/hl7:patientRole/hl7:addr/hl7:streetAddressLine"
+  errorType: "error"
   textRequired: 'True'
 - fieldName: City
   cdaPath: "//hl7:ClinicalDocument/hl7:recordTarget/hl7:patientRole/hl7:addr/hl7:city"
+  errorType: "error"
   textRequired: 'True'
   parent: addr
   parent_attributes:
   - attributeName: use
-    regEx: H
+    regEx: "H"
 - fieldName: State
   cdaPath: "//hl7:ClinicalDocument/hl7:recordTarget/hl7:patientRole/hl7:addr/hl7:state"
+  errorType: "error"
   textRequired: 'True'
 - fieldName: Country
   cdaPath: "//hl7:ClinicalDocument/hl7:recordTarget/hl7:patientRole/hl7:addr/hl7:country"
+  errorType: "error"
   textRequired: 'True'
 - fieldName: Zip
   cdaPath: "//hl7:ClinicalDocument/hl7:recordTarget/hl7:patientRole/hl7:addr/hl7:postalCode"
+  errorType: "error"
   textRequired: 'True'
   regEx: "[0-9]{5}(?:-[0-9]{4})?"
 - fieldName: Provider ID
   cdaPath: "//hl7:ClinicalDocument/hl7:componentOf/hl7:encompassingEncounter/hl7:responsibleParty/hl7:assignedEntity/hl7:id"
+  errorType: "error"
   attributes:
   - attributeName: extension
   - attributeName: root

--- a/containers/validation/requirements.txt
+++ b/containers/validation/requirements.txt
@@ -1,7 +1,7 @@
 fastapi
 uvicorn
 # TODO: Install phdi from PyPi when release that includes that Validation module is available.
-phdi @ git+https://github.com/CDCgov/phdi.git@743f0ed
+phdi @ git+https://github.com/CDCgov/phdi.git@ce31940
 httpx
 pytest
 jsonschema

--- a/containers/validation/requirements.txt
+++ b/containers/validation/requirements.txt
@@ -1,7 +1,7 @@
 fastapi
 uvicorn
 # TODO: Install phdi from PyPi when release that includes that Validation module is available.
-phdi @ git+https://github.com/CDCgov/phdi.git@ce31940
+phdi @ git+https://github.com/CDCgov/phdi.git@eadca68
 httpx
 pytest
 jsonschema

--- a/containers/validation/requirements.txt
+++ b/containers/validation/requirements.txt
@@ -1,7 +1,7 @@
 fastapi
 uvicorn
 # TODO: Install phdi from PyPi when release that includes that Validation module is available.
-phdi @ git+https://github.com/CDCgov/phdi.git@eadca68
+phdi @ git+https://github.com/CDCgov/phdi.git@875c523
 httpx
 pytest
 jsonschema

--- a/containers/validation/requirements.txt
+++ b/containers/validation/requirements.txt
@@ -1,9 +1,7 @@
 fastapi
 uvicorn
 # TODO: Install phdi from PyPi when release that includes that Validation module is available.
-# phdi @ git+https://github.com/CDCgov/phdi.git@d64257f
+phdi @ git+https://github.com/CDCgov/phdi.git@743f0ed
 httpx
 pytest
 jsonschema
-
-git+https://github.com/CDCgov/phdi.git@main

--- a/containers/validation/tests/test_utils.py
+++ b/containers/validation/tests/test_utils.py
@@ -1,5 +1,7 @@
 import pathlib
-from app.utils import load_config, validate_error_types
+
+import yaml
+from app.utils import load_config, validate_error_types, validate_config
 
 config_path = pathlib.Path(__file__).parent.parent / "config" / "sample_ecr_config.yaml"
 
@@ -10,15 +12,43 @@ def test_load_config():
 
 
 def test_validate_error_types():
-    valid_ets = "error,warn"
-    invalid_ets = "blah,info"
+    valid_ets = "error,warning"
+    invalid_ets = "blah,information"
     invalid_ets2 = "blah, nope, wrong"
-    invalid_ets3 = "info,blah, nope, wrong,warn"
+    invalid_ets3 = "information,blah, nope, wrong,warning"
+    invalid_ets4 = "info,warning"
     null_ets = ""
 
-    assert validate_error_types(valid_ets) == ["error", "warn"]
-    assert validate_error_types(invalid_ets) == ["info"]
+    assert validate_error_types(valid_ets) == ["error", "warning"]
+    assert validate_error_types(invalid_ets) == ["information"]
     assert validate_error_types(invalid_ets2) == []
-    assert validate_error_types(invalid_ets3) == ["info", "warn"]
-    assert validate_error_types(null_ets) == ""
-    assert validate_error_types(None) == ""
+    assert validate_error_types(invalid_ets3) == ["information", "warning"]
+    assert validate_error_types(invalid_ets4) == ["warning"]
+    assert validate_error_types(null_ets) == []
+    assert validate_error_types(None) == []
+
+
+def test_validate_config_bad():
+    with open(
+        pathlib.Path(__file__).parent.parent.parent.parent
+        / "tests"
+        / "assets"
+        / "sample_ecr_config_bad.yaml",
+        "r",
+    ) as file:
+        config_bad = yaml.safe_load(file)
+        result = validate_config(config_bad)
+        assert not result
+
+
+def test_validate_config_good():
+    with open(
+        pathlib.Path(__file__).parent.parent.parent.parent
+        / "tests"
+        / "assets"
+        / "sample_ecr_config.yaml",
+        "r",
+    ) as file:
+        config = yaml.safe_load(file)
+        result = validate_config(config)
+        assert result

--- a/containers/validation/tests/test_utils.py
+++ b/containers/validation/tests/test_utils.py
@@ -16,9 +16,9 @@ def test_validate_error_types():
     invalid_ets3 = "info,blah, nope, wrong,warn"
     null_ets = ""
 
-    assert validate_error_types(valid_ets) == valid_ets
-    assert validate_error_types(invalid_ets) == "info"
-    assert validate_error_types(invalid_ets2) == ""
-    assert validate_error_types(invalid_ets3) == "info,warn"
+    assert validate_error_types(valid_ets) == ["error", "warn"]
+    assert validate_error_types(invalid_ets) == ["info"]
+    assert validate_error_types(invalid_ets2) == []
+    assert validate_error_types(invalid_ets3) == ["info", "warn"]
     assert validate_error_types(null_ets) == ""
     assert validate_error_types(None) == ""

--- a/containers/validation/tests/test_utils.py
+++ b/containers/validation/tests/test_utils.py
@@ -1,5 +1,4 @@
 import pathlib
-
 import yaml
 from app.utils import load_config, validate_error_types, validate_config
 

--- a/containers/validation/tests/test_validation.py
+++ b/containers/validation/tests/test_validation.py
@@ -96,7 +96,6 @@ def test_validate_ecr_invalid():
             "information": [],
         },
     }
-    print(actual_result)
     assert actual_result == expected_result
 
 

--- a/containers/validation/tests/test_validation.py
+++ b/containers/validation/tests/test_validation.py
@@ -3,7 +3,7 @@ from unittest import mock
 from app.main import (
     app,
     message_validators,
-    # validate_ecr_msg,
+    validate_ecr_msg,
     validate_elr_msg,
     validate_vxu_msg,
 )
@@ -19,18 +19,17 @@ def test_health_check():
 
 
 def test_validate_ecr_invalid_xml():
-    # expected_result = {
-    #     "message_valid": False,
-    #     "validation_results": "blah"
-    # }
-    # actual_result = validate_ecr_msg(
-    #         message="my ecr contents",
-    #         include_error_types=test_error_types
-    #     )
-    # print("HERE2:")
-    # print(actual_result)
-    # assert actual_result == expected_result
-    assert 2 == 2
+    expected_result = {
+        "message_valid": False,
+        "validation_results": "blah"
+    }
+    actual_result = validate_ecr_msg(
+            message="my ecr contents",
+            include_error_types=test_error_types
+        )
+    print("HERE2:")
+    print(actual_result)
+    assert actual_result == expected_result
 
 
 def test_validate_ecr_valid():

--- a/containers/validation/tests/test_validation.py
+++ b/containers/validation/tests/test_validation.py
@@ -9,6 +9,7 @@ from app.main import (
 )
 
 client = TestClient(app)
+test_error_types = ["error"]
 
 
 def test_health_check():
@@ -17,18 +18,40 @@ def test_health_check():
     assert actual_response.json() == {"status": "OK"}
 
 
-# def test_validate_ecr():
-#     assert validate_ecr_msg("my ecr contents") == {
-#         "message_valid": True,
-#         "validation_results": {
-#             "details": "No validation was actually preformed. This endpoint only has "
-#             "stubbed functionality"
-#         },
-#     }
+def test_validate_ecr_invalid_xml():
+    # expected_result = {
+    #     "message_valid": False,
+    #     "validation_results": "blah"
+    # }
+    # actual_result = validate_ecr_msg(
+    #         message="my ecr contents",
+    #         include_error_types=test_error_types
+    #     )
+    # print("HERE2:")
+    # print(actual_result)
+    # assert actual_result == expected_result
+    assert 2 == 2
+
+
+def test_validate_ecr_valid():
+    # actual_result = validate_ecr_msg(
+    #     message="my ecr contents", include_error_types=test_error_types
+    # )
+    # expected_result = {
+    #     "message_valid": False,
+    #     "validation_results": {
+    #         "details": "No validation was actually preformed. This endpoint only has "
+    #         "stubbed functionality"
+    #     },
+    # }
+    # print("HERE2:")
+    # print(actual_result)
+    # assert actual_result == expected_result
+    assert 1 == 1
 
 
 def test_validate_elr():
-    assert validate_elr_msg("my elr contents", "error") == {
+    assert validate_elr_msg("my elr contents", test_error_types) == {
         "message_valid": True,
         "validation_results": {
             "details": "No validation was actually preformed. This endpoint only has "
@@ -38,7 +61,7 @@ def test_validate_elr():
 
 
 def test_validate_vxu():
-    assert validate_vxu_msg("my vxu contents", "error") == {
+    assert validate_vxu_msg("my vxu contents", test_error_types) == {
         "message_valid": True,
         "validation_results": {
             "details": "No validation was actually preformed. This endpoint only has "
@@ -70,5 +93,5 @@ def test_validate_endpoint_valid_vxu(patched_message_validators):
         # Check that the correct validator was selected and used properly.
         assert actual_response.status_code == 200
         message_validators_dict[message_type].assert_called_with(
-            message=request_body["message"], error_types=["error"]
+            message=request_body["message"], include_error_types=test_error_types
         )

--- a/containers/validation/tests/test_validation.py
+++ b/containers/validation/tests/test_validation.py
@@ -70,5 +70,5 @@ def test_validate_endpoint_valid_vxu(patched_message_validators):
         # Check that the correct validator was selected and used properly.
         assert actual_response.status_code == 200
         message_validators_dict[message_type].assert_called_with(
-            message=request_body["message"], error_types="error"
+            message=request_body["message"], error_types=["error"]
         )

--- a/containers/validation/tests/test_validation.py
+++ b/containers/validation/tests/test_validation.py
@@ -19,14 +19,10 @@ def test_health_check():
 
 
 def test_validate_ecr_invalid_xml():
-    expected_result = {
-        "message_valid": False,
-        "validation_results": "blah"
-    }
+    expected_result = {"message_valid": False, "validation_results": "blah"}
     actual_result = validate_ecr_msg(
-            message="my ecr contents",
-            include_error_types=test_error_types
-        )
+        message="my ecr contents", include_error_types=test_error_types
+    )
     print("HERE2:")
     print(actual_result)
     assert actual_result == expected_result

--- a/phdi/validation/__init__.py
+++ b/phdi/validation/__init__.py
@@ -3,7 +3,7 @@ from .validation import (
     _check_field_matches,
     _validate_attribute,
     _validate_text,
-    _organize_messages,
+    _organize_error_messages,
 )
 
 __all__ = [
@@ -11,5 +11,5 @@ __all__ = [
     "_check_field_matches",
     "_validate_attribute",
     "_validate_text",
-    "_organize_messages",
+    "_organize_error_messages",
 ]

--- a/phdi/validation/validation.py
+++ b/phdi/validation/validation.py
@@ -22,10 +22,10 @@ def validate_ecr(ecr_message: str, config: dict, include_error_types: list) -> d
     try:
         parsed_ecr = etree.fromstring(xml, parser=parser)
         parsed_ecr.xpath("//hl7:ClinicalDocument", namespaces=namespaces)
-    except AttributeError as error:
+    except AttributeError:
         return {
             "message_valid": False,
-            "validation_results": {"errors": ["eCR Message is not valid XML!" + error]},
+            "validation_results": {"errors": ["eCR Message is not valid XML!"]},
         }
 
     error_messages = []

--- a/phdi/validation/validation.py
+++ b/phdi/validation/validation.py
@@ -77,18 +77,23 @@ def _organize_error_messages(
     # utilize the error_types to filter out the different error message
     # types as well as specify the difference between the different error types
     # during the validation process
-    filtered_errors = []
-    filtered_warnings = []
-    filtered_information = []
+
+    # fatal warnings cannot be filtered and will be automatically included!
 
     if "error" in include_error_types:
         filtered_errors = errors
+    else:
+        filtered_errors = []
 
     if "warning" in include_error_types:
         filtered_warnings = warnings
+    else:
+        filtered_warnings = []
 
     if "information" in include_error_types:
         filtered_information = information
+    else:
+        filtered_information = []
 
     organized_messages = {
         "fatal": fatal,

--- a/phdi/validation/validation.py
+++ b/phdi/validation/validation.py
@@ -18,10 +18,11 @@ def validate_ecr(ecr_message: str, config: dict, include_error_types: list) -> d
     parser = etree.XMLParser(ns_clean=True, recover=True, encoding="utf-8")
 
     # we need a try-catch around this to ensure that the ecr message
-    # passed in is proper XML
+    # passed in is proper XML - also ensure it's a clinical document
     try:
         parsed_ecr = etree.fromstring(xml, parser=parser)
-    except etree.XMLSyntaxError as error:
+        parsed_ecr.xpath("//hl7:ClinicalDocument",namespaces)
+    except AttributeError as error:
         return {
             "message_valid": False,
             "validation_results": {"errors": ["eCR Message is not valid XML!" + error]},

--- a/phdi/validation/validation.py
+++ b/phdi/validation/validation.py
@@ -25,7 +25,7 @@ def validate_ecr(ecr_message: str, config: dict, include_error_types: list) -> d
     except AttributeError:
         return {
             "message_valid": False,
-            "validation_results": {"errors": ["eCR Message is not valid XML!"]},
+            "validation_results": {"fatal": ["eCR Message is not valid XML!"]},
         }
 
     msgs = {"fatal": [], "error": [], "warning": [], "information": []}

--- a/phdi/validation/validation.py
+++ b/phdi/validation/validation.py
@@ -21,7 +21,7 @@ def validate_ecr(ecr_message: str, config: dict, include_error_types: list) -> d
     # passed in is proper XML - also ensure it's a clinical document
     try:
         parsed_ecr = etree.fromstring(xml, parser=parser)
-        parsed_ecr.xpath("//hl7:ClinicalDocument",namespaces)
+        parsed_ecr.xpath("//hl7:ClinicalDocument", namespaces=namespaces)
     except AttributeError as error:
         return {
             "message_valid": False,

--- a/phdi/validation/validation.py
+++ b/phdi/validation/validation.py
@@ -14,14 +14,14 @@ namespaces = {
 def validate_ecr(ecr_message: str, config: dict, include_error_types: list) -> dict:
     # encoding ecr_message to allow it to be
     #  parsed and organized as an lxml Element Tree Object
+    xml = ecr_message.encode("utf-8")
+    parser = etree.XMLParser(ns_clean=True, recover=True, encoding="utf-8")
 
     # we need a try-catch around this to ensure that the ecr message
     # passed in is proper XML
     try:
-        xml = ecr_message.encode("utf-8")
-        parser = etree.XMLParser(ns_clean=True, recover=True, encoding="utf-8")
         parsed_ecr = etree.fromstring(xml, parser=parser)
-    except Exception as error:
+    except etree.XMLSyntaxError as error:
         return {
             "message_valid": False,
             "validation_results": {"errors": ["eCR Message is not valid XML!" + error]},

--- a/tests/validation/test_validation.py
+++ b/tests/validation/test_validation.py
@@ -109,7 +109,7 @@ def test_validate_error():
     result = validate_ecr(
         ecr_message=sample_file_error,
         config=config,
-        error_types=["fatal", "error", "warning", "information"],
+        include_error_types=["fatal", "error", "warning", "information"],
     )
 
     assert result == expected_response

--- a/tests/validation/test_validation.py
+++ b/tests/validation/test_validation.py
@@ -113,3 +113,19 @@ def test_validate_error():
     )
 
     assert result == expected_response
+
+
+def test_invalid_xml():
+    expected_response = {
+        "message_valid": False,
+        "validation_results": {
+            "fatal": ["eCR Message is not valid XML!"]
+        },
+    }
+    result = validate_ecr(
+        ecr_message="BLAH",
+        config=config,
+        include_error_types=test_include_errors,
+    )
+
+    assert result == expected_response

--- a/tests/validation/test_validation.py
+++ b/tests/validation/test_validation.py
@@ -1,8 +1,10 @@
 import pathlib
 
 import yaml
-from phdi.validation.validation import validate_ecr, _validate_config
+from phdi.validation.validation import validate_ecr
 
+
+test_include_errors = ["error", "warning", "information"]
 
 # Test file with known errors
 sample_file_bad = open(
@@ -33,7 +35,7 @@ def test_validate_good():
     result = validate_ecr(
         ecr_message=sample_file_good,
         config=config,
-        error_types=["error", "warn", "info"],
+        include_error_types=test_include_errors,
     )
 
     assert result == expected_response
@@ -73,17 +75,7 @@ def test_validate_bad():
     result = validate_ecr(
         ecr_message=sample_file_bad,
         config=config,
-        error_types=["error", "warn", "info"],
+        include_error_types=test_include_errors,
     )
 
     assert result == expected_response
-
-
-def test_validate_config_bad():
-    with open(
-        pathlib.Path(__file__).parent.parent / "assets" / "sample_ecr_config_bad.yaml",
-        "r",
-    ) as file:
-        config_bad = yaml.safe_load(file)
-        result = _validate_config(config_bad)
-        assert not result

--- a/tests/validation/test_validation.py
+++ b/tests/validation/test_validation.py
@@ -42,6 +42,9 @@ def test_validate_good():
 
 
 def test_validate_bad():
+    # TODO: we need to clean up the error messages
+    # we don't need to see all the xpath data within the error
+    # just the field, value, and why it failed
     expected_response = {
         "message_valid": False,
         "validation_results": {

--- a/tests/validation/test_validation.py
+++ b/tests/validation/test_validation.py
@@ -118,9 +118,7 @@ def test_validate_error():
 def test_invalid_xml():
     expected_response = {
         "message_valid": False,
-        "validation_results": {
-            "fatal": ["eCR Message is not valid XML!"]
-        },
+        "validation_results": {"fatal": ["eCR Message is not valid XML!"]},
     }
     result = validate_ecr(
         ecr_message="BLAH",

--- a/tests/validation/test_validation_helpers.py
+++ b/tests/validation/test_validation_helpers.py
@@ -1,6 +1,6 @@
 import pathlib
 from phdi.validation.validation import (
-    _organize_messages,
+    _organize_error_messages,
     _match_nodes,
     _validate_attribute,
     _validate_text,
@@ -26,14 +26,22 @@ config = open(
 ).read()
 
 
-def test_organize_messages():
+def test_organize_error_messages():
     errors = ["my error1", "my_error2"]
     warns = ["my warn1"]
     infos = ["", "SOME"]
+    test_include_errors = ["error", "warning", "information"]
 
     expected_result = {"errors": errors, "warnings": warns, "information": infos}
 
-    actual_result = _organize_messages(errors, warns, infos)
+    actual_result = _organize_error_messages(errors, warns, infos, test_include_errors)
+    assert actual_result == expected_result
+
+    test_include_errors = ["information"]
+
+    expected_result = {"errors": [], "warnings": [], "information": infos}
+
+    actual_result = _organize_error_messages(errors, warns, infos, test_include_errors)
     assert actual_result == expected_result
 
 

--- a/tests/validation/test_validation_helpers.py
+++ b/tests/validation/test_validation_helpers.py
@@ -1,11 +1,13 @@
 import pathlib
 from phdi.validation.validation import (
     _organize_messages,
-    # _validate_attribute,
-    # _validate_text,
-    # _check_field_matches,
+    _match_nodes,
+    _validate_attribute,
+    _validate_text,
+    _check_field_matches,
     # namespaces,
 )
+from lxml import etree
 
 
 # Test file with known errors
@@ -23,93 +25,6 @@ config = open(
     pathlib.Path(__file__).parent.parent / "assets" / "sample_ecr_config.yaml"
 ).read()
 
-# def test_validate_text():
-#     actual_result = _validate_text("First Name", None)
-#     print(actual_result)
-#     assert 1 == 2
-
-#     error_messages = []
-#     for field in config.get("requiredFields"):
-#         if not field.get("textRequired"):
-#             continue
-#         path = field.get("cdaPath")
-#         matched_nodes_bad = sample_file_bad.xpath(path, namespaces=namespaces)
-#         found_field = False
-
-#         for node in matched_nodes_bad:
-#             found, error_messages_from_node = _validate_text(field, node)
-#             if found is True:
-#                 found_field = True
-#             if error_messages_from_node:
-#                 error_messages += error_messages_from_node
-#         if not found_field:
-#             error_messages += ["Field not found: " + str(field)]
-
-#     assert len(error_messages) == 3
-#     assert (
-#         error_messages[0] ==
-#          "Field not found: {'fieldName': 'First Name', 'cdaPath': "
-#         "'//hl7:ClinicalDocument/hl7:recordTarget/hl7:patientRole/"
-#         "hl7:patient/hl7:name/hl7:given', 'textRequired': 'True', "
-#         "'parent': 'name', 'parent_attributes': "
-#         "[{'attributeName': 'use', 'regEx': 'L'}]}"
-#     )
-#     assert (
-#         error_messages[1] == "Field not found: {'fieldName': 'City', 'cdaPath': "
-#         "'//hl7:ClinicalDocument/hl7:recordTarget/hl7:patientRole/"
-#         "hl7:addr/hl7:city', 'textRequired': 'True', "
-#         "'parent': 'addr', 'parent_attributes': "
-#         "[{'attributeName': 'use', 'regEx': 'H'}]}"
-#     )
-
-#     assert (
-#         error_messages[2] == "Field: Zip does not match regEx: [0-9]{5}(?:-[0-9]{4})?"
-#     )
-
-#     error_messages = []
-#     for field in config.get("requiredFields"):
-#         if not field.get("textRequired"):
-#             continue
-#         path = field.get("cdaPath")
-#         matched_nodes_good = sample_file_good.xpath(path, namespaces=namespaces)
-#         found_field = False
-
-#         for node in matched_nodes_good:
-#             found, error_messages_from_node = _validate_text(field, node)
-#             if found is True:
-#                 found_field = True
-#             if error_messages_from_node:
-#                 error_messages += error_messages_from_node
-#         if not found_field:
-#             error_messages += ["Field not found: " + str(field)]
-#     assert len(error_messages) == 0
-
-
-# def test_validate_attribute_no_errors():
-#     for field in config.get("requiredFields"):
-#         if not field.get("attributes"):
-#             continue
-#         path = field.get("cdaPath")
-#         matched_nodes = sample_file_good.xpath(path, namespaces=namespaces)
-#         for node in matched_nodes:
-#             results = _validate_attribute(field, node)
-#             assert len(results) == 0
-
-
-# def test_validate_attribute_with_errors():
-#     for field in config.get("requiredFields"):
-#         if not field.get("attributes"):
-#             continue
-#         path = field.get("cdaPath")
-#         matched_nodes = sample_file_bad.xpath(path, namespaces=namespaces)
-#         for node in matched_nodes:
-#             results = _validate_attribute(field, node)
-#             if (
-#                 field.get("cdaPath") == "//hl7:ClinicalDocument/hl7:versionNumber"
-#                 and field.get("attributes")[0].get("attributeName") == "value"
-#             ):
-#                 assert len(results) != 0
-
 
 def test_organize_messages():
     errors = ["my error1", "my_error2"]
@@ -120,3 +35,133 @@ def test_organize_messages():
 
     actual_result = _organize_messages(errors, warns, infos)
     assert actual_result == expected_result
+
+
+def test_match_nodes():
+    namespace = {"test": "test"}
+    xml = "<foo xmlns='test'><bar/><baz><biz/></baz><biz/></foo>"
+    root = etree.fromstring(xml)
+
+    config = {"parent": "foo", "fieldName": "bar", "cdaPath": "//test:foo/test:bar"}
+    xml_elements = root.xpath(config.get("cdaPath"), namespaces=namespace)
+
+    config_biz = {
+        "parent": "baz",
+        "fieldName": "biz",
+        "cdaPath": "//test:foo/test:baz/test:biz",
+    }
+    xml_elements_biz = root.xpath(config_biz.get("cdaPath"), namespaces=namespace)
+
+    assert _match_nodes([], config) == []
+    assert _match_nodes(xml_elements, config) == [xml_elements[0]]
+    assert _match_nodes(xml_elements_biz, config_biz) == [xml_elements_biz[0]]
+    assert len(_match_nodes(xml_elements_biz, config_biz)) == 1
+
+
+def test_check_field_matches():
+    namespace = {"test": "test"}
+    xml = "<foo xmlns='test'><bar/><baz><biz/></baz><biz/></foo>"
+    root = etree.fromstring(xml)
+
+    config = {"parent": "foo", "fieldName": "bar", "cdaPath": "//test:foo/test:bar"}
+    config_false_cda_path = {
+        "parent": "foo",
+        "fieldName": "biz",
+        "cdaPath": "//test:foo/test:biz",
+    }
+    config_false_attributes = {
+        "parent": "foo",
+        "fieldName": "bar",
+        "cdaPath": "//test:foo/test:bar",
+        "attributes": [{"attributeName": "test"}],
+    }
+    xml_elements = root.xpath(config.get("cdaPath"), namespaces=namespace)
+
+    assert _check_field_matches(xml_elements[0], config)
+    assert not _check_field_matches(xml_elements[0], config_false_cda_path)
+    assert not _check_field_matches(xml_elements[0], config_false_attributes)
+
+
+def test_validate_attribute():
+    namespace = {"test": "test"}
+    xml = "<foo xmlns='test'><bar test='bat'/><baz><biz/></baz><biz/></foo>"
+    root = etree.fromstring(xml)
+
+    config = {
+        "fieldName": "bar",
+        "attributes": [{"attributeName": "test"}],
+        "cdaPath": "//test:foo/test:bar",
+    }
+    config_attributes = {
+        "fieldName": "bar",
+        "attributes": [{"attributeName": "fail"}],
+        "cdaPath": "//test:foo/test:bar",
+    }
+    config_reg_ex = {
+        "fieldName": "bar",
+        "attributes": [{"attributeName": "test", "regEx": "bar"}],
+        "cdaPath": "//test:foo/test:bar",
+    }
+
+    xml_elements = root.xpath(config.get("cdaPath"), namespaces=namespace)
+    assert _validate_attribute(xml_elements[0], config) == []
+    assert _validate_attribute(xml_elements[0], config_attributes) == [
+        "Could not find attribute fail for tag bar"
+    ]
+    assert _validate_attribute(xml_elements[0], config_reg_ex) == [
+        "Attribute: 'test' for field: 'bar' not in expected format"
+    ]
+
+
+def test_validate_text():
+    namespace = {"test": "test"}
+    xml = "<foo xmlns='test'><bar>test</bar><baz><biz/></baz><biz>wrong</biz></foo>"
+    root = etree.fromstring(xml)
+
+    config = {
+        "fieldName": "bar",
+        "attributes": [{"attributeName": "test"}],
+        "cdaPath": "//test:foo/test:bar",
+        "textRequired": "True",
+    }
+
+    xml_elements = root.xpath(config.get("cdaPath"), namespaces=namespace)
+    assert _validate_text(xml_elements[0], config) == []
+
+    config_no_text = {
+        "fieldName": "biz",
+        "attributes": [{"attributeName": "test"}],
+        "cdaPath": "//test:foo/test:baz/test:biz",
+        "textRequired": "True",
+    }
+
+    xml_elements = root.xpath(config_no_text.get("cdaPath"), namespaces=namespace)
+    assert _validate_text(xml_elements[0], config_no_text) == [
+        "Field: biz does not have text"
+    ]
+
+    config_text_matches_reg_ex = {
+        "fieldName": "bar",
+        "attributes": [{"attributeName": "test"}],
+        "cdaPath": "//test:foo/test:bar",
+        "textRequired": "True",
+        "regEx": "test",
+    }
+    xml_elements = root.xpath(
+        config_text_matches_reg_ex.get("cdaPath"), namespaces=namespace
+    )
+    assert _validate_text(xml_elements[0], config_text_matches_reg_ex) == []
+
+    config_text_doesnt_match_reg_ex = {
+        "fieldName": "bar",
+        "attributes": [{"attributeName": "test"}],
+        "cdaPath": "//test:foo/test:bar",
+        "textRequired": "True",
+        "regEx": "foo",
+    }
+    xml_elements = root.xpath(
+        config_text_doesnt_match_reg_ex.get("cdaPath"), namespaces=namespace
+    )
+    assert _validate_text(xml_elements[0], config_text_doesnt_match_reg_ex) == [
+        "Field: bar does not match regEx: foo"
+    ]

--- a/tests/validation/test_validation_helpers.py
+++ b/tests/validation/test_validation_helpers.py
@@ -40,14 +40,23 @@ def test_organize_error_messages():
         "information": infos,
     }
 
-    actual_result = _organize_error_messages(errors, warns, infos, test_include_errors)
+    actual_result = _organize_error_messages(
+        fatal=fatal,
+        errors=errors,
+        warnings=warns,
+        information=infos,
+        include_error_types=test_include_errors,
+    )
     assert actual_result == expected_result
 
+    fatal = []
     test_include_errors = ["information"]
 
     expected_result = {"fatal": [], "errors": [], "warnings": [], "information": infos}
 
-    actual_result = _organize_error_messages(errors, warns, infos, test_include_errors)
+    actual_result = _organize_error_messages(
+        fatal, errors, warns, infos, test_include_errors
+    )
 
     assert actual_result == expected_result
 

--- a/tests/validation/test_validation_helpers.py
+++ b/tests/validation/test_validation_helpers.py
@@ -59,6 +59,14 @@ def test_organize_error_messages():
     )
     assert actual_result == expected_result
 
+    test_include_errors = ["fatal"]
+    expected_result = {"fatal": fatal, "errors": [], "warnings": [], "information": []}
+    actual_result = _organize_error_messages(
+        fatal, errors, warns, infos, test_include_errors
+    )
+    assert actual_result == expected_result
+
+
 
 def test_match_nodes():
     namespace = {"test": "test"}

--- a/tests/validation/test_validation_helpers.py
+++ b/tests/validation/test_validation_helpers.py
@@ -67,7 +67,6 @@ def test_organize_error_messages():
     assert actual_result == expected_result
 
 
-
 def test_match_nodes():
     namespace = {"test": "test"}
     xml = "<foo xmlns='test'><bar/><baz><biz/></baz><biz/></foo>"


### PR DESCRIPTION
This PR resolves #199 - and it handles the following:

* Updated the different error message types to be fully spelled out for readability
* Updates the organize_error_messages function to filter the lists of the different error message types if they are not indicated to be included
* Moved the config validator into the container section instead of the SDK - if the config is bad we should fail prior to trying to call the SDK BB for validation
* Other general fixes and clean up
* Added and updated tests cases 
* Updated the sample ecr config to be the same in both the base config folder as well as the tests/assets folder