### PR TITLE
add transformations to block_vals dict

### DIFF
--- a/phdi/linkage/link.py
+++ b/phdi/linkage/link.py
@@ -366,7 +366,12 @@ def extract_blocking_values_from_record(
                         raise ValueError(
                             f"Transformation {transformations[block]} is not valid."
                         )
-                block_vals[block] = value
+                    block_vals[block] = {
+                        "value": value,
+                        "transformation": transformations[block],
+                    }
+                else:
+                    block_vals[block] = {"value": value}
 
         except KeyError:
             raise ValueError(f"Field {block} is not a supported extraction field.")

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -29,15 +29,17 @@ class PostgresConnectorClient(BaseMPIConnectorClient):
         self.patient_table = patient_table
         self.person_table = person_table
 
-    def block_data(self, block_data: Dict) -> List[list]:
+    def block_data(self, block_vals: Dict) -> List[list]:
         """
         Returns a list of lists containing records from the database that match on the
         incoming record's block values. If blocking on 'ZIP' and the incoming record's
         zip code is '90210', the resulting block of data would contain records that all
         have the same zip code of 90210.
 
-        :param block_data: Dictionary containing key value pairs for the column name for
-          blocking and the data for the incoming record, e.g., ["ZIP"]: "90210".
+        :param block_vals: Dictionary containing key value pairs for the column name for
+          blocking and the data for the incoming record as well as any transformations,
+          e.g., {["ZIP"]: {"value": "90210"}} or
+          {["ZIP"]: {"value": "90210",}, "transformation":"first4"}.
         :return: A list of records that are within the block, e.g., records that all
           have 90210 as their ZIP.
         """
@@ -55,11 +57,11 @@ class PostgresConnectorClient(BaseMPIConnectorClient):
         except Exception as error:  # pragma: no cover
             raise ValueError(f"{error}")
 
-        if len(block_data) == 0:
+        if len(block_vals) == 0:
             raise ValueError("`block_data` cannot be empty.")
 
         # Generate raw SQL query
-        query = self._generate_block_query(self.patient_table, block_data)
+        query = self._generate_block_query(self.patient_table, block_vals)
 
         # Execute query
         self.cursor.execute(query)

--- a/tests/linkage/test_linkage.py
+++ b/tests/linkage/test_linkage.py
@@ -75,14 +75,14 @@ def test_extract_blocking_values_from_record():
         patient, blocking_fields, transforms
     )
     assert blocking_vals == {
-        "first_name": "John",
-        "last_name": "Shep",
-        "zip": "10001-0001",
-        "city": "Faketon",
-        "birthdate": "1983-02-01",
-        "sex": "female",
-        "state": "NY",
-        "address": "e St",
+        "first_name": {"value": "John", "transformation": "first4"},
+        "last_name": {"value": "Shep", "transformation": "first4"},
+        "zip": {"value": "10001-0001"},
+        "city": {"value": "Faketon"},
+        "birthdate": {"value": "1983-02-01"},
+        "sex": {"value": "female"},
+        "state": {"value": "NY"},
+        "address": {"value": "e St", "transformation": "last4"},
     }
 
 


### PR DESCRIPTION
# Add transformations to block_vals dictionary

## Summary
This PR updates the `extract_blocking_values_from_record` function to return both the values and any transformations to be performed on the data when blocking, e.g., "first4" or "last4". The `block_vals` dict is passed to the MPI client that then performs the blocking. To prevent the user from having to re-enter the transformations during the blocking, the proposed changes passes along the transformations within `block_vals`.


## Additional Information
This PR is a pre-requisite for modifying the Postgres MPI blocking queries in the `update-mpi-queries-jsonpaths` branch.

[//]: # (PR title: Remember to name your PR descriptively!)