### PR TITLE
remove 'licenses' from geocode_bundle function call

### DIFF
--- a/containers/ingestion/app/routers/fhir_geospatial.py
+++ b/containers/ingestion/app/routers/fhir_geospatial.py
@@ -95,6 +95,7 @@ def geocode_bundle_endpoint(
     input.pop("geocode_method", None)
     input.pop("auth_id", None)
     input.pop("auth_token", None)
+    input.pop("licenses", None)
     result = {}
     try:
         geocoder_result = geocode_client.geocode_bundle(**input)

--- a/containers/ingestion/tests/test_fhir_geospatial.py
+++ b/containers/ingestion/tests/test_fhir_geospatial.py
@@ -64,7 +64,7 @@ def test_geocode_bundle_success_smarty(patched_client):
     client.post("/fhir/geospatial/geocode/geocode_bundle", json=test_request)
 
     patched_client.return_value.geocode_bundle.assert_called_with(
-        bundle=test_bundle, licenses=None, overwrite=True
+        bundle=test_bundle, overwrite=True
     )
 
 

--- a/containers/ingestion/tests/test_fhir_geospatial.py
+++ b/containers/ingestion/tests/test_fhir_geospatial.py
@@ -48,7 +48,7 @@ def test_geocode_bundle_success_census(patched_client):
     client.post("/fhir/geospatial/geocode/geocode_bundle", json=test_request)
 
     patched_client.return_value.geocode_bundle.assert_called_with(
-        bundle=test_bundle, licenses=None, overwrite=True
+        bundle=test_bundle, overwrite=True
     )
 
 


### PR DESCRIPTION
# PULL REQUEST

## Summary
The recent changes to the Smarty license introduced a bug when hitting the geocode endpoint, with the following error:

<img width="678" alt="Screenshot 2023-03-29 at 3 17 40 PM" src="https://user-images.githubusercontent.com/80282552/228680430-1a6f3a93-088c-4424-8b6e-db7c34c26166.png">

This change removes the `licenses` param before sending a request to the `geocode_bundle` function, as the `geocode_bundle` function doesn't recognize `licenses`.

## Related Issue
n/a - discovered during demo prep

## Additional Information
Long-term this seems like a good opportunity to add an integration test for the ingestion service, but first things first let's get it working again :) 

[//]: # (PR title: Remember to name your PR descriptively!)