### PR TITLE
Updated container to look for STLT specific ecr config

### DIFF
--- a/containers/validation/app/main.py
+++ b/containers/validation/app/main.py
@@ -3,12 +3,12 @@ from pydantic import BaseModel, Field
 from typing import Literal
 from pathlib import Path
 from phdi.validation.validation import validate_ecr
-from .utils import load_config, validate_error_types
+from .utils import load_ecr_config, validate_error_types
 
 # TODO: Remove hard coded location for config path
 # and/or provide a mechanism to pass in coniguration
 #  via endpoint
-config = load_config()
+ecr_config = load_ecr_config()
 
 
 # Instantiate FastAPI and set metadata.
@@ -75,7 +75,7 @@ def validate_ecr_msg(message: str, include_error_types: list) -> ValidateRespons
     """
 
     return validate_ecr(
-        ecr_message=message, config=config, include_error_types=include_error_types
+        ecr_message=message, config=ecr_config, include_error_types=include_error_types
     )
 
 

--- a/containers/validation/app/main.py
+++ b/containers/validation/app/main.py
@@ -1,4 +1,3 @@
-import pathlib
 from fastapi import FastAPI
 from pydantic import BaseModel, Field
 from typing import Literal
@@ -6,11 +5,10 @@ from pathlib import Path
 from phdi.validation.validation import validate_ecr
 from .utils import load_config, validate_error_types
 
-# TODO: remove the hard coding of the location of the config file
-# and utilize the location passed in...OR we could use a specified
-# location for the config file with a particular name that we would utilize
-config_path = pathlib.Path(__file__).parent.parent / "config" / "sample_ecr_config.yaml"
-config = load_config(path=config_path)
+# TODO: Remove hard coded location for config path
+# and/or provide a mechanism to pass in coniguration
+#  via endpoint
+config = load_config()
 
 
 # Instantiate FastAPI and set metadata.

--- a/containers/validation/app/utils.py
+++ b/containers/validation/app/utils.py
@@ -1,8 +1,14 @@
 import pathlib
 import yaml
+import re
 
 
 VALID_ERROR_TYPES = ["fatal", "errors", "warnings", "information"]
+# TODO: remove the hard coding of the location of the config file
+# and utilize the location passed in...OR we could use a specified
+# location for the config file with a particular name that we would utilize
+DEFAULT_CONFIG_PATH = pathlib.Path(__file__).parent.parent / "config"
+# / "sample_ecr_config.yaml"
 
 
 # TODO: Determine where/when this configuration should be loaded (as we
@@ -10,7 +16,7 @@ VALID_ERROR_TYPES = ["fatal", "errors", "warnings", "information"]
 # of loading it each time we validate an eCR)
 # we may also need to move this to a different location depending upon where/when
 # the loading occurs
-def load_config(path: pathlib.Path) -> dict:
+def load_config(file_path: pathlib.Path = None) -> dict:
     """
     Given the path to a local YAML file containing a validation
     configuration, loads the file and returns the resulting validation
@@ -22,6 +28,18 @@ def load_config(path: pathlib.Path) -> dict:
     :return: A dict representing a validation configuration read
         from the given path.
     """
+    path = DEFAULT_CONFIG_PATH / "sample_ecr_config.yaml"
+
+    # first check if there is a STLT defined config.yaml
+    # if not, then just use the default sample_ecr_config.yaml
+    for file in pathlib.Path(DEFAULT_CONFIG_PATH).glob("*.yaml"):
+        file_name = pathlib.Path(file).stem
+        if file_path is None and re.search("ecr_config_[a-z]+", file_name.lower()):
+            path = DEFAULT_CONFIG_PATH / file
+            exit
+        elif file_path is not None:
+            path = file_path
+
     try:
         with open(path, "r") as file:
             if path.suffix == ".yaml":

--- a/containers/validation/app/utils.py
+++ b/containers/validation/app/utils.py
@@ -16,7 +16,7 @@ DEFAULT_CONFIG_PATH = pathlib.Path(__file__).parent.parent / "config"
 # of loading it each time we validate an eCR)
 # we may also need to move this to a different location depending upon where/when
 # the loading occurs
-def load_config(file_path: pathlib.Path = None) -> dict:
+def load_ecr_config(file_path: pathlib.Path = None) -> dict:
     """
     Given the path to a local YAML file containing a validation
     configuration, loads the file and returns the resulting validation

--- a/containers/validation/tests/test_utils.py
+++ b/containers/validation/tests/test_utils.py
@@ -9,6 +9,17 @@ def test_load_config():
     config = load_config(config_path)
     assert config != ""
 
+    config = load_config(None)
+    assert config != ""
+    config_fields = config.get("fields")
+    value_for_ecr_version = list(
+        filter(
+            lambda config_fields: config_fields["fieldName"] == "eICR Version Number",
+            config_fields,
+        )
+    )
+    assert value_for_ecr_version[0].get("errorType") == "warnings"
+
 
 def test_validate_error_types():
     valid_ets = "errors,warnings"

--- a/containers/validation/tests/test_utils.py
+++ b/containers/validation/tests/test_utils.py
@@ -1,15 +1,15 @@
 import pathlib
 import yaml
-from app.utils import load_config, validate_error_types, validate_config
+from app.utils import load_ecr_config, validate_error_types, validate_config
 
 config_path = pathlib.Path(__file__).parent.parent / "config" / "sample_ecr_config.yaml"
 
 
-def test_load_config():
-    config = load_config(config_path)
+def test_load_ecr_config():
+    config = load_ecr_config(config_path)
     assert config != ""
 
-    config = load_config(None)
+    config = load_ecr_config(None)
     assert config != ""
     config_fields = config.get("fields")
     value_for_ecr_version = list(

--- a/containers/validation/tests/test_validation.py
+++ b/containers/validation/tests/test_validation.py
@@ -85,7 +85,6 @@ def test_validate_ecr_valid():
         },
         "validated_message": sample_file_good_with_RR,
     }
-    print(actual_result1["validation_results"])
     assert actual_result1 == expected_result1
 
 
@@ -134,7 +133,6 @@ def test_validate_ecr_invalid():
     actual_result3 = validate_ecr_msg(
         message=sample_file_bad, include_error_types=test_error_types
     )
-    print(actual_result3["validation_results"])
     assert actual_result3 == expected_result3
 
 

--- a/containers/validation/tests/test_validation.py
+++ b/containers/validation/tests/test_validation.py
@@ -11,6 +11,7 @@ from app.main import (
 
 client = TestClient(app)
 test_error_types = ["errors", "warnings", "information"]
+
 # Test good file
 sample_file_good = open(
     pathlib.Path(__file__).parent.parent.parent.parent
@@ -18,12 +19,21 @@ sample_file_good = open(
     / "assets"
     / "ecr_sample_input_good.xml"
 ).read()
+
 # Test bad file
 sample_file_bad = open(
     pathlib.Path(__file__).parent.parent.parent.parent
     / "tests"
     / "assets"
     / "ecr_sample_input_bad.xml"
+).read()
+
+# Test good file with RR data
+sample_file_good_with_RR = open(
+    pathlib.Path(__file__).parent.parent.parent.parent
+    / "tests"
+    / "assets"
+    / "ecr_sample_input_good_with_RR.xml"
 ).read()
 
 
@@ -53,7 +63,7 @@ def test_validate_ecr_invalid_xml():
 
 def test_validate_ecr_valid():
     actual_result1 = validate_ecr_msg(
-        message=sample_file_good, include_error_types=test_error_types
+        message=sample_file_good_with_RR, include_error_types=test_error_types
     )
     expected_result1 = {
         "message_valid": True,
@@ -67,36 +77,48 @@ def test_validate_ecr_valid():
                     "root": "2.16.840.1.113883.9.9.9.9.9",
                     "extension": "db734647-fc99-424c-a864-7e3cda82e704",
                 },
-                "rr": {},
+                "rr": {
+                    "root": "4efa0e5c-c34c-429f-b5de-f1a13aef4a28",
+                    "extension": None,
+                },
             },
         },
-        "validated_message": sample_file_good,
+        "validated_message": sample_file_good_with_RR,
     }
+    print(actual_result1["validation_results"])
     assert actual_result1 == expected_result1
 
 
 def test_validate_ecr_invalid():
-    # TODO: we need to clean up the error messages
-    # we don't need to see all the xpath data within the error
-    # just the field, value, and why it failed
     expected_result3 = {
         "message_valid": False,
         "validation_results": {
             "fatal": [
-                "Could not find field. Field name: 'eICR Version Number' Attributes:"
-                + " name: 'value'",
-                "Could not find field. Field name: 'First Name' Parent element: 'name'"
-                + " Parent attributes: name: 'use' RegEx: 'L'",
-                "Could not find field. Field name: 'City' Parent element: 'addr' Parent"
-                + " attributes: name: 'use' RegEx: 'H'",
-                "Field does not match regEx: [0-9]{5}(?:-[0-9]{4})?. Field name:"
-                + " 'Zip' value: '9999'",
+                "Could not find field. Field name: 'Status' Attributes: "
+                + "name: 'code' "
+                + "RegEx: 'RRVS19|RRVS20|RRVS21|RRVS22', name: 'codeSystem', "
+                + "name: 'displayName'",
+                "Could not find field. Field name: "
+                + "'Conditions' Attributes: name: 'code' RegEx: '[0-9]+', "
+                + "name: 'codeSystem'",
+                "Could not find field. Field name: "
+                + "'City' Parent element: 'addr' Parent attributes: name: "
+                + "'use' RegEx: 'H'",
+                "Field does not match regEx: "
+                + "[0-9]{5}(?:-[0-9]{4})?. Field name: 'Zip' value: '9999'",
             ],
-            "errors": [],
+            "errors": [
+                "Could not find field. Field name: 'First Name' "
+                + "Parent element: 'name' Parent attributes: "
+                + "name: 'use' RegEx: 'L'"
+            ],
             "warnings": [
-                "Attribute: 'code' not in expected format. Field name: 'Sex'"
-                + " Attributes: name: 'code' RegEx: 'F|M|O|U' value: 't', name:"
-                + " 'codeSystem' value: '2.16.840.1.113883.5.1'"
+                "Could not find field. Field name: 'eICR Version Number'"
+                + " Attributes: name: 'value'",
+                "Attribute: 'code' not "
+                + "in expected format. Field name: 'Sex' Attributes: name:"
+                + " 'code' RegEx: 'F|M|O|U' value: 't', name: 'codeSystem'"
+                + " value: '2.16.840.1.113883.5.1'",
             ],
             "information": [],
             "message_ids": {
@@ -112,6 +134,7 @@ def test_validate_ecr_invalid():
     actual_result3 = validate_ecr_msg(
         message=sample_file_bad, include_error_types=test_error_types
     )
+    print(actual_result3["validation_results"])
     assert actual_result3 == expected_result3
 
 


### PR DESCRIPTION
Fixes #248 

The Validation Container looks for an ecr config for validation in the same folder, but it first looks for a STLT specific config (ie... ecr_config_LAC.yaml).  If that file is not present then it will default to the sample_ecr_config.yaml file.  Updated the tests to reflect these changes and added more tests.  I also updated the names of the variables to be more specific in regards to ecr.