### PR TITLE
Update FHIR Converter to use ecr directory and eicr template for ecr messages

### DIFF
--- a/containers/fhir-converter/Templates/eCR/Resource/_Observation.liquid
+++ b/containers/fhir-converter/Templates/eCR/Resource/_Observation.liquid
@@ -97,20 +97,26 @@
             { {% include 'DataType/CodeableConcept' CodeableConcept: observationEntry.interpretationCode -%} },
         ],
         "extension":
-            [
-                {% if specimenValue and specimenValue != "None" -%}
-                    {
-                        "url" : "http://hl7.org/fhir/R4/specimen.html",
-                        "valueString" : "{{ specimenValue }}",
-                    },
+            [ {
+                {% if specimenValue and specimenValue != "None" or if collectTime -%}
+
+                    "url" : "http://hl7.org/fhir/R4/specimen.html",
+                    "extension": [
+                    {% if specimenValue and specimenValue != "None" -%}
+                        {
+                            "url" : "specimen source",
+                            "valueString" : "{{ specimenValue }}",
+                        },
+                    {% endif -%}
+                    {% if collectTime -%}
+                        {
+                            "url" : "specimen collection time",
+                            "valueDateTime" : "{{ collectTime | format_as_date_time }}",
+                        },
+                    {% endif -%}
+                    ],
                 {% endif -%}
-                {% if collectTime -%}
-                    {
-                        "url" : "http://hl7.org/fhir/R4/specimen-definitions.html#Specimen.collection.collected_x_",
-                        "valueDateTime" : "{{ collectTime | format_as_date_time }}",
-                    },
-                {% endif -%}
-            ],
+    },],
     },
     "request":{
         "method":"PUT",

--- a/containers/fhir-converter/app/main.py
+++ b/containers/fhir-converter/app/main.py
@@ -75,6 +75,7 @@ class RootTemplate(str, Enum):
     SIU_S26 = "SIU_S26"
     VXU_V04 = "VXU_V04"
     CCD = "CCD"
+    EICR = "EICR"
     ConsultationNote = "ConsultationNote"
     DischargeSummary = "DischargeSummary"
     Header = "Header"
@@ -141,10 +142,10 @@ def convert_to_fhir(
     if input_type == "elr" or input_type == "vxu":
         template_directory_path = "/build/FHIR-Converter/data/Templates/Hl7v2"
     elif input_type == "ecr":
-        template_directory_path = "/build/FHIR-Converter/data/Templates/Ccda"
+        template_directory_path = "/build/FHIR-Converter/data/Templates/eCR"
     else:
         raise ValueError(
-            f"Invalid input_type {input_type}. Valid values are 'hl7v2' and 'ccda'."
+            f"Invalid input_type {input_type}. Valid values are 'hl7v2' and 'ecr'."
         )
     output_data_file_path = "/tmp/output.json"
 

--- a/containers/fhir-converter/tests/test_FHIR-Converter.py
+++ b/containers/fhir-converter/tests/test_FHIR-Converter.py
@@ -94,7 +94,7 @@ invalid_root_template_response = {
     "detail": [
         {
             "loc": ["body", "root_template"],
-            "msg": "value is not a valid enumeration member; permitted: 'ADT_A01', 'ADT_A02', 'ADT_A03', 'ADT_A04', 'ADT_A05', 'ADT_A06', 'ADT_A07', 'ADT_A08', 'ADT_A09', 'ADT_A10', 'ADT_A11', 'ADT_A13', 'ADT_A14', 'ADT_A15', 'ADT_A16', 'ADT_A25', 'ADT_A26', 'ADT_A27', 'ADT_A28', 'ADT_A29', 'ADT_A31', 'ADT_A40', 'ADT_A41', 'ADT_A45', 'ADT_A47', 'ADT_A60', 'BAR_P01', 'BAR_P02', 'BAR_P12', 'DFT_P03', 'DFT_P11', 'MDM_T01', 'MDM_T02', 'MDM_T05', 'MDM_T06', 'MDM_T09', 'MDM_T10', 'OMG_O19', 'OML_O21', 'ORM_O01', 'ORU_R01', 'OUL_R22', 'OUL_R23', 'OUL_R24', 'RDE_O11', 'RDE_O25', 'RDS_O13', 'REF_I12', 'REF_I14', 'SIU_S12', 'SIU_S13', 'SIU_S14', 'SIU_S15', 'SIU_S16', 'SIU_S17', 'SIU_S26', 'VXU_V04', 'EICR', 'CCD', 'ConsultationNote', 'DischargeSummary', 'Header', 'HistoryandPhysical', 'OperativeNote', 'ProcedureNote', 'ProgressNote', 'ReferralNote', 'TransferSummary'",
+            "msg": "value is not a valid enumeration member; permitted: 'ADT_A01', 'ADT_A02', 'ADT_A03', 'ADT_A04', 'ADT_A05', 'ADT_A06', 'ADT_A07', 'ADT_A08', 'ADT_A09', 'ADT_A10', 'ADT_A11', 'ADT_A13', 'ADT_A14', 'ADT_A15', 'ADT_A16', 'ADT_A25', 'ADT_A26', 'ADT_A27', 'ADT_A28', 'ADT_A29', 'ADT_A31', 'ADT_A40', 'ADT_A41', 'ADT_A45', 'ADT_A47', 'ADT_A60', 'BAR_P01', 'BAR_P02', 'BAR_P12', 'DFT_P03', 'DFT_P11', 'MDM_T01', 'MDM_T02', 'MDM_T05', 'MDM_T06', 'MDM_T09', 'MDM_T10', 'OMG_O19', 'OML_O21', 'ORM_O01', 'ORU_R01', 'OUL_R22', 'OUL_R23', 'OUL_R24', 'RDE_O11', 'RDE_O25', 'RDS_O13', 'REF_I12', 'REF_I14', 'SIU_S12', 'SIU_S13', 'SIU_S14', 'SIU_S15', 'SIU_S16', 'SIU_S17', 'SIU_S26', 'VXU_V04', 'CCD', 'EICR', 'ConsultationNote', 'DischargeSummary', 'Header', 'HistoryandPhysical', 'OperativeNote', 'ProcedureNote', 'ProgressNote', 'ReferralNote', 'TransferSummary'",
             "type": "type_error.enum",
             "ctx": {
                 "enum_values": [
@@ -155,8 +155,8 @@ invalid_root_template_response = {
                     "SIU_S17",
                     "SIU_S26",
                     "VXU_V04",
-                    "EICR",
                     "CCD",
+                    "EICR",
                     "ConsultationNote",
                     "DischargeSummary",
                     "Header",

--- a/containers/fhir-converter/tests/test_FHIR-Converter.py
+++ b/containers/fhir-converter/tests/test_FHIR-Converter.py
@@ -94,7 +94,7 @@ invalid_root_template_response = {
     "detail": [
         {
             "loc": ["body", "root_template"],
-            "msg": "value is not a valid enumeration member; permitted: 'ADT_A01', 'ADT_A02', 'ADT_A03', 'ADT_A04', 'ADT_A05', 'ADT_A06', 'ADT_A07', 'ADT_A08', 'ADT_A09', 'ADT_A10', 'ADT_A11', 'ADT_A13', 'ADT_A14', 'ADT_A15', 'ADT_A16', 'ADT_A25', 'ADT_A26', 'ADT_A27', 'ADT_A28', 'ADT_A29', 'ADT_A31', 'ADT_A40', 'ADT_A41', 'ADT_A45', 'ADT_A47', 'ADT_A60', 'BAR_P01', 'BAR_P02', 'BAR_P12', 'DFT_P03', 'DFT_P11', 'MDM_T01', 'MDM_T02', 'MDM_T05', 'MDM_T06', 'MDM_T09', 'MDM_T10', 'OMG_O19', 'OML_O21', 'ORM_O01', 'ORU_R01', 'OUL_R22', 'OUL_R23', 'OUL_R24', 'RDE_O11', 'RDE_O25', 'RDS_O13', 'REF_I12', 'REF_I14', 'SIU_S12', 'SIU_S13', 'SIU_S14', 'SIU_S15', 'SIU_S16', 'SIU_S17', 'SIU_S26', 'VXU_V04', 'CCD', 'ConsultationNote', 'DischargeSummary', 'Header', 'HistoryandPhysical', 'OperativeNote', 'ProcedureNote', 'ProgressNote', 'ReferralNote', 'TransferSummary'",
+            "msg": "value is not a valid enumeration member; permitted: 'ADT_A01', 'ADT_A02', 'ADT_A03', 'ADT_A04', 'ADT_A05', 'ADT_A06', 'ADT_A07', 'ADT_A08', 'ADT_A09', 'ADT_A10', 'ADT_A11', 'ADT_A13', 'ADT_A14', 'ADT_A15', 'ADT_A16', 'ADT_A25', 'ADT_A26', 'ADT_A27', 'ADT_A28', 'ADT_A29', 'ADT_A31', 'ADT_A40', 'ADT_A41', 'ADT_A45', 'ADT_A47', 'ADT_A60', 'BAR_P01', 'BAR_P02', 'BAR_P12', 'DFT_P03', 'DFT_P11', 'MDM_T01', 'MDM_T02', 'MDM_T05', 'MDM_T06', 'MDM_T09', 'MDM_T10', 'OMG_O19', 'OML_O21', 'ORM_O01', 'ORU_R01', 'OUL_R22', 'OUL_R23', 'OUL_R24', 'RDE_O11', 'RDE_O25', 'RDS_O13', 'REF_I12', 'REF_I14', 'SIU_S12', 'SIU_S13', 'SIU_S14', 'SIU_S15', 'SIU_S16', 'SIU_S17', 'SIU_S26', 'VXU_V04', 'EICR', 'CCD', 'ConsultationNote', 'DischargeSummary', 'Header', 'HistoryandPhysical', 'OperativeNote', 'ProcedureNote', 'ProgressNote', 'ReferralNote', 'TransferSummary'",
             "type": "type_error.enum",
             "ctx": {
                 "enum_values": [
@@ -155,6 +155,7 @@ invalid_root_template_response = {
                     "SIU_S17",
                     "SIU_S26",
                     "VXU_V04",
+                    "EICR",
                     "CCD",
                     "ConsultationNote",
                     "DischargeSummary",


### PR DESCRIPTION
# PULL REQUEST

## Summary
Updated the Observation template to use extensions within extension for specimen information.  Also updated the FHIR Converter to use the ECR directory and the EICR template for ECR messages.  Updated tests accordingly. 

## Related Issue
N/A
