### PR TITLE
Add algorithms module

### DIFF
--- a/phdi/linkage/__init__.py
+++ b/phdi/linkage/__init__.py
@@ -1,3 +1,5 @@
+from phdi.linkage.algorithms import DIBBS_BASIC, DIBBS_ENHANCED
+
 from phdi.linkage.link import (
     generate_hash_str,
     block_data,
@@ -32,6 +34,8 @@ from phdi.linkage.seed import convert_to_patient_fhir_resources
 
 
 __all__ = [
+    "DIBBS_BASIC",
+    "DIBBS_ENHANCED",
     "generate_hash_str",
     "block_data",
     "match_within_block",

--- a/phdi/linkage/algorithms.py
+++ b/phdi/linkage/algorithms.py
@@ -1,0 +1,66 @@
+DIBBS_BASIC = [
+    {
+        "funcs": {
+            1: "feature_match_fuzzy_string",
+            3: "feature_match_fuzzy_string",
+            4: "feature_match_fuzzy_string",
+        },
+        "blocks": [
+            {"value": "mrn", "transformation": "last4"},
+            {"value": "address", "transformation": "first4"},
+        ],
+        "matching_rule": "eval_perfect_match",
+        "cluster_ratio": 0.9,
+    },
+    {
+        "funcs": {
+            0: "feature_match_fuzzy_string",
+            2: "feature_match_fuzzy_string",
+        },
+        "blocks": [
+            {"value": "first_name", "transformation": "first4"},
+            {"value": "last_name", "transformation": "first4"},
+        ],
+        "matching_rule": "eval_perfect_match",
+        "cluster_ratio": 0.9,
+    },
+]
+
+
+DIBBS_ENHANCED = [
+    {
+        "funcs": {
+            1: "feature_match_log_odds_fuzzy_compare",
+            3: "feature_match_log_odds_fuzzy_compare",
+            4: "feature_match_log_odds_fuzzy_compare",
+        },
+        "blocks": [
+            {"value": "mrn", "transformation": "last4"},
+            {"value": "address", "transformation": "first4"},
+        ],
+        "matching_rule": "eval_log_odds_cutoff",
+        "cluster_ratio": 0.9,
+        "kwargs": {
+            "similarity_measure": "JaroWinkler",
+            "threshold": 0.7,
+            "true_match_threshold": 16.5,
+        },
+    },
+    {
+        "funcs": {
+            0: "feature_match_log_odds_fuzzy_compare",
+            2: "feature_match_log_odds_fuzzy_compare",
+        },
+        "blocks": [
+            {"value": "first_name", "transformation": "first4"},
+            {"value": "last_name", "transformation": "first4"},
+        ],
+        "matching_rule": "eval_log_odds_cutoff",
+        "cluster_ratio": 0.9,
+        "kwargs": {
+            "similarity_measure": "JaroWinkler",
+            "threshold": 0.7,
+            "true_match_threshold": 7.0,
+        },
+    },
+]

--- a/tests/linkage/test_linkage.py
+++ b/tests/linkage/test_linkage.py
@@ -40,6 +40,7 @@ from phdi.linkage.link import (
     _condense_extract_address_from_resource,
 )
 from phdi.linkage import DIBBsConnectorClient
+from phdi.linkage import DIBBS_BASIC
 
 import pathlib
 import pytest
@@ -973,13 +974,7 @@ def test_algo_write():
 
 # TODO: Move this to an integration test suite
 def test_link_record_against_mpi():
-    algorithm = read_linkage_config(
-        pathlib.Path(__file__).parent.parent.parent
-        / "phdi"
-        / "linkage"
-        / "algorithms"
-        / "dibbs_basic.json"
-    )
+    algorithm = DIBBS_BASIC
 
     postgres_client = _set_up_postgres_client()
 
@@ -1270,13 +1265,7 @@ def test_multi_element_blocking():
 
     # Insert multi-entry patient into DB
     patient = patients[2]
-    algorithm = read_linkage_config(
-        pathlib.Path(__file__).parent.parent.parent
-        / "phdi"
-        / "linkage"
-        / "algorithms"
-        / "dibbs_basic.json"
-    )
+    algorithm = DIBBS_BASIC
     link_record_against_mpi(patient, algorithm, postgres_client)
 
     # Now check that we can block on either name


### PR DESCRIPTION
# Create submodule for default algorithms

## Summary
After some filepath debugging with Dan, we've decided to define the default algorithms DIBBS uses for its linkage service as global constants within the SDK, so that the container service can access them without problematic filepaths. This PR defines that algorithms submodule and refactors the DIBBS algorithms to live there.

## Related Issue
Fixes part of 464 but not linking here because a separate PR will be needed to follow this one fixing the container paths.