### PR TITLE
Removing datetime that is added at the end of the filename

### DIFF
--- a/containers/ingestion/app/routers/cloud_storage.py
+++ b/containers/ingestion/app/routers/cloud_storage.py
@@ -70,7 +70,7 @@ def write_blob_to_cloud_storage_endpoint(
         storage_account_url=input["storage_account_url"],
     )
 
-    full_file_name = input["file_name"] + str(int(time.time()))
+    full_file_name = input["file_name"]
     cloud_provider_connection.upload_object(
         message=input,
         container_name=input["bucket_name"],


### PR DESCRIPTION
Removes the datetime string that appends to the file name in the write to storage function. It didn't serve a meaningful purpose, so we are replacing it wtih runid in a different branch