### PR TITLE
Base MPI Connector Client

### DIFF
--- a/phdi/linkage/__init__.py
+++ b/phdi/linkage/__init__.py
@@ -17,6 +17,8 @@ from phdi.linkage.link import (
     calculate_log_odds,
 )
 
+from phdi.linkage.core import BaseMPIConnectorClient
+
 __all__ = [
     "generate_hash_str",
     "block_data",
@@ -34,4 +36,5 @@ __all__ = [
     "calculate_u_probs",
     "load_json_probs",
     "calculate_log_odds",
+    "BaseMPIConnectorClient",
 ]

--- a/phdi/linkage/core.py
+++ b/phdi/linkage/core.py
@@ -1,0 +1,38 @@
+from typing import List, Dict
+from abc import ABC, abstractmethod
+
+
+class BaseMPIConnectorClient(ABC):
+    """
+    Represents a vendor-agnostic Master Patient Index (MPI) connector client. Requires
+    implementing classes to define methods to retrive blocks of data from the MPI.
+    Callers should use the provided interface functions (e.g., geocode_from_str)
+    to interact with the underlying vendor-specific client property.
+    """
+
+    @abstractmethod
+    def connect(**params) -> None:
+        """
+        Connects to a database server.
+
+        :param params: Vendor-specific database connection params.
+
+        """
+        pass  # pragma: no cover
+
+    @abstractmethod
+    def block_data(db_name: str, table_name: str, block_data: Dict) -> List[list]:
+        """
+        Returns a list of lists containing records from the database that match on the
+        incoming record's block values. If blocking on 'ZIP' and the incoming record's
+        zip code is '90210', the resulting block of data would contain records that all
+        have the same zip code of 90210.
+
+        :param db_name: Database name.
+        :param table_name: Table name.
+        :param block_data: Dictionary containing key value pairs for the column name for
+        blocking and the data for the incoming record, e.g., ["ZIP"]: "90210".
+        :return: A list of records that are within the block, e.g., records that all
+        have 90210 as their ZIP.
+        """
+        pass  # pragma: no cover

--- a/phdi/linkage/core.py
+++ b/phdi/linkage/core.py
@@ -29,32 +29,15 @@ class BaseMPIConnectorClient(ABC):
 
     @abstractmethod
     def upsert_match_patient(
-        patient_record: Dict, patient_table: str, person_table: str, person_id=None
+        patient_record: Dict, table_name: str, person_id=None
     ) -> None:
         """
         If a matching ID has been found in the MPI, inserts a new patient record into
-        the patient table with a matching personID; else a new patient record is
+        a table with a matching personID; else a new patient record is
         inserted with a new personID.
 
         :param patient_record: A FHIR patient resource.
-        :param patient_table: Name of MPI patient table.
-        :param person_table: Name of MPI person table.
-        :param person_id: The personID matching the patient record if a match has been
-        found in the MPI, defaults to None.
-        """
-        pass  # pragma: no cover
-
-    @abstractmethod
-    def upsert_match_person(
-        patient_record: Dict, person_table: str, person_id=None
-    ) -> None:
-        """
-        If a matching ID has been found in the MPI, updates an existing person record in
-        the person table to associate with the incoming patient record; else, a new
-        person record is inserted with a new personID.
-
-        :param patient_record: A FHIR patient resource.
-        :param person_table: Name of MPI person table.
+        :param table_name: Name of table to update or insert into.
         :param person_id: The personID matching the patient record if a match has been
         found in the MPI, defaults to None.
         """

--- a/phdi/linkage/core.py
+++ b/phdi/linkage/core.py
@@ -11,16 +11,6 @@ class BaseMPIConnectorClient(ABC):
     """
 
     @abstractmethod
-    def connect(**params) -> None:
-        """
-        Connects to a database server.
-
-        :param params: Vendor-specific database connection params.
-
-        """
-        pass  # pragma: no cover
-
-    @abstractmethod
     def block_data(db_name: str, table_name: str, block_data: Dict) -> List[list]:
         """
         Returns a list of lists containing records from the database that match on the

--- a/phdi/linkage/core.py
+++ b/phdi/linkage/core.py
@@ -29,15 +29,20 @@ class BaseMPIConnectorClient(ABC):
 
     @abstractmethod
     def upsert_match_patient(
-        patient_record: Dict, table_name: str, person_id=None
+        patient_record: Dict,
+        patient_table_name: str,
+        person_table_name: str,
+        person_id=None,
     ) -> None:
         """
-        If a matching ID has been found in the MPI, inserts a new patient record into
-        a table with a matching personID; else a new patient record is
-        inserted with a new personID.
+        If a matching person ID has been found in the MPI, inserts a new patient into
+        the patient table and updates the person table to link to the new patient; else
+        inserts a new patient into the patient table and inserts a new person into the
+        person table with a new personID, linking the new personID to the new patient.
 
         :param patient_record: A FHIR patient resource.
-        :param table_name: Name of table to update or insert into.
+        :param patient_table_name: Name of patient table to update or insert into.
+        :param person_table_name: Name of person table to update or insert into.
         :param person_id: The personID matching the patient record if a match has been
         found in the MPI, defaults to None.
         """

--- a/phdi/linkage/core.py
+++ b/phdi/linkage/core.py
@@ -26,3 +26,36 @@ class BaseMPIConnectorClient(ABC):
         have 90210 as their ZIP.
         """
         pass  # pragma: no cover
+
+    @abstractmethod
+    def upsert_match_patient(
+        patient_record: Dict, patient_table: str, person_table: str, person_id=None
+    ) -> None:
+        """
+        If a matching ID has been found in the MPI, inserts a new patient record into
+        the patient table with a matching personID; else a new patient record is
+        inserted with a new personID.
+
+        :param patient_record: A FHIR patient resource.
+        :param patient_table: Name of MPI patient table.
+        :param person_table: Name of MPI person table.
+        :param person_id: The personID matching the patient record if a match has been
+        found in the MPI, defaults to None.
+        """
+        pass  # pragma: no cover
+
+    @abstractmethod
+    def upsert_match_person(
+        patient_record: Dict, person_table: str, person_id=None
+    ) -> None:
+        """
+        If a matching ID has been found in the MPI, updates an existing person record in
+        the person table to associate with the incoming patient record; else, a new
+        person record is inserted with a new personID.
+
+        :param patient_record: A FHIR patient resource.
+        :param person_table: Name of MPI person table.
+        :param person_id: The personID matching the patient record if a match has been
+        found in the MPI, defaults to None.
+        """
+        pass  # pragma: no cover


### PR DESCRIPTION
I put together the `BaseMPIConnectorClient`, largely basing it off our [geocoding base client](https://github.com/CDCgov/phdi/blob/main/phdi/geospatial/core.py) as I don't have a ton of experience building out this kind of thing. 

Initially, I thought about including a `connect` method but I think we would be better served with connect to a db within `__init__` so that the specifics of connecting to a Postgres DB vs. SQLite could be handled there. I'm open to any and all suggestions, though. 