### PR TITLE
Generate new UUID for patient resources.

### DIFF
--- a/containers/fhir-converter/app/main.py
+++ b/containers/fhir-converter/app/main.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import subprocess
 import json
-
+import uuid
 from enum import Enum
 from fastapi import FastAPI, Response, status
 from pydantic import BaseModel
@@ -173,6 +173,13 @@ def convert_to_fhir(
     # Process the response from FHIR Converter.
     if converter_response.returncode == 0:
         result = json.load(open(output_data_file_path))
+        # Generate a new UUID for the patient resource.
+        for entry in result["FhirResource"]["entry"]:
+            if entry["resource"]["resourceType"] == "Patient":
+                new_id = str(uuid.uuid4())
+                entry["fullURL"] = f"urn:uuid:{new_id}"
+                entry["resource"]["id"] = new_id
+                break
     else:
         result = vars(converter_response)
         # Include original input data in the result.

--- a/containers/fhir-converter/requirements.txt
+++ b/containers/fhir-converter/requirements.txt
@@ -36,3 +36,4 @@ uvicorn==0.17.6
 uvloop==0.16.0
 watchgod==0.8.2
 websockets==10.3
+uuid

--- a/containers/fhir-converter/tests/test_FHIR-Converter.py
+++ b/containers/fhir-converter/tests/test_FHIR-Converter.py
@@ -17,13 +17,20 @@ valid_response = {
     "FhirResource": {
         "resourceType": "Bundle",
         "type": "batch",
-        "timestamp": "1989-08-18T11:26:00+02:15",
+        "timestamp": "2021-08-18T11:26:00+02:15",
         "identifier": {"value": "MSG00001"},
         "id": "513a3d06-5e87-6fbc-ad1b-170ab430499f",
-        "entry": [{"resource": "FHIR_RESOURCE"}],
+        "entry": [
+            {
+                "fullUrl": "urn:uuid:9e909e52-61a1-be50-1878-a12ef8c36346",
+                "resource": {
+                    "resourceType": "Patient",
+                    "id": "02710678-32ab-4cea-b2f3-859b40a93ce3",
+                },
+            }
+        ],
     },
 }
-
 conversion_failure_response = {
     "_mock_call_args": None,
     "_mock_call_args_list": [],


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR ensures that the FHIR converter gives every patient resource unique UUID.

## Additional Information
Although we previously assumed that every "UUID" generate by the FHIR converter was unique, recent testing has proved that this is not the case. This is an issue because the current assumption of our record linkage approach is that every patient resource will have a unique ID which is causing end to end testing failures.

[//]: # (PR title: Remember to name your PR descriptively!)