### PR TITLE
Add get_secret() method to AzureCredentialManager.

### DIFF
--- a/phdi/cloud/azure.py
+++ b/phdi/cloud/azure.py
@@ -2,6 +2,7 @@ import json
 
 from phdi.cloud.core import BaseCredentialManager, BaseCloudStorageConnection
 from azure.core.credentials import AccessToken
+from azure.keyvault.secrets import SecretClient
 from azure.identity import DefaultAzureCredential
 from azure.storage.blob import ContainerClient, BlobServiceClient
 from datetime import datetime, timezone
@@ -25,7 +26,7 @@ class AzureCredentialManager(BaseCredentialManager):
     def access_token(self) -> AccessToken:
         return self.__access_token
 
-    def __init__(self, resource_location: str, scope: str = None):
+    def __init__(self, resource_location: str = None, scope: str = None):
         """
         Creates a new AzureCredentialManager object.
 
@@ -78,6 +79,23 @@ class AzureCredentialManager(BaseCredentialManager):
         except AttributeError:
             # access_token not set
             return True
+
+    def get_secret(self, secret_name: str, key_vault_name: str) -> str:
+        """
+        Get the value of a secret from an Azure key vault given the names of the vault 
+        and the secret.
+
+        :param secret_name: The name of the secret whose value should be retrieved from 
+            the key vault.
+        :param key_vault_name: The name of the key vault where the secret is stored.
+        :return: The value of the secret specified by secret_name.
+        """
+
+        vault_url = f"https://{key_vault_name}.vault.azure.net"
+        secret_client = SecretClient(
+            vault_url=vault_url, credential=self.get_credential_object()
+        )
+        return secret_client.get_secret(secret_name).value
 
 
 class AzureCloudContainerConnection(BaseCloudStorageConnection):

--- a/phdi/cloud/azure.py
+++ b/phdi/cloud/azure.py
@@ -82,10 +82,10 @@ class AzureCredentialManager(BaseCredentialManager):
 
     def get_secret(self, secret_name: str, key_vault_name: str) -> str:
         """
-        Get the value of a secret from an Azure key vault given the names of the vault 
+        Get the value of a secret from an Azure key vault given the names of the vault
         and the secret.
 
-        :param secret_name: The name of the secret whose value should be retrieved from 
+        :param secret_name: The name of the secret whose value should be retrieved from
             the key vault.
         :param key_vault_name: The name of the key vault where the secret is stored.
         :return: The value of the secret specified by secret_name.

--- a/poetry.lock
+++ b/poetry.lock
@@ -39,6 +39,14 @@ tests = ["attrs[tests-no-zope]", "zope.interface"]
 tests-no-zope = ["cloudpickle", "cloudpickle", "hypothesis", "hypothesis", "mypy (>=0.971,<0.990)", "mypy (>=0.971,<0.990)", "pympler", "pympler", "pytest (>=4.3.0)", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-mypy-plugins", "pytest-xdist[psutil]", "pytest-xdist[psutil]"]
 
 [[package]]
+name = "azure-common"
+version = "1.1.28"
+description = "Microsoft Azure Client Library for Python (Common)"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "azure-core"
 version = "1.26.3"
 description = "Microsoft Azure Core Library for Python"
@@ -68,6 +76,20 @@ cryptography = ">=2.5"
 msal = ">=1.12.0,<2.0.0"
 msal-extensions = ">=0.3.0,<2.0.0"
 six = ">=1.12.0"
+
+[[package]]
+name = "azure-keyvault-secrets"
+version = "4.7.0"
+description = "Microsoft Azure Key Vault Secrets Client Library for Python"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+azure-common = ">=1.1,<2.0"
+azure-core = ">=1.24.0,<2.0.0"
+isodate = ">=0.6.1"
+typing-extensions = ">=4.0.1"
 
 [[package]]
 name = "azure-storage-blob"
@@ -1214,7 +1236,7 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "1e9043f9e56d7faf961048cb1d02b10ddd22731e2851296038ef0f8c46da943c"
+content-hash = "0495b184cb7de5d62bf4d8db43353e7e1777ae3170410b74222f444a3ea6b8fe"
 
 [metadata.files]
 antlr4-python3-runtime = [
@@ -1228,6 +1250,10 @@ attrs = [
     {file = "attrs-22.2.0-py3-none-any.whl", hash = "sha256:29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836"},
     {file = "attrs-22.2.0.tar.gz", hash = "sha256:c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99"},
 ]
+azure-common = [
+    {file = "azure-common-1.1.28.zip", hash = "sha256:4ac0cd3214e36b6a1b6a442686722a5d8cc449603aa833f3f0f40bda836704a3"},
+    {file = "azure_common-1.1.28-py2.py3-none-any.whl", hash = "sha256:5c12d3dcf4ec20599ca6b0d3e09e86e146353d443e7fcc050c9a19c1f9df20ad"},
+]
 azure-core = [
     {file = "azure-core-1.26.3.zip", hash = "sha256:acbd0daa9675ce88623da35c80d819cdafa91731dee6b2695c64d7ca9da82db4"},
     {file = "azure_core-1.26.3-py3-none-any.whl", hash = "sha256:f7bad0a7b4d800d6e73733ea7e13a616016221ac111ff9a344fe4cba41e51bbe"},
@@ -1235,6 +1261,10 @@ azure-core = [
 azure-identity = [
     {file = "azure-identity-1.12.0.zip", hash = "sha256:7f9b1ae7d97ea7af3f38dd09305e19ab81a1e16ab66ea186b6579d85c1ca2347"},
     {file = "azure_identity-1.12.0-py3-none-any.whl", hash = "sha256:2a58ce4a209a013e37eaccfd5937570ab99e9118b3e1acf875eed3a85d541b92"},
+]
+azure-keyvault-secrets = [
+    {file = "azure-keyvault-secrets-4.7.0.zip", hash = "sha256:77ee2534ba651a1f306c85d7b505bc3ccee8fea77450ebafafc26aec16e5445d"},
+    {file = "azure_keyvault_secrets-4.7.0-py3-none-any.whl", hash = "sha256:a16c7e6dfa9cba68892bb6fcb905bf2e2ec1f2a6dc05522b61df79621e050901"},
 ]
 azure-storage-blob = [
     {file = "azure-storage-blob-12.15.0.zip", hash = "sha256:f8b8d582492740ab16744455408342fb8e4c8897b64a8a3fc31743844722c2f2"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ detect-delimiter = "^0.1.1"
 psycopg2-binary = "^2.9.5" 
 sqlalchemy = "^2.0.0"
 matplotlib = "^3.7.1"
+azure-keyvault-secrets = "^4.7.0"
 
 [tool.poetry.dev-dependencies]
 pdoc = "^13.0.0"

--- a/tests/cloud/test_cloud.py
+++ b/tests/cloud/test_cloud.py
@@ -161,14 +161,16 @@ def test_azure_need_new_token_without_token():
     cred_manager = AzureCredentialManager("https://some-url")
     assert cred_manager._need_new_token()
 
+
 @mock.patch("phdi.cloud.azure.SecretClient")
 @mock.patch("phdi.cloud.azure.DefaultAzureCredential")
-def test_azure_credential_manager_get_secret(patched_az_creds, patched_az_secret_client):
-    
+def test_azure_credential_manager_get_secret(
+    patched_az_creds, patched_az_secret_client
+):
     # Set dummy values for key vault name and secret name.
     key_vault_name = "some-key-vault"
     secret_name = "some-secret"
-    
+
     # Mock SecretClient with appropriate return value.
     secret_object = mock.Mock()
     secret_object.value = "some-secret-value"
@@ -177,9 +179,8 @@ def test_azure_credential_manager_get_secret(patched_az_creds, patched_az_secret
     patched_az_secret_client.return_value = secret_client
     cred_manager = AzureCredentialManager()
     assert cred_manager.get_secret(key_vault_name, secret_name) == secret_object.value
-    
-    
-    
+
+
 @mock.patch("phdi.cloud.gcp.google.auth.transport.requests.Request")
 @mock.patch("phdi.cloud.gcp.google.auth.default")
 def test_gcp_credential_manager(mock_gcp_creds, mock_gcp_requests):

--- a/tests/cloud/test_cloud.py
+++ b/tests/cloud/test_cloud.py
@@ -161,7 +161,25 @@ def test_azure_need_new_token_without_token():
     cred_manager = AzureCredentialManager("https://some-url")
     assert cred_manager._need_new_token()
 
-
+@mock.patch("phdi.cloud.azure.SecretClient")
+@mock.patch("phdi.cloud.azure.DefaultAzureCredential")
+def test_azure_credential_manager_get_secret(patched_az_creds, patched_az_secret_client):
+    
+    # Set dummy values for key vault name and secret name.
+    key_vault_name = "some-key-vault"
+    secret_name = "some-secret"
+    
+    # Mock SecretClient with appropriate return value.
+    secret_object = mock.Mock()
+    secret_object.value = "some-secret-value"
+    secret_client = mock.Mock()
+    secret_client.get_secret.return_value = secret_object
+    patched_az_secret_client.return_value = secret_client
+    cred_manager = AzureCredentialManager()
+    assert cred_manager.get_secret(key_vault_name, secret_name) == secret_object.value
+    
+    
+    
 @mock.patch("phdi.cloud.gcp.google.auth.transport.requests.Request")
 @mock.patch("phdi.cloud.gcp.google.auth.default")
 def test_gcp_credential_manager(mock_gcp_creds, mock_gcp_requests):


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR adds a `.get_secret()` method to the AzureCredentialManager class that can read a secret from an Azure Key Vault given the name of a vault and the name of the secret.


[//]: # (PR title: Remember to name your PR descriptively!)