### PR TITLE
Reference postgres vars properly

### DIFF
--- a/phdi/linkage/__init__.py
+++ b/phdi/linkage/__init__.py
@@ -24,8 +24,6 @@ from phdi.linkage.link import (
     read_linkage_config,
     link_record_against_mpi,
     add_person_resource,
-    _compare_address_elements,
-    _compare_name_elements,
 )
 
 from phdi.linkage.core import BaseMPIConnectorClient
@@ -59,6 +57,4 @@ __all__ = [
     "DIBBsConnectorClient",
     "link_record_against_mpi",
     "add_person_resource",
-    "_compare_address_elements",
-    "_compare_name_elements",
 ]

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -59,6 +59,8 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
             raise ValueError("`block_vals` cannot be empty.")
 
         # Connect to MPI
+        db_cursor = None
+        db_connection = None
         try:
             with psycopg2.connect(
                 database=self.database,
@@ -80,8 +82,10 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
 
         finally:
             # Close cursor and connection
-            db_cursor.close()
-            db_connection.close()
+            if db_cursor is not None:
+                db_cursor.close()
+            if db_connection is not None:
+                db_connection.close()
 
         # Set up blocked data by adding column headers as 1st row of LoL
         # TODO: Replace indices with column names for reability
@@ -108,6 +112,8 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
           found in the MPI, defaults to None.
         """
         # Connect to MPI
+        db_cursor = None
+        db_connection = None
         try:
             with psycopg2.connect(
                 database=self.database,
@@ -157,8 +163,10 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
             raise ValueError(f"{error}")
 
         finally:
-            db_cursor.close()
-            db_connection.close()
+            if db_cursor is not None:
+                db_cursor.close()
+            if db_connection is not None:
+                db_connection.close()
 
         return person_id[0][0]
 

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -1,15 +1,22 @@
 from typing import List, Dict, Union
 from phdi.linkage.core import BaseMPIConnectorClient
 import psycopg2
+from psycopg2.extensions import connection, cursor
 import json
 
 
 class DIBBsConnectorClient(BaseMPIConnectorClient):
     """
-    Represents a Postgres-specific Master Patient Index (MPI) connector client for the
-    DIBBs implementation of the record linkage building block. Callers should use the
-    provided interface functions (e.g., block_vals) to interact with the underlying
-    vendor-specific client property.
+    Represents a Postgres-specific Master Patient Index (MPI) connector
+    client for the DIBBs implementation of the record linkage building
+    block. Callers should use the provided interface functions (e.g.,
+    block_vals) to interact with the underlying vendor-specific client
+    property.
+
+    When instantiating a DIBBSConnectorClient, the connection to the
+    database is automatically tested using the provided parameters.
+    A refused, timed-out, or otherwise error-ed connection will raise
+    an immediate exception.
     """
 
     def __init__(
@@ -40,6 +47,27 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
             "state": """$.address[*].state""",
             "zip": """$.address[*].postalCode""",
         }
+        db_conn = self.get_connection()
+        self._close_connections(db_conn=db_conn)
+
+    def get_connection(self) -> Union[connection, None]:
+        """
+        Simple method for initiating a connection to the database specified
+        by the parameters given to the class' instantiation.
+        """
+        db_conn = None
+        try:
+            db_conn = psycopg2.connect(
+                database=self.database,
+                user=self.user,
+                password=self.password,
+                host=self.host,
+                port=self.port,
+            )
+        except Exception as error:  # pragma: no cover
+            raise ValueError(f"{error}")
+        finally:
+            return db_conn
 
     def block_data(self, block_vals: Dict) -> List[list]:
         """
@@ -58,21 +86,14 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
         if len(block_vals) == 0:
             raise ValueError("`block_vals` cannot be empty.")
 
-        # Connect to MPI
         db_cursor = None
-        db_connection = None
+        db_conn = None
         try:
-            with psycopg2.connect(
-                database=self.database,
-                user=self.user,
-                password=self.password,
-                host=self.host,
-                port=self.port,
-            ) as db_connection:
-                with db_connection.cursor() as db_cursor:
+            # Use context manager to handle commits and transactions
+            with self.get_connection() as db_conn:
+                with db_conn.cursor() as db_cursor:
                     # Generate raw SQL query
                     query = self._generate_block_query(block_vals)
-
                     # Execute query
                     db_cursor.execute(query)
                     blocked_data = [list(row) for row in db_cursor.fetchall()]
@@ -81,11 +102,7 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
             raise ValueError(f"{error}")
 
         finally:
-            # Close cursor and connection
-            if db_cursor is not None:
-                db_cursor.close()
-            if db_connection is not None:
-                db_connection.close()
+            self._close_connections(db_conn=db_conn, db_cursor=db_cursor)
 
         # Set up blocked data by adding column headers as 1st row of LoL
         # TODO: Replace indices with column names for reability
@@ -111,18 +128,12 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
         :param person_id: The personID matching the patient record if a match has been
           found in the MPI, defaults to None.
         """
-        # Connect to MPI
         db_cursor = None
-        db_connection = None
+        db_conn = None
         try:
-            with psycopg2.connect(
-                database=self.database,
-                user=self.user,
-                password=self.password,
-                host=self.host,
-                port=self.port,
-            ) as db_connection:
-                with db_connection.cursor() as db_cursor:
+            # Use context manager to handle commits and transactions
+            with self.get_connection() as db_conn:
+                with db_conn.cursor() as db_cursor:
                     # Match has been found
                     if person_id is not None:
                         # Insert into patient table
@@ -157,16 +168,12 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
                         )
 
                     db_cursor.execute(insert_patient_table)
-                    db_connection.commit()
 
         except Exception as error:  # pragma: no cover
             raise ValueError(f"{error}")
 
         finally:
-            if db_cursor is not None:
-                db_cursor.close()
-            if db_connection is not None:
-                db_connection.close()
+            self._close_connections(db_conn=db_conn, db_cursor=db_cursor)
 
         return person_id[0][0]
 
@@ -236,3 +243,20 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
 
         query = select_query + f" FROM {self.patient_table}" + block_query + ";"
         return query
+
+    def _close_connections(
+        self,
+        db_conn: Union[connection, None] = None,
+        db_cursor: Union[cursor, None] = None,
+    ) -> None:
+        """
+        Simple helper method to close passed connections. If a context manager's
+        `with` block successfully executes, the connection will already be
+        committed and closed, so the resource will already be released. However,
+        if the `with` block terminates before safe execution, this function
+        allows a `finally` clause to succinctly clean up all open connections.
+        """
+        if db_cursor is not None:
+            db_cursor.close()
+        if db_conn is not None:
+            db_conn.close()

--- a/tests/linkage/test_linkage.py
+++ b/tests/linkage/test_linkage.py
@@ -30,12 +30,12 @@ from phdi.linkage import (
     read_linkage_config,
     link_record_against_mpi,
     add_person_resource,
-    _compare_address_elements,
-    _compare_name_elements,
 )
 from phdi.linkage.link import (
     _match_within_block_cluster_ratio,
     _map_matches_to_record_ids,
+    _compare_address_elements,
+    _compare_name_elements,
 )
 from phdi.linkage import DIBBsConnectorClient
 

--- a/tests/linkage/test_postgres_mpi_connector.py
+++ b/tests/linkage/test_postgres_mpi_connector.py
@@ -2,13 +2,12 @@ from phdi.linkage.postgres import DIBBsConnectorClient
 import pathlib
 import pytest
 import json
-import psycopg2
 import copy
 
 
 def test_postgres_connection():
     postgres_client = create_valid_mpi_client()
-    postgres_client.connection = open_mpi_connection(postgres_client)
+    postgres_client.connection = postgres_client.get_connection()
     postgres_client.cursor = postgres_client.connection.cursor()
 
     assert postgres_client.connection is not None
@@ -88,7 +87,7 @@ def test_block_data():
             '{json.dumps(patient_resource)}');"""
         ),
     }
-    postgres_client.connection = open_mpi_connection(postgres_client)
+    postgres_client.connection = postgres_client.get_connection()
     postgres_client.cursor = postgres_client.connection.cursor()
 
     for command, statement in funcs.items():
@@ -110,7 +109,7 @@ def test_block_data():
     assert type(blocked_data[1]) is list
 
     # Clean up
-    postgres_client.connection = open_mpi_connection(postgres_client)
+    postgres_client.connection = postgres_client.get_connection()
     postgres_client.cursor = postgres_client.connection.cursor()
     postgres_client.cursor.execute(
         f"DROP TABLE IF EXISTS {postgres_client.patient_table}"
@@ -182,7 +181,7 @@ def test_dibbs_blocking():
             '{json.dumps(patient_resource_2)}');"""
         ),
     }
-    postgres_client.connection = open_mpi_connection(postgres_client)
+    postgres_client.connection = postgres_client.get_connection()
     postgres_client.cursor = postgres_client.connection.cursor()
 
     for command, statement in funcs.items():
@@ -244,7 +243,7 @@ def test_dibbs_blocking():
 
 def test_insert_match_patient():
     postgres_client = create_valid_mpi_client()
-    postgres_client.connection = open_mpi_connection(postgres_client)
+    postgres_client.connection = postgres_client.get_connection()
     postgres_client.cursor = postgres_client.connection.cursor()
 
     raw_bundle = json.load(
@@ -328,7 +327,7 @@ def test_insert_match_patient():
         person_id=person_id,
     )
     # Re-open connection for next test
-    postgres_client.connection = open_mpi_connection(postgres_client)
+    postgres_client.connection = postgres_client.get_connection()
     postgres_client.cursor = postgres_client.connection.cursor()
 
     # Extract all data
@@ -346,7 +345,7 @@ def test_insert_match_patient():
     assert data[-1][1] == person_id
 
     # Re-open connection for next test
-    postgres_client.connection = open_mpi_connection(postgres_client)
+    postgres_client.connection = postgres_client.get_connection()
     postgres_client.cursor = postgres_client.connection.cursor()
 
     postgres_client.cursor.execute(f"SELECT * from {postgres_client.person_table}")
@@ -357,7 +356,7 @@ def test_insert_match_patient():
     assert len(data) == 3
 
     # Re-open connection for next test
-    postgres_client.connection = open_mpi_connection(postgres_client)
+    postgres_client.connection = postgres_client.get_connection()
     postgres_client.cursor = postgres_client.connection.cursor()
 
     # Match has not been found, i.e., new patient and person added, new person_id is
@@ -373,7 +372,7 @@ def test_insert_match_patient():
     )
 
     # Re-open connection for next test
-    postgres_client.connection = open_mpi_connection(postgres_client)
+    postgres_client.connection = postgres_client.get_connection()
     postgres_client.cursor = postgres_client.connection.cursor()
 
     postgres_client.cursor.execute(f"SELECT * from {postgres_client.patient_table}")
@@ -385,7 +384,7 @@ def test_insert_match_patient():
     assert data[-1][-1]["address"] == patient_resource["address"]
 
     # Re-open connection for next test
-    postgres_client.connection = open_mpi_connection(postgres_client)
+    postgres_client.connection = postgres_client.get_connection()
     postgres_client.cursor = postgres_client.connection.cursor()
 
     # Assert new patient record was added to person table with new person_id
@@ -396,7 +395,7 @@ def test_insert_match_patient():
     assert data[-1][0] is not None
 
     # Clean up
-    postgres_client.connection = open_mpi_connection(postgres_client)
+    postgres_client.connection = postgres_client.get_connection()
     postgres_client.cursor = postgres_client.connection.cursor()
     postgres_client.cursor.execute(
         f"DROP TABLE IF EXISTS {postgres_client.patient_table}"
@@ -419,14 +418,4 @@ def create_valid_mpi_client():
         port="5432",
         patient_table="test_patient_mpi",
         person_table="test_person_mpi",
-    )
-
-
-def open_mpi_connection(postgres_client: DIBBsConnectorClient):
-    return psycopg2.connect(
-        database=postgres_client.database,
-        user=postgres_client.user,
-        password=postgres_client.password,
-        host=postgres_client.host,
-        port=postgres_client.port,
     )


### PR DESCRIPTION
# Postgres vars fast fix

## Summary
If the connection to the MPI is refused or otherwise errors out, the python code proceeds to the finally block without having correctly initialized the `db_cursor` or the `db_connection`, leading to a `variable referenced before assignment` error (which I saw in my linkage endpoint PR). This PR corrects that by defaulting each of the variables to `None` before its invoked so that the finally block can proceed correctly

## Related Issue
Fixes not a github issue, but a bug I found
