### PR TITLE
Update Dockerfiles to slim-bullseye

### DIFF
--- a/containers/alerts/Dockerfile
+++ b/containers/alerts/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim
 
 WORKDIR /code
 

--- a/containers/alerts/Dockerfile
+++ b/containers/alerts/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-buster
+FROM python:3.10-slim-bullseye
 
 WORKDIR /code
 

--- a/containers/ingestion/Dockerfile
+++ b/containers/ingestion/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim
 
 WORKDIR /code
 

--- a/containers/ingestion/Dockerfile
+++ b/containers/ingestion/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-buster
+FROM python:3.10-slim-bullseye
 
 WORKDIR /code
 

--- a/containers/message-parser/Dockerfile
+++ b/containers/message-parser/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim
 
 WORKDIR /code
 

--- a/containers/message-parser/Dockerfile
+++ b/containers/message-parser/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-buster
+FROM python:3.10-slim-bullseye
 
 WORKDIR /code
 

--- a/containers/record-linkage/Dockerfile
+++ b/containers/record-linkage/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim
 
 WORKDIR /code
 

--- a/containers/record-linkage/Dockerfile
+++ b/containers/record-linkage/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-buster
+FROM python:3.10-slim-bullseye
 
 WORKDIR /code
 

--- a/containers/tabulation/Dockerfile
+++ b/containers/tabulation/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim
 
 WORKDIR /code
 

--- a/containers/tabulation/Dockerfile
+++ b/containers/tabulation/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-buster
+FROM python:3.10-slim-bullseye
 
 WORKDIR /code
 

--- a/containers/validation/Dockerfile
+++ b/containers/validation/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim
 
 WORKDIR /code
 

--- a/containers/validation/Dockerfile
+++ b/containers/validation/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-buster
+FROM python:3.10-slim-bullseye
 
 WORKDIR /code
 

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -4,6 +4,7 @@ import psycopg2
 import json
 
 
+# test change
 class DIBBsConnectorClient(BaseMPIConnectorClient):
     """
     Represents a Postgres-specific Master Patient Index (MPI) connector client for the

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -4,7 +4,6 @@ import psycopg2
 import json
 
 
-# test change
 class DIBBsConnectorClient(BaseMPIConnectorClient):
     """
     Represents a Postgres-specific Master Patient Index (MPI) connector client for the


### PR DESCRIPTION
# PULL REQUEST

## Summary
Update dockerfiles to slim-bullseye, as there's a vulnerability associated with slim-buster.

## Related Issue
Fixes #364 

## Additional Information
n/a

[//]: # (PR title: Remember to name your PR descriptively!)