### PR TITLE
Auto update GH pages with latest generated pdoc

### DIFF
--- a/.github/workflows/tagRelease.yaml
+++ b/.github/workflows/tagRelease.yaml
@@ -46,6 +46,8 @@ jobs:
         run: |
           poetry run pdoc ./phdi -o ./docs/${{ github.event.inputs.custom_tag }}
           git checkout docs --
+          rm -rf ./docs/latest
+          cp -r ./docs/${{ github.event.inputs.custom_tag }} ./docs/latest
 
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:


### PR DESCRIPTION
PR for new system of storing and tracking docs generated by the release workflow. New docs are saved to the docs branch, but the latest docs are also saved into a "Latest" directory that the GH pages site is pointed at. Visiting the pages site will always display the most recent set of docs, but older docs can be linked to using a URL.

Two changes that aren't in this PR but are also part of how this works:

- Update PHDI repo settings so GH pages tracks the docs folder on the docs branch
- Index html update on the docs branch to pull in the docs from the latest directory

Cheers!