### PR TITLE
Add config folder into validation container

### DIFF
--- a/containers/validation/Dockerfile
+++ b/containers/validation/Dockerfile
@@ -10,6 +10,7 @@ COPY ./requirements.txt /code/requirements.txt
 RUN pip install -r requirements.txt
 
 COPY ./app /code/app
+COPY ./config /code/config
 COPY ./description.md /code/description.md
 
 EXPOSE 8080


### PR DESCRIPTION
The validation container currently fails to spin up because the config files aren't present in the container. This should fix that!