### PR TITLE
Create blocking extractor function

### DIFF
--- a/phdi/fhir/utils.py
+++ b/phdi/fhir/utils.py
@@ -4,10 +4,12 @@ import random
 from functools import cache
 from typing import Any, Callable, List, Literal, Union
 
+selection_criteria_types = Literal["first", "last", "random"]
+
 
 def apply_selection_criteria(
     value: List[Any],
-    selection_criteria: Literal["first", "last", "random"],
+    selection_criteria: selection_criteria_types,
 ) -> str:
     """
     Returns value(s), according to the selection criteria, from a given list of values
@@ -25,6 +27,10 @@ def apply_selection_criteria(
         value = value[-1]
     elif selection_criteria == "random":
         value = random.choice(value)
+    else:
+        raise ValueError(
+            f'Selection criteria {selection_criteria} is not a valid option. Must be one of "first", "last", or "random".'  # noqa
+        )
 
     # Temporary hack to ensure no structured data is written using pyarrow.
     # Currently Pyarrow does not support mixing non-structured and structured data.

--- a/phdi/fhir/utils.py
+++ b/phdi/fhir/utils.py
@@ -1,4 +1,66 @@
-from typing import Any, List
+import fhirpathpy
+import json
+import random
+from functools import cache
+from typing import Any, Callable, List, Literal, Union
+
+
+def apply_selection_criteria(
+    value: List[Any],
+    selection_criteria: Literal["first", "last", "random"],
+) -> str:
+    """
+    Returns value(s), according to the selection criteria, from a given list of values
+    parsed from a FHIR resource. A single string value is returned - if the selected
+    value is a complex structure (list or dict), it is converted to a string.
+    :param value: A list containing the values parsed from a FHIR resource.
+    :param selection_criteria: A string indicating which element(s) of a list to select.
+    :return: Value(s) parsed from a FHIR resource that conform to the selection
+      criteria.
+    """
+
+    if selection_criteria == "first":
+        value = value[0]
+    elif selection_criteria == "last":
+        value = value[-1]
+    elif selection_criteria == "random":
+        value = random.choice(value)
+
+    # Temporary hack to ensure no structured data is written using pyarrow.
+    # Currently Pyarrow does not support mixing non-structured and structured data.
+    # https://github.com/awslabs/aws-data-wrangler/issues/463
+    # Will need to consider other methods of writing to parquet if this is an essential
+    # feature.
+    if type(value) == dict:  # pragma: no cover
+        value = json.dumps(value)
+    elif type(value) == list:
+        value = ",".join(value)
+    return value
+
+
+def extract_value_with_resource_path(
+    resource: dict,
+    path: str,
+    selection_criteria: Literal["first", "last", "random"] = "first",
+) -> Union[Any, None]:
+    """
+    Yields a single value from a resource based on a provided `fhir_path`.
+    If the path doesn't map to an extant value in the first, returns
+    `None` instead.
+    :param resource: The FHIR resource to extract a value from.
+    :param path: The `fhir_path` at which the value can be found in the
+      resource.
+    :param selection_criteria: A string dictating which value to extract,
+      if multiple values exist at the path location.
+    :return: The extracted value, or `None` if the value doesn't exist.
+    """
+    parse_function = get_fhirpathpy_parser(path)
+    value = parse_function(resource)
+    if len(value) == 0:
+        return None
+    else:
+        value = apply_selection_criteria(value, selection_criteria)
+        return value
 
 
 def find_entries_by_resource_type(bundle: dict, resource_type: str) -> List[dict]:
@@ -70,6 +132,19 @@ def get_field(
     index = max(min(index, len(elements)) - 1, 0)
 
     return elements[index] if len(elements) > 0 else None
+
+
+@cache
+def get_fhirpathpy_parser(fhirpath_expression: str) -> Callable:
+    """
+    Accepts a FHIRPath expression, and returns a callable function
+    which returns the evaluated value at fhirpath_expression for
+    a specified FHIR resource.
+    :param fhirpath_expression: The FHIRPath expression to evaluate.
+    :return: A function that, when called passing in a FHIR resource,
+      will return value at `fhirpath_expression`.
+    """
+    return fhirpathpy.compile(fhirpath_expression)
 
 
 def get_one_line_address(address: dict) -> str:

--- a/phdi/linkage/__init__.py
+++ b/phdi/linkage/__init__.py
@@ -19,6 +19,7 @@ from phdi.linkage.link import (
     feature_match_log_odds_fuzzy_compare,
     profile_log_odds,
     eval_log_odds_cutoff,
+    extract_blocking_values_from_record,
 )
 
 from phdi.linkage.core import BaseMPIConnectorClient
@@ -45,4 +46,5 @@ __all__ = [
     "profile_log_odds",
     "eval_log_odds_cutoff",
     "BaseMPIConnectorClient",
+    "extract_blocking_values_from_record",
 ]

--- a/phdi/linkage/link.py
+++ b/phdi/linkage/link.py
@@ -1,14 +1,17 @@
 import hashlib
 import json
+import matplotlib.pyplot as plt
 import pandas as pd
 import pathlib
-from itertools import combinations
-from random import sample
-from math import log
-from phdi.harmonization.utils import compare_strings
-from typing import List, Callable, Dict, Union
 import sqlite3
-import matplotlib.pyplot as plt
+
+from itertools import combinations
+from math import log
+from random import sample
+from typing import List, Callable, Dict, Union
+
+from phdi.harmonization.utils import compare_strings
+from phdi.fhir.utils import extract_value_with_resource_path
 
 
 def block_data(data: pd.DataFrame, blocks: List) -> dict:
@@ -23,6 +26,58 @@ def block_data(data: pd.DataFrame, blocks: List) -> dict:
       values as the data within each block, stored as a list of
       lists.
     """
+    blocked_data_tuples = tuple(data.groupby(blocks))
+
+    # Convert data to list of lists within dict
+    blocked_data = dict()
+    for block, df in blocked_data_tuples:
+        blocked_data[block] = df.values.tolist()
+
+    return blocked_data
+
+
+def block_data_from_db(db_name: str, table_name: str, block_data: Dict) -> List[list]:
+    """
+    Returns a list of lists containing records from the database that match on the
+    incoming record's block values. If blocking on 'ZIP' and the incoming record's zip
+    code is '90210', the resulting block of data would contain records that all have the
+    same zip code of 90210.
+
+    :param db_name: Database name.
+    :param table_name: Table name.
+    :param block_data: Dictionary containing key value pairs for the column name for
+      blocking and the data for the incoming record, e.g., ["ZIP"]: "90210".
+    :return: A list of records that are within the block, e.g., records that all have
+      90210 as their ZIP.
+
+    """
+    if len(block_data) == 0:
+        raise ValueError("`block_data` cannot be empty.")
+
+    conn = sqlite3.connect(db_name)
+    cursor = conn.cursor()
+    cursor.row_factory = lambda c, row: [i for i in row]
+
+    query = _generate_block_query(table_name, block_data)  # Generate SQL query
+    cursor.execute(query)  # Execute query
+    block = cursor.fetchall()  # Fetch data from query
+    conn.commit()
+    conn.close()
+
+    return block
+
+
+def block_parquet_data(path: str, blocks: List) -> Dict:
+    """
+    Generates dictionary of blocked data where each key is a block and each value is a
+    distinct list of lists containing the data for a given block.
+
+    :param path: Path to parquet file containing data that needs to be linked.
+    :param blocks: List of columns to be used in blocking.
+    :return: A dictionary of with the keys as the blocks and the values as the data
+    within each block, stored as a list of lists.
+    """
+    data = pd.read_parquet(path, engine="pyarrow")
     blocked_data_tuples = tuple(data.groupby(blocks))
 
     # Convert data to list of lists within dict
@@ -245,6 +300,78 @@ def eval_log_odds_cutoff(feature_comparisons: List, **kwargs) -> bool:
     if "true_match_threshold" not in kwargs:
         raise KeyError("Cutoff threshold for true matches must be passed.")
     return sum(feature_comparisons) >= kwargs["true_match_threshold"]
+
+
+def extract_blocking_values_from_record(
+    record: dict, blocking_fields: List, transformations: dict[str, str]
+) -> dict:
+    """
+    Extracts values from a given patient record for eventual use in database
+    record linkage blocking. A list of fields to block on, as well as a mapping
+    of those fields to any desired transformations of their extracted values,
+    is used to fhir-path parse the value out of the incoming patient record.
+
+    Currently supported blocking fields:
+    - first_name
+    - last_name
+    - birthdate
+    - address
+    - city
+    - state
+    - zip
+    - sex
+
+    Currently supported transformations on extracted fields:
+    - first4: the first four characters of the value
+    - last4: the last four characters of the value
+
+    :param record: A FHIR-formatted Patient record.
+    :param blocking_fields: A List of supported fields whose values to pull
+      from the patient record.
+    :param transformations: A dictionary mapping field names to any desired
+      transformations for those fields. If no transformation is desired for
+      a field, simply leave it out of the dictionary.
+    """
+
+    # Pre-defined supported FHIR Path mappings and transformations
+    fields_to_fhirpaths = {
+        "first_name": "Patient.name.given",
+        "last_name": "Patient.name.family",
+        "birthdate": "Patient.birthDate",
+        "address": "Patient.address.line",
+        "zip": "Patient.address.postalCode",
+        "city": "Patient.address.city",
+        "state": "Patient.address.state",
+        "sex": "Patient.gender",
+    }
+    transform_funcs = {
+        "first4": lambda x: x[:4] if len(x) >= 4 else x,
+        "last4": lambda x: x[-4:] if len(x) >= 4 else x,
+    }
+
+    block_vals = dict.fromkeys(blocking_fields, "")
+    for block in blocking_fields:
+        try:
+            # Apply utility extractor for safe parsing
+            value = str(
+                extract_value_with_resource_path(
+                    record, fields_to_fhirpaths[block], selection_criteria="first"
+                )
+            )
+            if value:
+                if block in transformations:
+                    try:
+                        value = transform_funcs[transformations[block]](value)
+                    except KeyError:
+                        raise ValueError(
+                            f"Transformation {transformations[block]} is not valid."
+                        )
+                block_vals[block] = value
+
+        except KeyError:
+            raise ValueError(f"Field {block} is not a supported extraction field.")
+
+    return block_vals
 
 
 def feature_match_exact(
@@ -630,6 +757,87 @@ def profile_log_odds(
     plt.show()
 
 
+def score_linkage_vs_truth(
+    found_matches: dict[Union[int, str], set],
+    true_matches: dict[Union[int, str], set],
+    records_in_dataset: int,
+    expand_clusters_pairwise: bool = False,
+) -> tuple:
+    """
+    Compute the statistical qualities of a run of record linkage against
+    known true results. This function assumes that matches have already
+    been determined by the algorithm, and further assumes that true
+    matches have already been identified in the data.
+
+    :param found_matches: A dictionary mapping IDs of records to sets of
+      other records which were determined to be a match.
+    :param true_matches: A dictionary mapping IDs of records to sets of
+      other records which are _known_ to be a true match.
+    :param records_in_dataset: The number of records in the original data
+      set to-link.
+    :param expand_clusters_pairwise: Optionally, whether we need to take
+      the cross-product of members within the sets of the match list. This
+      parameter only needs to be used if the linkage algorithm was run in
+      cluster mode. Default is False.
+    :return: A tuple reporting the sensitivity/precision, specificity/recall,
+      positive prediction value, and F1 score of the linkage algorithm.
+    """
+
+    # If cluster mode was used, only the "master" patient's set will exist
+    # Need to expand other permutations for accurate statistics
+    if expand_clusters_pairwise:
+        new_found_matches = {}
+        for root_rec in found_matches:
+            if root_rec not in new_found_matches:
+                new_found_matches[root_rec] = found_matches[root_rec]
+            for paired_record in found_matches[root_rec]:
+                if paired_record not in new_found_matches:
+                    new_found_matches[paired_record] = set()
+                for other_record in found_matches[root_rec]:
+                    if other_record > paired_record:
+                        new_found_matches[paired_record].add(other_record)
+        found_matches = new_found_matches
+
+    # Need division by 2 because ordering is irrelevant, matches are symmetric
+    total_possible_matches = (records_in_dataset * (records_in_dataset - 1)) / 2.0
+    true_positives = 0.0
+    false_positives = 0.0
+    false_negatives = 0.0
+
+    for root_record in true_matches:
+        if root_record in found_matches:
+            true_positives += len(
+                true_matches[root_record].intersection(found_matches[root_record])
+            )
+            false_positives += len(
+                found_matches[root_record].difference(true_matches[root_record])
+            )
+            false_negatives += len(
+                true_matches[root_record].difference(found_matches[root_record])
+            )
+        else:
+            false_negatives += len(true_matches[root_record])
+    for record in set(set(found_matches.keys()).difference(true_matches.keys())):
+        false_positives += len(found_matches[record])
+
+    true_negatives = (
+        total_possible_matches - true_positives - false_positives - false_negatives
+    )
+
+    print("True Positives Found:", true_positives)
+    print("False Positives Misidentified:", false_positives)
+    print("False Negatives Missed:", false_negatives)
+
+    sensitivity = round(true_positives / (true_positives + false_negatives), 3)
+    specificity = round(true_negatives / (true_negatives + false_positives), 3)
+    ppv = round(true_positives / (true_positives + false_positives), 3)
+    f1 = round(
+        (2 * true_positives) / (2 * true_positives + false_negatives + false_positives),
+        3,
+    )
+    return (sensitivity, specificity, ppv, f1)
+
+
 def _eval_record_in_cluster(
     block: List[List],
     i: int,
@@ -740,139 +948,6 @@ def _match_within_block_cluster_ratio(
         if not found_master_cluster:
             clusters.append({i})
     return clusters
-
-
-def score_linkage_vs_truth(
-    found_matches: dict[Union[int, str], set],
-    true_matches: dict[Union[int, str], set],
-    records_in_dataset: int,
-    expand_clusters_pairwise: bool = False,
-) -> tuple:
-    """
-    Compute the statistical qualities of a run of record linkage against
-    known true results. This function assumes that matches have already
-    been determined by the algorithm, and further assumes that true
-    matches have already been identified in the data.
-
-    :param found_matches: A dictionary mapping IDs of records to sets of
-      other records which were determined to be a match.
-    :param true_matches: A dictionary mapping IDs of records to sets of
-      other records which are _known_ to be a true match.
-    :param records_in_dataset: The number of records in the original data
-      set to-link.
-    :param expand_clusters_pairwise: Optionally, whether we need to take
-      the cross-product of members within the sets of the match list. This
-      parameter only needs to be used if the linkage algorithm was run in
-      cluster mode. Default is False.
-    :return: A tuple reporting the sensitivity/precision, specificity/recall,
-      positive prediction value, and F1 score of the linkage algorithm.
-    """
-
-    # If cluster mode was used, only the "master" patient's set will exist
-    # Need to expand other permutations for accurate statistics
-    if expand_clusters_pairwise:
-        new_found_matches = {}
-        for root_rec in found_matches:
-            if root_rec not in new_found_matches:
-                new_found_matches[root_rec] = found_matches[root_rec]
-            for paired_record in found_matches[root_rec]:
-                if paired_record not in new_found_matches:
-                    new_found_matches[paired_record] = set()
-                for other_record in found_matches[root_rec]:
-                    if other_record > paired_record:
-                        new_found_matches[paired_record].add(other_record)
-        found_matches = new_found_matches
-
-    # Need division by 2 because ordering is irrelevant, matches are symmetric
-    total_possible_matches = (records_in_dataset * (records_in_dataset - 1)) / 2.0
-    true_positives = 0.0
-    false_positives = 0.0
-    false_negatives = 0.0
-
-    for root_record in true_matches:
-        if root_record in found_matches:
-            true_positives += len(
-                true_matches[root_record].intersection(found_matches[root_record])
-            )
-            false_positives += len(
-                found_matches[root_record].difference(true_matches[root_record])
-            )
-            false_negatives += len(
-                true_matches[root_record].difference(found_matches[root_record])
-            )
-        else:
-            false_negatives += len(true_matches[root_record])
-    for record in set(set(found_matches.keys()).difference(true_matches.keys())):
-        false_positives += len(found_matches[record])
-
-    true_negatives = (
-        total_possible_matches - true_positives - false_positives - false_negatives
-    )
-
-    print("True Positives Found:", true_positives)
-    print("False Positives Misidentified:", false_positives)
-    print("False Negatives Missed:", false_negatives)
-
-    sensitivity = round(true_positives / (true_positives + false_negatives), 3)
-    specificity = round(true_negatives / (true_negatives + false_positives), 3)
-    ppv = round(true_positives / (true_positives + false_positives), 3)
-    f1 = round(
-        (2 * true_positives) / (2 * true_positives + false_negatives + false_positives),
-        3,
-    )
-    return (sensitivity, specificity, ppv, f1)
-
-
-def block_parquet_data(path: str, blocks: List) -> Dict:
-    """
-    Generates dictionary of blocked data where each key is a block and each value is a
-    distinct list of lists containing the data for a given block.
-
-    :param path: Path to parquet file containing data that needs to be linked.
-    :param blocks: List of columns to be used in blocking.
-    :return: A dictionary of with the keys as the blocks and the values as the data
-    within each block, stored as a list of lists.
-    """
-    data = pd.read_parquet(path, engine="pyarrow")
-    blocked_data_tuples = tuple(data.groupby(blocks))
-
-    # Convert data to list of lists within dict
-    blocked_data = dict()
-    for block, df in blocked_data_tuples:
-        blocked_data[block] = df.values.tolist()
-
-    return blocked_data
-
-
-def block_data_from_db(db_name: str, table_name: str, block_data: Dict) -> List[list]:
-    """
-    Returns a list of lists containing records from the database that match on the
-    incoming record's block values. If blocking on 'ZIP' and the incoming record's zip
-    code is '90210', the resulting block of data would contain records that all have the
-    same zip code of 90210.
-
-    :param db_name: Database name.
-    :param table_name: Table name.
-    :param block_data: Dictionary containing key value pairs for the column name for
-      blocking and the data for the incoming record, e.g., ["ZIP"]: "90210".
-    :return: A list of records that are within the block, e.g., records that all have
-      90210 as their ZIP.
-
-    """
-    if len(block_data) == 0:
-        raise ValueError("`block_data` cannot be empty.")
-
-    conn = sqlite3.connect(db_name)
-    cursor = conn.cursor()
-    cursor.row_factory = lambda c, row: [i for i in row]
-
-    query = _generate_block_query(table_name, block_data)  # Generate SQL query
-    cursor.execute(query)  # Execute query
-    block = cursor.fetchall()  # Fetch data from query
-    conn.commit()
-    conn.close()
-
-    return block
 
 
 def _generate_block_query(table_name: str, block_data: Dict) -> str:

--- a/tests/fhir/tabulation/test_fhir_tabulation.py
+++ b/tests/fhir/tabulation/test_fhir_tabulation.py
@@ -11,7 +11,6 @@ from unittest import mock
 from requests.models import Response
 
 from phdi.fhir.tabulation.tables import (
-    _apply_selection_criteria,
     drop_invalid,
     tabulate_data,
     generate_tables,
@@ -25,17 +24,18 @@ from phdi.fhir.tabulation.tables import (
     extract_data_from_schema,
     _merge_include_query_params_for_location,
 )
+from phdi.fhir.utils import apply_selection_criteria
 
 
 def test_apply_selection_criteria():
     selection_criteria_test_list = ["one", "two", "three"]
-    assert _apply_selection_criteria(selection_criteria_test_list, "first") == "one"
-    assert _apply_selection_criteria(selection_criteria_test_list, "last") == "three"
+    assert apply_selection_criteria(selection_criteria_test_list, "first") == "one"
+    assert apply_selection_criteria(selection_criteria_test_list, "last") == "three"
     assert (
-        _apply_selection_criteria(selection_criteria_test_list, "random")
+        apply_selection_criteria(selection_criteria_test_list, "random")
         in selection_criteria_test_list
     )
-    assert _apply_selection_criteria(selection_criteria_test_list, "all") == ",".join(
+    assert apply_selection_criteria(selection_criteria_test_list, "all") == ",".join(
         selection_criteria_test_list
     )
 

--- a/tests/fhir/tabulation/test_fhir_tabulation.py
+++ b/tests/fhir/tabulation/test_fhir_tabulation.py
@@ -24,20 +24,6 @@ from phdi.fhir.tabulation.tables import (
     extract_data_from_schema,
     _merge_include_query_params_for_location,
 )
-from phdi.fhir.utils import apply_selection_criteria
-
-
-def test_apply_selection_criteria():
-    selection_criteria_test_list = ["one", "two", "three"]
-    assert apply_selection_criteria(selection_criteria_test_list, "first") == "one"
-    assert apply_selection_criteria(selection_criteria_test_list, "last") == "three"
-    assert (
-        apply_selection_criteria(selection_criteria_test_list, "random")
-        in selection_criteria_test_list
-    )
-    assert apply_selection_criteria(selection_criteria_test_list, "all") == ",".join(
-        selection_criteria_test_list
-    )
 
 
 def test_tabulate_data_invalid_table_name():

--- a/tests/fhir/test_utils.py
+++ b/tests/fhir/test_utils.py
@@ -3,10 +3,27 @@ import pathlib
 import pytest
 
 from phdi.fhir.utils import (
+    apply_selection_criteria,
     find_entries_by_resource_type,
     get_field,
     get_one_line_address,
 )
+
+
+def test_apply_selection_criteria():
+    with pytest.raises(ValueError) as e:
+        apply_selection_criteria([], "invalid")
+        assert (
+            'is not a valid option. Must be one of "first", "last", or "random"'
+            in str(e.value)
+        )
+    selection_criteria_test_list = ["one", "two", "three"]
+    assert apply_selection_criteria(selection_criteria_test_list, "first") == "one"
+    assert apply_selection_criteria(selection_criteria_test_list, "last") == "three"
+    assert (
+        apply_selection_criteria(selection_criteria_test_list, "random")
+        in selection_criteria_test_list
+    )
 
 
 def test_find_resource_by_type():


### PR DESCRIPTION
This PR introduces the blocking extractor functionally specified in #295 . We currently support a number of predefined fields to extract (so that the FHIR handling is abstracted from the user and made easy), as well as a small handful of transforms that can be performed on the data for purposes of string manipulation. 

Also, as part of this PR, I did a bit of code rearranging since the fhirpath parsing was stuff we had utils for already but it needed moved out of the tabulation module. The diff looks far worse than this PR actually is.