### PR TITLE
Kenneth/custom error messages

### DIFF
--- a/phdi/validation/validation.py
+++ b/phdi/validation/validation.py
@@ -189,18 +189,23 @@ def _validate_attribute(xml_element, config_field) -> list:
             attribute_name = attribute.get("attributeName")
             attribute_value = xml_element.get(attribute_name)
             if not attribute_value:
-                error_messages.append(
+                message = _check_custom_message(
+                    config_field,
                     f"Could not find attribute {attribute_name} "
-                    + f"for tag {config_field.get('fieldName')}"
+                    + f"for tag {config_field.get('fieldName')}",
                 )
+                error_messages.append(message)
         if "regEx" in attribute:
             pattern = re.compile(attribute.get("regEx"))
             if (not attribute_value) or (not pattern.match(attribute_value)):
                 field_name = config_field.get("fieldName")
-                error_messages.append(
+                message = _check_custom_message(
+                    config_field,
                     f"Attribute: '{attribute_name}' for field: '{field_name}'"
-                    + " not in expected format"
+                    + " not in expected format",
                 )
+                error_messages.append(message)
+
     return error_messages
 
 
@@ -223,16 +228,30 @@ def _validate_text(xml_element, config_field):
     if regEx is not None:
         pattern = re.compile(regEx)
         if pattern.match(text) is None:
-            return [
+            message = _check_custom_message(
+                config_field,
                 "Field: "
                 + config_field.get("fieldName")
                 + " does not match regEx: "
-                + config_field.get("regEx")
-            ]
+                + config_field.get("regEx"),
+            )
+            return [message]
         else:
             return []
     else:
         if text is not None and text != "":
             return []
         else:
-            return ["Field: " + config_field.get("fieldName") + " does not have text"]
+            message = _check_custom_message(
+                config_field,
+                "Field: " + config_field.get("fieldName") + " does not have text",
+            )
+            return [message]
+
+
+def _check_custom_message(config_field, default_message):
+    message = default_message
+    if config_field.get("customMessage"):
+        print("hi")
+        message = config_field.get("customMessage")
+    return message

--- a/phdi/validation/validation.py
+++ b/phdi/validation/validation.py
@@ -252,6 +252,5 @@ def _validate_text(xml_element, config_field):
 def _check_custom_message(config_field, default_message):
     message = default_message
     if config_field.get("customMessage"):
-        print("hi")
         message = config_field.get("customMessage")
     return message

--- a/tests/assets/sample_ecr_config_custom_messages.yaml
+++ b/tests/assets/sample_ecr_config_custom_messages.yaml
@@ -1,0 +1,8 @@
+---
+fields:
+- fieldName: Zip
+  cdaPath: "//hl7:ClinicalDocument/hl7:recordTarget/hl7:patientRole/hl7:addr/hl7:postalCode"
+  errorType: "error"
+  textRequired: 'True'
+  regEx: "[0-9]{5}(?:-[0-9]{4})?"
+  customMessage: "Invalid postal code"

--- a/tests/validation/test_validation.py
+++ b/tests/validation/test_validation.py
@@ -125,3 +125,27 @@ def test_invalid_xml():
     )
 
     assert result == expected_response
+
+
+def test_custom_error_messages():
+    expected_result = {
+        "message_valid": False,
+        "validation_results": {
+            "errors": ["Invalid postal code"],
+            "warnings": [],
+            "information": [],
+        },
+    }
+    with open(
+        pathlib.Path(__file__).parent.parent
+        / "assets"
+        / "sample_ecr_config_custom_messages.yaml",
+        "r",
+    ) as file:
+        config_custom = yaml.safe_load(file)
+        result = validate_ecr(
+            ecr_message=sample_file_bad,
+            config=config_custom,
+            error_types=["error", "warn", "info"],
+        )
+        assert expected_result == result

--- a/tests/validation/test_validation.py
+++ b/tests/validation/test_validation.py
@@ -129,11 +129,12 @@ def test_invalid_xml():
 
 def test_custom_error_messages():
     expected_result = {
-        "message_valid": False,
+        "message_valid": True,
         "validation_results": {
             "errors": ["Invalid postal code"],
+            "fatal": [],
             "warnings": [],
-            "information": [],
+            "information": ["Validation complete with no errors!"],
         },
     }
     with open(
@@ -146,6 +147,6 @@ def test_custom_error_messages():
         result = validate_ecr(
             ecr_message=sample_file_bad,
             config=config_custom,
-            error_types=["error", "warn", "info"],
+            include_error_types=test_include_errors,
         )
         assert expected_result == result

--- a/tests/validation/test_validation_helpers.py
+++ b/tests/validation/test_validation_helpers.py
@@ -5,6 +5,7 @@ from phdi.validation.validation import (
     _validate_attribute,
     _validate_text,
     _check_field_matches,
+    _check_custom_message,
     # namespaces,
 )
 from lxml import etree
@@ -223,3 +224,28 @@ def test_validate_text():
     assert _validate_text(xml_elements[0], config_text_doesnt_match_reg_ex) == [
         "Field: bar does not match regEx: foo"
     ]
+
+
+def test_check_custom_message():
+    config_field_with_custom = {
+        "fieldName": "bar",
+        "attributes": [{"attributeName": "test"}],
+        "cdaPath": "//test:foo/test:bar",
+        "textRequired": "True",
+        "regEx": "foo",
+        "customMessage": "this is a custom message",
+    }
+    result = _check_custom_message(
+        config_field_with_custom, "this is a default message"
+    )
+    assert result == "this is a custom message"
+
+    config_field_no_custom = {
+        "fieldName": "bar",
+        "attributes": [{"attributeName": "test"}],
+        "cdaPath": "//test:foo/test:bar",
+        "textRequired": "True",
+        "regEx": "foo",
+    }
+    result = _check_custom_message(config_field_no_custom, "this is a default message")
+    assert result == "this is a default message"


### PR DESCRIPTION
This ticket resolves #234. The purpose of this branch is to add the ability for users to add custom error messages. If there are no custom errors, it will default to the standard error message