### PR TITLE
Change FHIR converter input types

### DIFF
--- a/containers/fhir-converter/main.py
+++ b/containers/fhir-converter/main.py
@@ -128,8 +128,8 @@ def convert_to_fhir(
     converter can be found at https://github.com/microsoft/FHIR-Converter.
 
     :param input_data: The message to be converted as a string.
-    :param input_type: The type of message to be converted. Valid values are "elr", "vxu",
-        and "ecr".
+    :param input_type: The type of message to be converted. Valid values are
+        "elr", "vxu", and "ecr".
     :param root_template: Name of the liquid template within to be used for conversion.
         Options are listed in the FHIR-Converter README.md.
     """

--- a/containers/fhir-converter/main.py
+++ b/containers/fhir-converter/main.py
@@ -11,7 +11,8 @@ api = FastAPI()
 
 
 class InputType(str, Enum):
-    hl7v2 = "hl7v2"
+    elr = "elr"
+    vxu = "vxu"
     ecr = "ecr"
 
 
@@ -127,8 +128,8 @@ def convert_to_fhir(
     converter can be found at https://github.com/microsoft/FHIR-Converter.
 
     :param input_data: The message to be converted as a string.
-    :param input_type: The type of message to be converted. Valid values are "hl7v2"
-        and "c-cda".
+    :param input_type: The type of message to be converted. Valid values are "elr", "vxu",
+        and "ecr".
     :param root_template: Name of the liquid template within to be used for conversion.
         Options are listed in the FHIR-Converter README.md.
     """
@@ -137,7 +138,7 @@ def convert_to_fhir(
     converter_project_path = (
         "/build/FHIR-Converter/output/Microsoft.Health.Fhir.Liquid.Converter.Tool.dll"
     )
-    if input_type == "hl7v2":
+    if input_type == "elr" or input_type == "vxu":
         template_directory_path = "/build/FHIR-Converter/data/Templates/Hl7v2"
     elif input_type == "ecr":
         template_directory_path = "/build/FHIR-Converter/data/Templates/Ccda"

--- a/containers/fhir-converter/test_FHIR-Converter.py
+++ b/containers/fhir-converter/test_FHIR-Converter.py
@@ -8,7 +8,7 @@ client = TestClient(api)
 
 valid_request = {
     "input_data": "VALID_INPUT_DATA",
-    "input_type": "hl7v2",
+    "input_type": "elr",
     "root_template": "ADT_A01",
 }
 
@@ -49,13 +49,13 @@ conversion_failure_response = {
     "method_calls": [],
     "original_request": {
         "input_data": "VALID_INPUT_DATA",
-        "input_type": "hl7v2",
+        "input_type": "elr",
         "root_template": "ADT_A01",
     },
     "returncode": 1,
 }
 
-missing_input_data_request = {"input_type": "hl7v2", "root_template": "ADT_A01"}
+missing_input_data_request = {"input_type": "elr", "root_template": "ADT_A01"}
 
 missing_input_data_response = {
     "detail": [
@@ -77,16 +77,16 @@ invalid_input_type_response = {
     "detail": [
         {
             "loc": ["body", "input_type"],
-            "msg": "value is not a valid enumeration member; permitted: 'hl7v2', 'ecr'",
+            "msg": "value is not a valid enumeration member; permitted: 'elr', 'vxu', 'ecr'",
             "type": "type_error.enum",
-            "ctx": {"enum_values": ["hl7v2", "ecr"]},
+            "ctx": {"enum_values": ["elr", "vxu", "ecr"]},
         }
     ]
 }
 
 invalid_root_template_request = {
     "input_data": "VALID_INPUT_DATA",
-    "input_type": "hl7v2",
+    "input_type": "elr",
     "root_template": "INVALID_ROOT_TEMPLATE",
 }
 

--- a/containers/ingestion/tests/test_config.py
+++ b/containers/ingestion/tests/test_config.py
@@ -10,6 +10,7 @@ def test_get_settings_success():
     os.environ["SALT_STR"] = "my-salt"
     os.environ["AUTH_ID"] = "test_id"
     os.environ["AUTH_TOKEN"] = "test_token"
+    os.environ["LICENSES"] = '["us-standard-cloud"]'
     os.environ["CLOUD_PROVIDER"] = "azure"
     os.environ["BUCKET_NAME"] = "my_bucket"
     os.environ["STORAGE_ACCOUNT_URL"] = "storage_url"
@@ -20,6 +21,7 @@ def test_get_settings_success():
         "salt_str": "my-salt",
         "auth_id": "test_id",
         "auth_token": "test_token",
+        "licenses": '["us-standard-cloud"]',
         "cloud_provider": "azure",
         "bucket_name": "my_bucket",
         "storage_account_url": "storage_url",
@@ -28,6 +30,7 @@ def test_get_settings_success():
     os.environ.pop("CLOUD_PROVIDER", None)
     os.environ.pop("AUTH_ID", None)
     os.environ.pop("AUTH_TOKEN", None)
+    os.environ.pop("LICENSES", None)
     os.environ.pop("BUCKET_NAME", None)
     os.environ.pop("STORAGE_ACCOUNT_URL", None)
 


### PR DESCRIPTION
# PULL REQUEST

## Summary
Due to the addition of the validation service, we now need to support the input types of "vxu" and "elr" in the FHIR converter.