### PR TITLE
Remove "use" filter in jsonb queries

### DIFF
--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -30,15 +30,15 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
         self.patient_table = patient_table
         self.person_table = person_table
         self.fields_to_jsonpaths = {
-            "address": """$.address[*] ?(@.use=="home").line""",
+            "address": """$.address[*].line""",
             "birthdate": "$.birthDate",
-            "city": """$.address[*] ?(@.use=="home").city""",
-            "first_name": """$.name[*] ?(@.use=="official").given""",
-            "last_name": """$.name[*] ?(@.use=="official").family""",
-            "mrn": """$.identifier ?(@.type.coding[0].code=="MR").value""",
+            "city": """$.address[*].city""",
+            "first_name": """$.name[*].given""",
+            "last_name": """$.name[*].family""",
+            "mrn": """$.identifier.value""",
             "sex": "$.gender",
-            "state": """$.address[*] ?(@.use=="home").state""",
-            "zip": """$.address[*] ?(@.use=="home").postalCode""",
+            "state": """$.address[*].state""",
+            "zip": """$.address[*].postalCode""",
         }
 
     def block_data(self, block_vals: Dict) -> List[list]:

--- a/tests/linkage/test_postgres_mpi_connector.py
+++ b/tests/linkage/test_postgres_mpi_connector.py
@@ -84,7 +84,6 @@ def test_block_data():
             / "patient_bundle.json"
         )
     )
-    raw_bundle = json.load(open("C://Repos/phdi/tests/assets/patient_bundle.json"))
     patient_resource = raw_bundle.get("entry")[1].get("resource")
     patient_resource["id"] = "4d88cd35-5ee7-4419-a847-2818fdfeec50"
 

--- a/tests/linkage/test_postgres_mpi_connector.py
+++ b/tests/linkage/test_postgres_mpi_connector.py
@@ -84,7 +84,7 @@ def test_block_data():
             / "patient_bundle.json"
         )
     )
-
+    raw_bundle = json.load(open("C://Repos/phdi/tests/assets/patient_bundle.json"))
     patient_resource = raw_bundle.get("entry")[1].get("resource")
     patient_resource["id"] = "4d88cd35-5ee7-4419-a847-2818fdfeec50"
 


### PR DESCRIPTION
# Remove "use" filter in jsonb queries

## Summary
Because "use" is not mandatory in address and name fields for patient resources, we have to remove the filtering on "use".


[//]: # (PR title: Remember to name your PR descriptively!)