### PR TITLE
Fix issues found by FHIR Path and FHIR Converter

### DIFF
--- a/containers/fhir-converter/Templates/eCR/Entry/Problem/_entry_act_entryRelationship.liquid
+++ b/containers/fhir-converter/Templates/eCR/Entry/Problem/_entry_act_entryRelationship.liquid
@@ -1,5 +1,9 @@
-{% if probRelationship.observation.code.codeSystem == "2.16.840.1.113883.6.96" and probRelationship.observation.code.code == "64572001" and probRelationship.observation.value.code and probRelationship.observation.value.value.code != "NA" -%}
-    {% assign conditionId = probRelationship.observation | to_json_string | generate_uuid -%}
-    {% include 'Resource/Condition' conditionEntry: probRelationship.observation, ID: conditionId -%}
-    {% include 'Reference/Condition/Subject' ID: conditionId, REF: fullPatientId -%}
+{% if probRelationship.observation.code.codeSystem == "2.16.840.1.113883.6.96" or probRelationship.observation.code.codeSystem == "2.16.840.1.113883.6.1" or probRelationship.observation.code.translation.codeSystem == "2.16.840.1.113883.6.96" or probRelationship.observation.code.translation.codeSystem == "2.16.840.1.113883.6.1" -%}
+    {% if probRelationship.observation.code.code == "64572001" or probRelationship.observation.code.code == "55607006" or probRelationship.observation.code.translation.code == "64572001" or probRelationship.observation.code.translation.code == "55607006" -%}
+        {% if probRelationship.observation.value.code and probRelationship.observation.value.value.code != "NA" -%}
+            {% assign conditionId = probRelationship.observation | to_json_string | generate_uuid -%}
+            {% include 'Resource/Condition' conditionEntry: probRelationship.observation, ID: conditionId -%}
+            {% include 'Reference/Condition/Subject' ID: conditionId, REF: fullPatientId -%}
+        {% endif -%}
+    {% endif -%}
 {% endif -%}

--- a/containers/fhir-converter/Templates/eCR/Entry/SocialHistory/_entry.liquid
+++ b/containers/fhir-converter/Templates/eCR/Entry/SocialHistory/_entry.liquid
@@ -1,3 +1,8 @@
-{% assign observationId = entry.observation | to_json_string | generate_uuid -%}
-{% include 'Resource/Observation' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
-{% include 'Reference/Observation/Subject' ID: observationId, REF: fullPatientId -%}
+{% if entry.observation -%}
+    {% if entry.observation.code.nullFlavor or entry.observation.value.nullFlavor -%}
+    {% else -%}
+        {% assign observationId = entry.observation | to_json_string | generate_uuid -%}
+        {% include 'Resource/Observation' observationCategory: 'social-history', observationEntry: entry.observation, ID: observationId -%}
+        {% include 'Reference/Observation/Subject' ID: observationId, REF: fullPatientId -%}
+    {% endif -%}
+{% endif -%}

--- a/containers/fhir-converter/Templates/eCR/Entry/VitalSign/_entry_organizer_component.liquid
+++ b/containers/fhir-converter/Templates/eCR/Entry/VitalSign/_entry_organizer_component.liquid
@@ -1,3 +1,8 @@
-{% assign observationId = component.observation | to_json_string | generate_uuid -%}
-{% include 'Resource/Observation' observationCategory: 'vital-signs', observationEntry: component.observation, ID: observationId -%}
-{% include 'Reference/Observation/Subject' ID: observationId, REF: fullPatientId -%}
+{% if component.observation -%}
+    {% if component.observation.code.nullFlavor or component.observation.value.nullFlavor -%}
+    {% else -%}
+        {% assign observationId = component.observation | to_json_string | generate_uuid -%}
+        {% include 'Resource/Observation' observationCategory: 'vital-signs', observationEntry: component.observation, ID: observationId -%}
+        {% include 'Reference/Observation/Subject' ID: observationId, REF: fullPatientId -%}
+    {% endif -%}
+{% endif -%}

--- a/containers/fhir-converter/Templates/eCR/Header.liquid
+++ b/containers/fhir-converter/Templates/eCR/Header.liquid
@@ -13,7 +13,7 @@
     {% assign locationId = msg.ClinicalDocument.componentOf.encompassingEncounter.location.healthCareFacility | to_json_string | generate_uuid -%}
     {% include 'Resource/LocationHealthCareFacility' location: msg.ClinicalDocument.componentOf.encompassingEncounter.location.healthCareFacility ID: locationId -%}
     {% assign fullLocationId = locationId | prepend: 'Location/' -%}
-    {% include 'Reference/Encounter/Location_Location' ID: encounterId, REF: fullLocationId -%}
+    {% include 'Reference/Encounter/Location_Location' ID: encounterId, REF: fullLocationId, LOC: msg.ClinicalDocument.componentOf.encompassingEncounter.location.healthCareFacility -%}
   {% endif -%}
 {% endif -%}
 

--- a/containers/fhir-converter/Templates/eCR/Header.liquid
+++ b/containers/fhir-converter/Templates/eCR/Header.liquid
@@ -3,13 +3,10 @@
 {% include 'Resource/Composition' composition: msg.ClinicalDocument, practitionerId: practitionerId, ID: compositionId -%}
 {% include 'Reference/Composition/Subject' ID: compositionId, REF: fullPatientId -%}
 
-{% if msg.ClinicalDocument.componentOf.encompassingEncounter.responsibleParty.assignedEntity -%}
-  {% include 'Resource/PractitionerResponsibleParty' practitioner: msg.ClinicalDocument.componentOf.encompassingEncounter.responsibleParty.assignedEntity ID: practitionerId -%}
-{% endif -%}
-
 {% if msg.ClinicalDocument.componentOf.encompassingEncounter -%}
   {% assign encounterId = msg.ClinicalDocument.componentOf.encompassingEncounter | to_json_string | generate_uuid -%}
   {% include 'Resource/Encounter' encounter: msg.ClinicalDocument.componentOf.encompassingEncounter ID: encounterId -%}
+  {% include 'Reference/Encounter/Subject' ID: encounterId, REF: fullPatientId -%}
   {% assign fullEncounterId = encounterId | prepend: 'Encounter/' -%}
   {% include 'Reference/Composition/Encounter' ID: compositionId, REF: fullEncounterId -%}
   {% if msg.ClinicalDocument.componentOf.encompassingEncounter.location.healthCareFacility -%}
@@ -18,6 +15,12 @@
     {% assign fullLocationId = locationId | prepend: 'Location/' -%}
     {% include 'Reference/Encounter/Location_Location' ID: encounterId, REF: fullLocationId -%}
   {% endif -%}
+{% endif -%}
+
+{% if msg.ClinicalDocument.componentOf.encompassingEncounter.responsibleParty.assignedEntity -%}
+  {% include 'Resource/PractitionerResponsibleParty' practitioner: msg.ClinicalDocument.componentOf.encompassingEncounter.responsibleParty.assignedEntity ID: practitionerId -%}
+  {% assign fullPractitionerId = practitionerId | prepend: 'Practitioner/' -%}
+  {% include 'Reference/Encounter/Participant_ResponsibleProvider' ID: encounterId, REF: fullPractitionerId -%}
 {% endif -%}
 
 {% if msg.ClinicalDocument.section.code.code and msg.ClinicalDocument.section.code.code == "88085-6" -%}
@@ -44,10 +47,10 @@
 {% endif -%}
 
 {% if msg.ClinicalDocument.custodian.assignedCustodian.representedCustodianOrganization.name._ -%}
-  {% assign organizationId = msg.ClinicalDocument.custodian.assignedCustodian.representedCustodianOrganization | to_json_string | generate_uuid -%}
-  {% include 'Resource/Organization' organization: msg.ClinicalDocument.custodian.assignedCustodian.representedCustodianOrganization ID: organizationId -%}
-  {% assign fullOrganizationId = organizationId | prepend: 'Organization/' -%}
-  {% include 'Reference/Composition/Custodian' ID: compositionId, REF: fullOrganizationId -%}
+  {% evaluate custId using 'Utils/GenerateId' obj: msg.ClinicalDocument.custodian.assignedCustodian.representedCustodianOrganization -%}
+  {% include 'Resource/Organization' organization: msg.ClinicalDocument.custodian.assignedCustodian.representedCustodianOrganization ID: custId -%}
+  {% assign fullCustId = custId | prepend: 'Organization/' -%}
+  {% include 'Reference/Composition/Custodian' ID: compositionId, REF: fullCustId -%}
 {% endif -%}
 
 {% assign authors = msg.ClinicalDocument.author | to_array -%}
@@ -59,20 +62,28 @@
     {% include 'Reference/Composition/Author' ID: compositionId, REF: fullDeviceId -%}
   {% endif -%}
 
-  {% if author.assignedAuthor.representedOrganization -%}
-    {% assign organizationId = author.assignedAuthor.representedOrganization | to_json_string | generate_uuid -%}
-    {% include 'Resource/Organization' organization: author.assignedAuthor.representedOrganization ID: organizationId -%}
-    {% assign fullOrganizationId = organizationId | prepend: 'Organization/' -%}
-    {% if deviceId -%}
-      {% include 'Reference/Device/Owner' ID: deviceId, REF: fullOrganizationId -%}
+  {% if author.assignedAuthor.representedOrganization and author.assignedAuthor.representedOrganization.name and author.assignedAuthor.representedOrganization.name._ -%}
+    {% if author.assignedAuthor.assignedPerson and author.assignedAuthor.assignedPerson.name and author.assignedAuthor.assignedPerson.name.given.first._  -%}
+      {% evaluate authorId using 'Utils/GenerateId' obj: author.assignedAuthor -%}
+      {% include 'Resource/Practitioner' practitioner: author.assignedAuthor ID: authorId -%}
+      {% assign fullAuthorId = authorId | prepend: 'Practitioner/' -%}
+      {% include 'Reference/Composition/Author' ID: compositionId, REF: fullAuthorId -%}
+      {% if deviceId -%}
+        {% include 'Reference/Device/Owner' ID: deviceId, REF: fullAuthorId -%}
+      {% endif -%}
+    {% else -%}
+      {% evaluate authorOrgId using 'Utils/GenerateId' obj: author.assignedAuthor.representedOrganization -%}
+      {% include 'Resource/Organization' organization: author.assignedAuthor.representedOrganization ID: authorOrgId -%}
+      {% assign fullAuthoerOrgId = AuthorOrgId | prepend: 'Organization/' -%}
+      {% if deviceId -%}
+        {% include 'Reference/Device/Owner' ID: deviceId, REF: fullAuthoerOrgId -%}
+      {% endif -%}
     {% endif -%}
-  {% endif -%}
-
-  {% if author.assignedAuthor.assignedPerson -%}
-    {% evaluate practitionerId using 'Utils/GenerateId' obj: author.assignedAuthor -%}
-    {% include 'Resource/Practitioner' practitioner: author.assignedAuthor ID: practitionerId -%}
-    {% assign fullPractitionerId = practitionerId | prepend: 'Practitioner/' -%}
-    {% include 'Reference/Composition/Author' ID: compositionId, REF: fullPractitionerId -%}
+  {% elsif author.assignedAuthor.assignedPerson and author.assignedAuthor.assignedPerson.name and author.assignedAuthor.assignedPerson.name.given.first._ -%}
+    {% evaluate authorId using 'Utils/GenerateId' obj: author.assignedAuthor -%}
+    {% include 'Resource/Practitioner' practitioner: author.assignedAuthor ID: authorId -%}
+    {% assign fullAuthorId = authorId | prepend: 'Practitioner/' -%}
+    {% include 'Reference/Composition/Author' ID: compositionId, REF: fullAuthorId -%}
   {% endif -%}
 {% endfor -%}
 

--- a/containers/fhir-converter/Templates/eCR/Header.liquid
+++ b/containers/fhir-converter/Templates/eCR/Header.liquid
@@ -74,9 +74,9 @@
     {% else -%}
       {% evaluate authorOrgId using 'Utils/GenerateId' obj: author.assignedAuthor.representedOrganization -%}
       {% include 'Resource/Organization' organization: author.assignedAuthor.representedOrganization ID: authorOrgId -%}
-      {% assign fullAuthoerOrgId = AuthorOrgId | prepend: 'Organization/' -%}
+      {% assign fullAuthorOrgId = AuthorOrgId | prepend: 'Organization/' -%}
       {% if deviceId -%}
-        {% include 'Reference/Device/Owner' ID: deviceId, REF: fullAuthoerOrgId -%}
+        {% include 'Reference/Device/Owner' ID: deviceId, REF: fullAuthorOrgId -%}
       {% endif -%}
     {% endif -%}
   {% elsif author.assignedAuthor.assignedPerson and author.assignedAuthor.assignedPerson.name and author.assignedAuthor.assignedPerson.name.given.first._ -%}

--- a/containers/fhir-converter/Templates/eCR/Reference/Encounter/_Location_Location.liquid
+++ b/containers/fhir-converter/Templates/eCR/Reference/Encounter/_Location_Location.liquid
@@ -5,10 +5,31 @@
         "location":
         [
             {
+                {% assign ids = LOC.id | to_array -%}
+                {% if ids.first and ids.first.root -%}
+                    "id": "{{ids.first.root}}",
+                {% else -%}
+                    "id": "None",
+                {% endif -%}
                 "location":
                 {
                     "reference":"{{ REF }}",
+                    {% if LOC.location.name and LOC.location.name._ -%}
+                        "display":"{{ LOC.location.name._ }}",
+                    {% elsif LOC.serviceProviderOrganization and LOC.serviceProviderOrganization.name and LOC.serviceProviderOrganization.name._ -%}
+                        "display":"{{ LOC.serviceProviderOrganization.name._ }}",
+                    {% else -%}
+                        "display": "None",
+                    {% endif -%}
+
                 },
+                {% assign codes = LOC.code | to_array -%}
+                {% if codes.first -%}
+                "extension": [{
+                    "url": "http://build.fhir.org/ig/HL7/case-reporting/StructureDefinition-us-ph-location-definitions.html#Location.type",
+                    "valueCodeableConcept": { {% include 'DataType/CodeableConcept' CodeableConcept: codes.first -%} },
+                },],
+                {% endif -%}
             },
         ],
     },

--- a/containers/fhir-converter/Templates/eCR/Reference/Encounter/_Participant_ResponsibleProvider.liquid
+++ b/containers/fhir-converter/Templates/eCR/Reference/Encounter/_Participant_ResponsibleProvider.liquid
@@ -1,0 +1,26 @@
+{
+    "resource":{
+        "resourceType": "Encounter",
+        "id":"{{ ID }}",
+        "participant":
+        [
+            {
+                "type": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                                "code": "ATND"
+                            },
+
+                        ],
+                    },
+                ],
+                "individual":
+                {
+                    "reference":"{{ REF }}",
+                },
+            },
+        ],
+    },
+},

--- a/containers/fhir-converter/Templates/eCR/Resource/_Composition.liquid
+++ b/containers/fhir-converter/Templates/eCR/Resource/_Composition.liquid
@@ -99,6 +99,14 @@
                                     "valueString" : "{{ component.section.text.content._ }}"
                                 },
                             ],
+                        {% elsif component.section.text and component.section.text.table.tbody.tr.td._ -%}
+                            "extension":
+                            [
+                                {
+                                    "url" : "http://hl7.org/fhir/cda/ccda/StructureDefinition/2.16.840.1.113883.10.20.22.2.12",
+                                    "valueString" : "{{ component.section.text.table.tbody.tr.td._ }}"
+                                },
+                            ],
                         {% endif -%}
                     {% endif -%}
                     "entry": 

--- a/containers/fhir-converter/Templates/eCR/Resource/_Condition.liquid
+++ b/containers/fhir-converter/Templates/eCR/Resource/_Condition.liquid
@@ -47,7 +47,9 @@
             {% endif -%}
         },
         {% if conditionEntry.effectiveTime.low.value -%}
-        "onsetDateTime":"{{ conditionEntry.effectiveTime.low.value | format_as_date_time }}",
+            "onsetDateTime":"{{ conditionEntry.effectiveTime.low.value | format_as_date_time }}",
+        {% elsif conditionEntry.author.time and conditionEntry.author.time.value -%}
+            "onsetDateTime":"{{ conditionEntry.author.time.value | format_as_date_time }}",
         {% endif -%}
         "onsetAge":
         {

--- a/containers/fhir-converter/Templates/eCR/Resource/_LocationHealthCareFacility.liquid
+++ b/containers/fhir-converter/Templates/eCR/Resource/_LocationHealthCareFacility.liquid
@@ -10,14 +10,29 @@
             { {% include 'DataType/IdentifierRoot' Identifier: id -%} },
             {% endfor -%}
         ],
-        "name":"{{ location.location.name._ }}",
+        
+        {% if location.location.name and location.location.name._ -%}
+            "name":"{{ location.location.name._ }}",
+        {% elsif location.serviceProviderOrganization and location.serviceProviderOrganization.name and location.serviceProviderOrganization.name._ -%}
+            "name":"{{ location.serviceProviderOrganization.name._ }}",
+        {% endif -%}
+
+
         "address":
         {
-            {% include 'DataType/Address' Address: location.location.addr -%}
+            {% if location.location.addr and location.location.addr.state._ -%}
+                {% include 'DataType/Address' Address: location.location.addr -%}
+            {% elsif location.serviceProviderOrganization.addr and location.serviceProviderOrganization.addr.state._ -%}
+                {% include 'DataType/Address' Address: location.serviceProviderOrganization.addr -%}
+            {% endif -%}
         },
         "telecom":
         [
             {% assign telecoms = location.location.telecom | to_array -%}
+            {% if telecoms.first.value -%}
+            {% else -%}
+                {% assign telecoms = location.serviceProviderOrganization.telecom | to_array -%}
+            {% endif -%}
             {% for telecom in telecoms -%}
             { {% include 'DataType/ContactPoint' ContactPoint: telecom -%} },
             {% endfor -%}

--- a/containers/fhir-converter/Templates/eCR/Resource/_Practitioner.liquid
+++ b/containers/fhir-converter/Templates/eCR/Resource/_Practitioner.liquid
@@ -3,13 +3,11 @@
     "resource":{
         "resourceType": "Practitioner",
         "id":"{{ ID }}",
-        {% if practitioner.assignedPerson and practitioner.assignedPerson.name and practitioner.assignedPerson.name.given._ -%}
-            {% assign actualPractitioner = practitioner.assignedPerson -%}
+        {% if practitioner.assignedPerson and practitioner.assignedPerson.name and practitioner.assignedPerson.name.given.first._ -%}
             {% assign personNames = practitioner.assignedPerson.name | to_array -%}
             {% assign personType = "PERSON" -%}
         {% endif -%}
         {% if practitioner.representedOrganization and practitioner.representedOrganization.name._ -%}
-            {% assign actualPractitioner = practitioner.representedOrganization -%}
             {% assign orgNames = practitioner.representedOrganization.name | to_array -%}
             {% assign orgType = "ORG" -%}
         {% endif -%}
@@ -31,7 +29,7 @@
         "name":
         [
             {% if personType and personType == "PERSON" -%}
-                {% for personName in names -%}
+                {% for personName in personNames -%}
                 { {% include 'DataType/HumanName' HumanName: personName -%} },
                 {% endfor -%}
             {% endif -%}
@@ -54,7 +52,7 @@
                 {% endfor -%}
             {% endif -%}
             {% if orgType and orgType == "ORG" -%}
-                {% assign addrs = actualPractitioner.addr | to_array -%}
+                {% assign addrs = practitioner.representedOrganization.addr | to_array -%}
                 {% for addr in addrs -%}
                 { {% include 'DataType/Address' Address: addr -%} },
                 {% endfor -%}
@@ -66,10 +64,13 @@
                 {% assign telecoms = practitioner.telecom | to_array -%}
             {% endif -%}
             {% if orgType and orgType == "ORG" -%}
-                {% assign telecoms = actualPractitioner.telecom | to_array -%}
+                {% assign orgTelecoms = practitioner.representedOrganization.telecom | to_array -%}
             {% endif -%}
             
             {% for telecom in telecoms -%}
+            { {% include 'DataType/ContactPoint' ContactPoint: telecom -%} },
+            {% endfor -%}
+            {% for orgTelecom in orgTelecoms -%}
             { {% include 'DataType/ContactPoint' ContactPoint: telecom -%} },
             {% endfor -%}
         ],

--- a/containers/fhir-converter/Templates/eCR/Resource/_PractitionerResponsibleParty.liquid
+++ b/containers/fhir-converter/Templates/eCR/Resource/_PractitionerResponsibleParty.liquid
@@ -3,6 +3,17 @@
     "resource":{
         "resourceType": "Practitioner",
         "id":"{{ ID }}",
+        {% if practitioner.assignedPerson and practitioner.assignedPerson.name and practitioner.assignedPerson.name.given._ -%}
+            {% assign actualPractitioner = practitioner.assignedPerson -%}
+            {% assign personNames = practitioner.assignedPerson.name | to_array -%}
+            {% assign personType = "PERSON" -%}
+        {% endif -%}
+        {% if practitioner.representedOrganization and practitioner.representedOrganization.name._ -%}
+            {% assign actualPractitioner = practitioner.representedOrganization -%}
+            {% assign orgNames = practitioner.representedOrganization.name | to_array -%}
+            {% assign orgType = "ORG" -%}
+        {% endif -%}
+
         "meta":
         {
             "profile":
@@ -19,21 +30,45 @@
         ],
         "name":
         [
-            {% assign names = practitioner.assignedPerson.name | to_array -%}
-            {% for name in names -%}
-            { {% include 'DataType/HumanName' HumanName: name -%} },
-            {% endfor -%}
+            {% if personType and personType == "PERSON" -%}
+                {% for personName in names -%}
+                { {% include 'DataType/HumanName' HumanName: personName -%} },
+                {% endfor -%}
+            {% endif -%}
+            {% if orgType and orgType == "ORG" -%}
+                {% for orgName in orgNames -%}
+                {
+                    "use": "usual",
+                    "text": "{{orgName._}}",
+                },
+                {% endfor -%}
+            {% endif -%}
+
         ],
         "address":
         [
-            {% assign addrs = practitioner.addr | to_array -%}
-            {% for addr in addrs -%}
-            { {% include 'DataType/Address' Address: addr -%} },
-            {% endfor -%}
+            {% if personType and personType == "PERSON" -%}
+                {% assign addrs = practitioner.addr | to_array -%}
+                {% for addr in addrs -%}
+                { {% include 'DataType/Address' Address: addr -%} },
+                {% endfor -%}
+            {% endif -%}
+            {% if orgType and orgType == "ORG" -%}
+                {% assign addrs = actualPractitioner.addr | to_array -%}
+                {% for addr in addrs -%}
+                { {% include 'DataType/Address' Address: addr -%} },
+                {% endfor -%}
+            {% endif -%}
         ],
         "telecom":
         [
-            {% assign telecoms = practitioner.telecom | to_array -%}
+            {% if personType and personType == "PERSON" -%}
+                {% assign telecoms = practitioner.telecom | to_array -%}
+            {% endif -%}
+            {% if orgType and orgType == "ORG" -%}
+                {% assign telecoms = actualPractitioner.telecom | to_array -%}
+            {% endif -%}
+            
             {% for telecom in telecoms -%}
             { {% include 'DataType/ContactPoint' ContactPoint: telecom -%} },
             {% endfor -%}

--- a/containers/fhir-converter/Templates/eCR/Resource/_PractitionerResponsibleParty.liquid
+++ b/containers/fhir-converter/Templates/eCR/Resource/_PractitionerResponsibleParty.liquid
@@ -21,6 +21,12 @@
                 "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
             ],
         },
+        "extension": [
+        {
+            "url": "http://hl7.org/fhir/StructureDefinition/_datatype",
+            "valueString": "Responsible Party"
+        },
+        ],
         "identifier":
         [
             {% assign ids = practitioner.id | to_array -%}
@@ -83,12 +89,6 @@
             {% endfor -%}
         ],
     },
-    "extension": [
-        {
-            "url": "http://hl7.org/fhir/StructureDefinition/_datatype",
-            "valueString": "Responsible Party"
-        },
-    ],
     "request":{
         "method":"PUT",
         "url":"Practitioner/{{ ID }}",

--- a/containers/fhir-converter/Templates/eCR/Utils/_GenerateId.liquid
+++ b/containers/fhir-converter/Templates/eCR/Utils/_GenerateId.liquid
@@ -10,6 +10,7 @@
         {% else -%}
             {% if obj.representedOrganization.name._ and obj.assignedPerson.name.given._ -%}
                 {{ obj.representedOrganization | to_json_string append: '|' | append: obj.assignedPerson | to_json_string | generate_uuid }}
+                {% break -%}
             {% elsif obj.representedOrganization.name._ -%}
                 {{ obj.representedOrganization | to_json_string | generate_uuid }}
                 {% break -%}
@@ -27,8 +28,11 @@
         {% elsif singleId.root -%}
             {{ singleId.root | generate_uuid }}
             {% break -%}
+        {% elsif singleId.extension -%}
+            {{ singleId.extension | generate_uuid }}
+            {% break -%}
         {% else -%}
-            {{ obj.id }}
+            {{ obj | to_json_string | generate_uuid }}
             {% break -%}
         {% endif -%}
     {% endif -%}

--- a/containers/fhir-converter/Templates/eCR/ValueSet/ValueSet.json
+++ b/containers/fhir-converter/Templates/eCR/ValueSet/ValueSet.json
@@ -371,13 +371,13 @@
         "code": "usual"
       },
       "L": {
-        "code": "usual"
+        "code": "official"
       },
       "P": {
         "code": "nickname"
       },
       "__default__": {
-        "code": ""
+        "code": "usual"
       }
     },
     "ValueSet/ObservationStatus": {


### PR DESCRIPTION

# PULL REQUEST

## Summary
While testing the FHIR Path's for all the fields LAC is interested in from ECR messages, for our message parser BB, I discovered some inconsistencies in the data, specifically around practitioner, organization, observation resources and their references within other resources. The ECR templates need to be updated to provide the correct data and locations for fields from ECR into FHIR so that there are no errors when uploading to the FHIR server as well as locations that can be accessed by the message parser to get the data that LAC desires.

Modify the ECR FHIR Converter templates to filter out observations and practitioners where fields are missing or are 'nullFlavor' as well as ensure that proper authors are added (Orgs, Pract., and Devices) as well as their references when appropriate. Also attempted to resolve an issue where multiple orgs exist in the Bundle, but the id's didn't match even though all their other data did match.

## Related Issue
Fixes #423 

## Additional Information
Nothing else at this time