### PR TITLE
Create basic SQL DDL file

### DIFF
--- a/phdi/linkage/tables.ddl
+++ b/phdi/linkage/tables.ddl
@@ -1,0 +1,18 @@
+USE DibbsMpiDB;
+BEGIN;
+CREATE TABLE IF NOT EXISTS patient (
+    patient_id  VARCHAR(32) PRIMARY KEY
+    person_id   VARCHAR(32) FOREIGN KEY
+    name    JSONB
+    sex ENUM ('male', 'female', 'other', 'unknown')
+    birthdate   DATE
+    telecom JSONB
+    identifier  JSONB
+    address JSONB
+);
+
+CREATE TABLE IF NOT EXISTS person (
+    person_id   VARCHAR(32) PRIMARY KEY
+    external_person_id  VARCHAR(64)
+);
+COMMIT;


### PR DESCRIPTION
This PR creates a really basic ddl file for our MPI tables within the linkage folder. The database used at the top should be swapped out whenever we actually stand a DB up, and I left everything transactional so that we get rollback if the creation fails. Let me know if the field lengths don't seem long enough or we want other info here.