### PR TITLE
Sanitize MPI SQL queries

### DIFF
--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -168,7 +168,7 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
         finally:
             self._close_connections(db_conn=db_conn, db_cursor=db_cursor)
 
-        return person_id[0][0]
+        return person_id
 
     def _generate_block_query(self, block_vals: dict) -> Tuple[SQL, list[str]]:
         """

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -97,7 +97,7 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
 
                     query, data = self._generate_block_query(block_vals)
                     # Execute query
-                    db_cursor.execute(query, tuple(data))
+                    db_cursor.execute(query, data)
                     blocked_data = [list(row) for row in db_cursor.fetchall()]
 
         except Exception as error:  # pragma: no cover

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -94,7 +94,7 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
             with self.get_connection() as db_conn:
                 with db_conn.cursor() as db_cursor:
                     # Generate raw SQL query
-                    
+
                     query, data = self._generate_block_query(block_vals)
                     # Execute query
                     db_cursor.execute(query, tuple(data))
@@ -142,9 +142,7 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
                         # person_id
                         insert_new_person = SQL(
                             "INSERT INTO {person_table} (external_person_id) VALUES ('NULL') RETURNING person_id;"
-                        ).format(
-                            person_table=Identifier(self.person_table)
-                        )
+                        ).format(person_table=Identifier(self.person_table))
 
                         db_cursor.execute(insert_new_person)
 
@@ -154,7 +152,7 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
                     # Insert into patient table
                     insert_new_patient = SQL(
                         "INSERT INTO {patient_table} (patient_id, person_id, patient_resource) VALUES (%s, %s, %s);"
-                    ).format(patient_table= Identifier(self.patient_table))
+                    ).format(patient_table=Identifier(self.patient_table))
                     data = [
                         patient_resource.get("id"),
                         person_id,
@@ -182,7 +180,7 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
           e.g., {["ZIP"]: {"value": "90210"}} or
           {["ZIP"]: {"value": "90210",}, "transformation":"first4"}.
         :raises ValueError: If column key in `block_vals` is not supported.
-        :return: A tuple containing a psycopg2.sql.SQL object representing the query as 
+        :return: A tuple containing a psycopg2.sql.SQL object representing the query as
             well as list of all data to be inserted into it.
 
         """
@@ -216,20 +214,26 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
             if "transformation" in param:
                 # first4 transformations
                 if block_vals[col_name]["transformation"] == "first4":
-                    block_query_stubs_data.append(f'{self.fields_to_jsonpaths[col_name]} starts with "{block_vals[col_name]["value"]}"')
+                    block_query_stubs_data.append(
+                        f'{self.fields_to_jsonpaths[col_name]} starts with "{block_vals[col_name]["value"]}"'
+                    )
                 # last4 transformations
                 else:
-                    block_query_stubs_data.append(f'{self.fields_to_jsonpaths[col_name]} like_regex "{block_vals[col_name]["value"]}$$"')
+                    block_query_stubs_data.append(
+                        f'{self.fields_to_jsonpaths[col_name]} like_regex "{block_vals[col_name]["value"]}$$"'
+                    )
             # Build query for columns without transformations
             else:
-                block_query_stubs_data.append(f'{self.fields_to_jsonpaths[col_name]} like_regex "{block_vals[col_name]["value"]}"')
-            
+                block_query_stubs_data.append(
+                    f'{self.fields_to_jsonpaths[col_name]} like_regex "{block_vals[col_name]["value"]}"'
+                )
+
         block_query = " WHERE " + " AND ".join(stub for stub in block_query_stubs)
 
         query = select_query + " FROM {patient_table}" + block_query + ";"
-        query = SQL(query).format( patient_table=Identifier(self.patient_table))
+        query = SQL(query).format(patient_table=Identifier(self.patient_table))
         data = select_query_stubs_data + block_query_stubs_data
-        
+
         return query, data
 
     def _close_connections(

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -141,7 +141,8 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
                         # Insert a new record into person table to generate new
                         # person_id
                         insert_new_person = SQL(
-                            "INSERT INTO {person_table} (external_person_id) VALUES ('NULL') RETURNING person_id;"
+                            "INSERT INTO {person_table} (external_person_id) VALUES "
+                            "('NULL') RETURNING person_id;"
                         ).format(person_table=Identifier(self.person_table))
 
                         db_cursor.execute(insert_new_person)
@@ -151,7 +152,8 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
 
                     # Insert into patient table
                     insert_new_patient = SQL(
-                        "INSERT INTO {patient_table} (patient_id, person_id, patient_resource) VALUES (%s, %s, %s);"
+                        "INSERT INTO {patient_table} "
+                        "(patient_id, person_id, patient_resource) VALUES (%s, %s, %s);"
                     ).format(patient_table=Identifier(self.patient_table))
                     data = [
                         patient_resource.get("id"),
@@ -208,24 +210,28 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
         block_query_stubs = []
         block_query_stubs_data = []
         for col_name, param in block_vals.items():
-            query = "CAST(jsonb_path_query_array(patient_resource, %s) as VARCHAR)= '[true]'"
+            query = "CAST(jsonb_path_query_array(patient_resource, %s) as VARCHAR)= "\
+                "'[true]'"
             block_query_stubs.append(query)
             # Add appropriate transformations
             if "transformation" in param:
                 # first4 transformations
                 if block_vals[col_name]["transformation"] == "first4":
                     block_query_stubs_data.append(
-                        f'{self.fields_to_jsonpaths[col_name]} starts with "{block_vals[col_name]["value"]}"'
+                        f'{self.fields_to_jsonpaths[col_name]} starts with '
+                        f'"{block_vals[col_name]["value"]}"'
                     )
                 # last4 transformations
                 else:
                     block_query_stubs_data.append(
-                        f'{self.fields_to_jsonpaths[col_name]} like_regex "{block_vals[col_name]["value"]}$$"'
+                        f'{self.fields_to_jsonpaths[col_name]} like_regex '
+                        f'"{block_vals[col_name]["value"]}$$"'
                     )
             # Build query for columns without transformations
             else:
                 block_query_stubs_data.append(
-                    f'{self.fields_to_jsonpaths[col_name]} like_regex "{block_vals[col_name]["value"]}"'
+                    f'{self.fields_to_jsonpaths[col_name]} like_regex '
+                    f'"{block_vals[col_name]["value"]}"'
                 )
 
         block_query = " WHERE " + " AND ".join(stub for stub in block_query_stubs)

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -210,27 +210,29 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
         block_query_stubs = []
         block_query_stubs_data = []
         for col_name, param in block_vals.items():
-            query = "CAST(jsonb_path_query_array(patient_resource, %s) as VARCHAR)= "\
+            query = (
+                "CAST(jsonb_path_query_array(patient_resource, %s) as VARCHAR)= "
                 "'[true]'"
+            )
             block_query_stubs.append(query)
             # Add appropriate transformations
             if "transformation" in param:
                 # first4 transformations
                 if block_vals[col_name]["transformation"] == "first4":
                     block_query_stubs_data.append(
-                        f'{self.fields_to_jsonpaths[col_name]} starts with '
+                        f"{self.fields_to_jsonpaths[col_name]} starts with "
                         f'"{block_vals[col_name]["value"]}"'
                     )
                 # last4 transformations
                 else:
                     block_query_stubs_data.append(
-                        f'{self.fields_to_jsonpaths[col_name]} like_regex '
+                        f"{self.fields_to_jsonpaths[col_name]} like_regex "
                         f'"{block_vals[col_name]["value"]}$$"'
                     )
             # Build query for columns without transformations
             else:
                 block_query_stubs_data.append(
-                    f'{self.fields_to_jsonpaths[col_name]} like_regex '
+                    f"{self.fields_to_jsonpaths[col_name]} like_regex "
                     f'"{block_vals[col_name]["value"]}"'
                 )
 

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -1,6 +1,7 @@
-from typing import List, Dict, Union
+from typing import List, Dict, Union, Tuple
 from phdi.linkage.core import BaseMPIConnectorClient
 import psycopg2
+from psycopg2.sql import Identifier, SQL
 from psycopg2.extensions import connection, cursor
 import json
 
@@ -93,9 +94,11 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
             with self.get_connection() as db_conn:
                 with db_conn.cursor() as db_cursor:
                     # Generate raw SQL query
-                    query = self._generate_block_query(block_vals)
+                    
+                    query, data = self._generate_block_query(block_vals)
+                    breakpoint()
                     # Execute query
-                    db_cursor.execute(query)
+                    db_cursor.execute(query, tuple(data))
                     blocked_data = [list(row) for row in db_cursor.fetchall()]
 
         except Exception as error:  # pragma: no cover
@@ -138,10 +141,10 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
                     if person_id is None:
                         # Insert a new record into person table to generate new
                         # person_id
-                        insert_new_person = psycopg2.sql.SQL(
+                        insert_new_person = SQL(
                             "INSERT INTO {person_table} (external_person_id) VALUES ('NULL') RETURNING person_id;"
                         ).format(
-                            person_table=psycopg2.sql.Identifier(self.person_table)
+                            person_table=Identifier(self.person_table)
                         )
 
                         db_cursor.execute(insert_new_person)
@@ -150,9 +153,9 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
                         person_id = db_cursor.fetchall()[0][0]
 
                     # Insert into patient table
-                    insert_new_patient = psycopg2.sql.SQL(
+                    insert_new_patient = SQL(
                         "INSERT INTO {patient_table} (patient_id, person_id, patient_resource) VALUES (%s, %s, %s);"
-                    ).format(patient_table=psycopg2.sql.Identifier(self.patient_table))
+                    ).format(patient_table= Identifier(self.patient_table))
                     data = [
                         patient_resource.get("id"),
                         person_id,
@@ -168,7 +171,7 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
 
         return person_id[0][0]
 
-    def _generate_block_query(self, block_vals: dict) -> str:
+    def _generate_block_query(self, block_vals: dict) -> Tuple[SQL, list[str]]:
         """
         Generates a query for selecting a block of data from the patient table per the
         block_vals parameters. Accepted blocking fields include: first_name, last_name,
@@ -180,7 +183,8 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
           e.g., {["ZIP"]: {"value": "90210"}} or
           {["ZIP"]: {"value": "90210",}, "transformation":"first4"}.
         :raises ValueError: If column key in `block_vals` is not supported.
-        :return: Query to select block of data base on `block_vals` parameters.
+        :return: A tuple containing a psycopg2.sql.SQL object representing the query as 
+            well as list of all data to be inserted into it.
 
         """
         # Check whether `block_vals` contains supported keys
@@ -194,46 +198,40 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
 
         # Generate select query to extract fields_to_jsonpaths keys
         select_query_stubs = []
+        select_query_stubs_data = []
         for key in self.fields_to_jsonpaths:
-            query = f"""jsonb_path_query_array(patient_resource,
-                '{self.fields_to_jsonpaths[key]}') as {key}"""
+            query = f"jsonb_path_query_array(patient_resource,%s) as {key}"
             select_query_stubs.append(query)
+            select_query_stubs_data.append(self.fields_to_jsonpaths[key])
         select_query = "SELECT patient_id, person_id, " + ", ".join(
             stub for stub in select_query_stubs
         )
 
         # Generate blocking query based on blocking criteria
         block_query_stubs = []
+        block_query_stubs_data = []
         for col_name, param in block_vals.items():
+            query = "CAST(jsonb_path_query_array(patient_resource, %s) as VARCHAR)= '[true]'"
+            block_query_stubs.append(query)
             # Add appropriate transformations
             if "transformation" in param:
                 # first4 transformations
                 if block_vals[col_name]["transformation"] == "first4":
-                    query = f"""
-                        CAST(jsonb_path_query_array(patient_resource,
-                        '{self.fields_to_jsonpaths[col_name]} starts with
-                        "{block_vals[col_name]["value"]}"') as VARCHAR)
-                        = '[true]'"""
+                    block_query_stubs_data.append(f'{self.fields_to_jsonpaths[col_name]} starts with "{block_vals[col_name]["value"]}"')
                 # last4 transformations
                 else:
-                    query = f"""
-                        CAST(jsonb_path_query_array(patient_resource,
-                        '{self.fields_to_jsonpaths[col_name]} like_regex
-                        "{block_vals[col_name]["value"]}$$"') as VARCHAR)
-                        = '[true]'"""
-
+                    block_query_stubs_data.append(f'{self.fields_to_jsonpaths[col_name]} like_regex "{block_vals[col_name]["value"]}$$"')
             # Build query for columns without transformations
             else:
-                query = f"""CAST(jsonb_path_query_array(patient_resource,
-                        '{self.fields_to_jsonpaths[col_name]} like_regex
-                        "{block_vals[col_name]["value"]}"') as VARCHAR)
-                        = '[true]'"""
-            block_query_stubs.append(query)
-
+                block_query_stubs_data.append(f'{self.fields_to_jsonpaths[col_name]} like_regex "{block_vals[col_name]["value"]}"')
+            
         block_query = " WHERE " + " AND ".join(stub for stub in block_query_stubs)
 
-        query = select_query + f" FROM {self.patient_table}" + block_query + ";"
-        return query
+        query = select_query + " FROM {patient_table}" + block_query + ";"
+        query = SQL(query).format( patient_table=Identifier(self.patient_table))
+        data = select_query_stubs_data + block_query_stubs_data
+        
+        return query, data
 
     def _close_connections(
         self,

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -96,7 +96,6 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
                     # Generate raw SQL query
                     
                     query, data = self._generate_block_query(block_vals)
-                    breakpoint()
                     # Execute query
                     db_cursor.execute(query, tuple(data))
                     blocked_data = [list(row) for row in db_cursor.fetchall()]

--- a/tests/linkage/test_linkage.py
+++ b/tests/linkage/test_linkage.py
@@ -1007,7 +1007,7 @@ def test_link_record_against_mpi():
     # Sixth patient: in first pass, MRN blocks with one cluster and name matches in it,
     #  in second pass name blocks on different cluster and address matches it,
     #  finds greatest strength match and correctly assigns to larger cluster
-    #breakpoint()
+    
     assert matches == [False, True, False, True, False, True]
     assert sorted(list(mapped_patients.values())) == [1, 1, 4]
 

--- a/tests/linkage/test_linkage.py
+++ b/tests/linkage/test_linkage.py
@@ -1007,6 +1007,7 @@ def test_link_record_against_mpi():
     # Sixth patient: in first pass, MRN blocks with one cluster and name matches in it,
     #  in second pass name blocks on different cluster and address matches it,
     #  finds greatest strength match and correctly assigns to larger cluster
+    #breakpoint()
     assert matches == [False, True, False, True, False, True]
     assert sorted(list(mapped_patients.values())) == [1, 1, 4]
 

--- a/tests/linkage/test_linkage.py
+++ b/tests/linkage/test_linkage.py
@@ -1007,7 +1007,7 @@ def test_link_record_against_mpi():
     # Sixth patient: in first pass, MRN blocks with one cluster and name matches in it,
     #  in second pass name blocks on different cluster and address matches it,
     #  finds greatest strength match and correctly assigns to larger cluster
-    
+
     assert matches == [False, True, False, True, False, True]
     assert sorted(list(mapped_patients.values())) == [1, 1, 4]
 

--- a/tests/linkage/test_postgres_mpi_connector.py
+++ b/tests/linkage/test_postgres_mpi_connector.py
@@ -23,8 +23,23 @@ def test_generate_block_query():
     }
 
     generated_query, generated_data = postgres_client._generate_block_query(block_vals)
-    assert generated_query.__str__() == 'Composed([SQL(\'SELECT patient_id, person_id, jsonb_path_query_array(patient_resource,%s) as address, jsonb_path_query_array(patient_resource,%s) as birthdate, jsonb_path_query_array(patient_resource,%s) as city, jsonb_path_query_array(patient_resource,%s) as first_name, jsonb_path_query_array(patient_resource,%s) as last_name, jsonb_path_query_array(patient_resource,%s) as mrn, jsonb_path_query_array(patient_resource,%s) as sex, jsonb_path_query_array(patient_resource,%s) as state, jsonb_path_query_array(patient_resource,%s) as zip FROM \'), Identifier(\'test_patient_mpi\'), SQL(" WHERE CAST(jsonb_path_query_array(patient_resource, %s) as VARCHAR)= \'[true]\' AND CAST(jsonb_path_query_array(patient_resource, %s) as VARCHAR)= \'[true]\';")])'
-    assert generated_data == ['$.address[*].line', '$.birthDate', '$.address[*].city', '$.name[*].given', '$.name[*].family', '$.identifier.value', '$.gender', '$.address[*].state', '$.address[*].postalCode', '$.address[*].postalCode like_regex "90120-1001"', '$.name[*].family starts with "GONZ"']
+    assert (
+        generated_query.__str__()
+        == "Composed([SQL('SELECT patient_id, person_id, jsonb_path_query_array(patient_resource,%s) as address, jsonb_path_query_array(patient_resource,%s) as birthdate, jsonb_path_query_array(patient_resource,%s) as city, jsonb_path_query_array(patient_resource,%s) as first_name, jsonb_path_query_array(patient_resource,%s) as last_name, jsonb_path_query_array(patient_resource,%s) as mrn, jsonb_path_query_array(patient_resource,%s) as sex, jsonb_path_query_array(patient_resource,%s) as state, jsonb_path_query_array(patient_resource,%s) as zip FROM '), Identifier('test_patient_mpi'), SQL(\" WHERE CAST(jsonb_path_query_array(patient_resource, %s) as VARCHAR)= '[true]' AND CAST(jsonb_path_query_array(patient_resource, %s) as VARCHAR)= '[true]';\")])"
+    )
+    assert generated_data == [
+        "$.address[*].line",
+        "$.birthDate",
+        "$.address[*].city",
+        "$.name[*].given",
+        "$.name[*].family",
+        "$.identifier.value",
+        "$.gender",
+        "$.address[*].state",
+        "$.address[*].postalCode",
+        '$.address[*].postalCode like_regex "90120-1001"',
+        '$.name[*].family starts with "GONZ"',
+    ]
 
     # Test bad block_data
     block_vals = {"bad_block_column": "90120-1001"}

--- a/tests/linkage/test_postgres_mpi_connector.py
+++ b/tests/linkage/test_postgres_mpi_connector.py
@@ -21,15 +21,10 @@ def test_generate_block_query():
         "zip": {"value": "90120-1001"},
         "last_name": {"value": "GONZ", "transformation": "first4"},
     }
-    expected_query_line_0 = (
-        """SELECT patient_id, person_id, jsonb_path_query_array(patient_resource,"""
-    )
-    expected_query_last_line = "= '[true]';"
 
-    generated_query = postgres_client._generate_block_query(block_vals)
-
-    assert expected_query_line_0 == generated_query.split("\n")[0]
-    assert expected_query_last_line == generated_query.split("\n")[-1].strip()
+    generated_query, generated_data = postgres_client._generate_block_query(block_vals)
+    assert generated_query.__str__() == 'Composed([SQL(\'SELECT patient_id, person_id, jsonb_path_query_array(patient_resource,%s) as address, jsonb_path_query_array(patient_resource,%s) as birthdate, jsonb_path_query_array(patient_resource,%s) as city, jsonb_path_query_array(patient_resource,%s) as first_name, jsonb_path_query_array(patient_resource,%s) as last_name, jsonb_path_query_array(patient_resource,%s) as mrn, jsonb_path_query_array(patient_resource,%s) as sex, jsonb_path_query_array(patient_resource,%s) as state, jsonb_path_query_array(patient_resource,%s) as zip FROM \'), Identifier(\'test_patient_mpi\'), SQL(" WHERE CAST(jsonb_path_query_array(patient_resource, %s) as VARCHAR)= \'[true]\' AND CAST(jsonb_path_query_array(patient_resource, %s) as VARCHAR)= \'[true]\';")])'
+    assert generated_data == ['$.address[*].line', '$.birthDate', '$.address[*].city', '$.name[*].given', '$.name[*].family', '$.identifier.value', '$.gender', '$.address[*].state', '$.address[*].postalCode', '$.address[*].postalCode like_regex "90120-1001"', '$.name[*].family starts with "GONZ"']
 
     # Test bad block_data
     block_vals = {"bad_block_column": "90120-1001"}

--- a/tests/linkage/test_postgres_mpi_connector.py
+++ b/tests/linkage/test_postgres_mpi_connector.py
@@ -25,7 +25,7 @@ def test_generate_block_query():
     generated_query, generated_data = postgres_client._generate_block_query(block_vals)
     assert (
         generated_query.__str__()
-        == "Composed([SQL('SELECT patient_id, person_id, jsonb_path_query_array(patient_resource,%s) as address, jsonb_path_query_array(patient_resource,%s) as birthdate, jsonb_path_query_array(patient_resource,%s) as city, jsonb_path_query_array(patient_resource,%s) as first_name, jsonb_path_query_array(patient_resource,%s) as last_name, jsonb_path_query_array(patient_resource,%s) as mrn, jsonb_path_query_array(patient_resource,%s) as sex, jsonb_path_query_array(patient_resource,%s) as state, jsonb_path_query_array(patient_resource,%s) as zip FROM '), Identifier('test_patient_mpi'), SQL(\" WHERE CAST(jsonb_path_query_array(patient_resource, %s) as VARCHAR)= '[true]' AND CAST(jsonb_path_query_array(patient_resource, %s) as VARCHAR)= '[true]';\")])" #noqa
+        == "Composed([SQL('SELECT patient_id, person_id, jsonb_path_query_array(patient_resource,%s) as address, jsonb_path_query_array(patient_resource,%s) as birthdate, jsonb_path_query_array(patient_resource,%s) as city, jsonb_path_query_array(patient_resource,%s) as first_name, jsonb_path_query_array(patient_resource,%s) as last_name, jsonb_path_query_array(patient_resource,%s) as mrn, jsonb_path_query_array(patient_resource,%s) as sex, jsonb_path_query_array(patient_resource,%s) as state, jsonb_path_query_array(patient_resource,%s) as zip FROM '), Identifier('test_patient_mpi'), SQL(\" WHERE CAST(jsonb_path_query_array(patient_resource, %s) as VARCHAR)= '[true]' AND CAST(jsonb_path_query_array(patient_resource, %s) as VARCHAR)= '[true]';\")])"  # noqa
     )
     assert generated_data == [
         "$.address[*].line",

--- a/tests/linkage/test_postgres_mpi_connector.py
+++ b/tests/linkage/test_postgres_mpi_connector.py
@@ -25,7 +25,7 @@ def test_generate_block_query():
     generated_query, generated_data = postgres_client._generate_block_query(block_vals)
     assert (
         generated_query.__str__()
-        == "Composed([SQL('SELECT patient_id, person_id, jsonb_path_query_array(patient_resource,%s) as address, jsonb_path_query_array(patient_resource,%s) as birthdate, jsonb_path_query_array(patient_resource,%s) as city, jsonb_path_query_array(patient_resource,%s) as first_name, jsonb_path_query_array(patient_resource,%s) as last_name, jsonb_path_query_array(patient_resource,%s) as mrn, jsonb_path_query_array(patient_resource,%s) as sex, jsonb_path_query_array(patient_resource,%s) as state, jsonb_path_query_array(patient_resource,%s) as zip FROM '), Identifier('test_patient_mpi'), SQL(\" WHERE CAST(jsonb_path_query_array(patient_resource, %s) as VARCHAR)= '[true]' AND CAST(jsonb_path_query_array(patient_resource, %s) as VARCHAR)= '[true]';\")])"
+        == "Composed([SQL('SELECT patient_id, person_id, jsonb_path_query_array(patient_resource,%s) as address, jsonb_path_query_array(patient_resource,%s) as birthdate, jsonb_path_query_array(patient_resource,%s) as city, jsonb_path_query_array(patient_resource,%s) as first_name, jsonb_path_query_array(patient_resource,%s) as last_name, jsonb_path_query_array(patient_resource,%s) as mrn, jsonb_path_query_array(patient_resource,%s) as sex, jsonb_path_query_array(patient_resource,%s) as state, jsonb_path_query_array(patient_resource,%s) as zip FROM '), Identifier('test_patient_mpi'), SQL(\" WHERE CAST(jsonb_path_query_array(patient_resource, %s) as VARCHAR)= '[true]' AND CAST(jsonb_path_query_array(patient_resource, %s) as VARCHAR)= '[true]';\")])" #noqa
     )
     assert generated_data == [
         "$.address[*].line",


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR introduces proper sanitization of inputs when constructing SQL queries against the MPI. This should resolve the error the record linkage service was producing during end to end tests in the starter kit and secure the record linkage service against SQL injection attacks.

## Related Issue
Fixes #507



[//]: # (PR title: Remember to name your PR descriptively!)