### PR TITLE
Run migrations after record linkage boot up

### DIFF
--- a/containers/record-linkage/app/main.py
+++ b/containers/record-linkage/app/main.py
@@ -14,8 +14,7 @@ import sys
 # get_settings()
 
 
-@asynccontextmanager
-async def lifespan(app: FastAPI):
+def run_migrations():
     dbname = os.getenv("DB_NAME")
     user = os.getenv("DB_USER")
     password = os.getenv("DB_PASSWORD")
@@ -40,7 +39,6 @@ async def lifespan(app: FastAPI):
         except errors.InFailedSqlTranroughsaction as err:
             # pass exception to function
             print_psycopg2_exception(err)
-    yield
 
 
 # Instantiate FastAPI and set metadata.
@@ -58,7 +56,6 @@ app = FastAPI(
         "url": "https://creativecommons.org/publicdomain/zero/1.0/",
     },
     description=description,
-    lifespan=lifespan,
 )
 
 
@@ -126,6 +123,8 @@ async def link_record(input: LinkRecordInput) -> LinkRecordResponse:
     :return: A JSON formatted response body with schema specified by the
         LinkRecordResponse model.
     """
+
+    run_migrations()
 
     return {"link_found": False, "updated_bundle": input.fhir_bundle}
 


### PR DESCRIPTION
The pipeline is erroring out on the record linkage step. This is the error I’m getting:
```
Error calling the endpoint 'https://phdi-dev2-record-linkage.salmondesert-05773626.centralus.azurecontainerapps.io/'. Response status code: 'ClientSideException HttpStatusCode : 408, HttpStatusString: RequestTimeout'. More details: Exception message: 'NA - Unknown [ClientSideException] A task was canceled.'.
Request didn't reach the server from the client. This could happen because of an underlying issue such as network connectivity, a DNS failure, a server certificate validation or a timeout. Url endpoint request timed out. Please make sure the endpoint response is within 1 minute and retry.
```

Testing again and watching the logs, it seems like this is actually a timeout. The activity fails before the fastapi app finishes booting up!

This may resolve the issue by moving the migrations after boot up, so that Fast API can respond in time to prevent the timeout.