### PR TITLE
Move migration function call to its own endpoint for use in deploymen…

### DIFF
--- a/containers/record-linkage/app/main.py
+++ b/containers/record-linkage/app/main.py
@@ -152,7 +152,7 @@ async def health_check() -> HealthCheckResponse:
 
 
 @app.get("/run-mpi-migrations")
-async def run_mpi_migrations() -> HealthCheckResponse:
+async def run_mpi_migrations():
 
     try:
         run_migrations()

--- a/containers/record-linkage/app/main.py
+++ b/containers/record-linkage/app/main.py
@@ -143,12 +143,22 @@ async def health_check() -> HealthCheckResponse:
     linkage service is available and running properly. The mpi_connection_status field
     contains a description of the connection health to the MPI database.
     """
-    run_migrations()
+
     try:
         connect_to_mpi_with_env_vars()
     except Exception as err:
         return {"status": "OK", "mpi_connection_status": str(err)}
     return {"status": "OK", "mpi_connection_status": "OK"}
+
+
+@app.get("/run-mpi-migrations")
+async def run_mpi_migrations() -> HealthCheckResponse:
+
+    try:
+        run_migrations()
+    except Exception as err:
+        return {"status": "OK", "Error": str(err)}
+    return {"status": "OK"}
 
 
 @app.post("/link-record", status_code=200)
@@ -166,7 +176,6 @@ async def link_record(input: LinkRecordInput, response: Response) -> LinkRecordR
 
     input = dict(input)
     input_bundle = input.get("bundle", {})
-    run_migrations()
 
     # Check that DB type is appropriately set up as Postgres so
     # we can fail fast if it's not


### PR DESCRIPTION
…t workflow

# PULL REQUEST

## Summary
Removing migration function call from health check endpoint and record-linkage endpoint and moving it instead to its own endpoint which we can hit during the deployment process to engage the migrationification process.

## Related Issue
Half of the fix for #432 , once this is merged I'll open a PR with the deployment workflow changes in phdi-azure
https://app.zenhub.com/workspaces/dibbs-63f7aa3e1ecdbb0011edb299/issues/gh/cdcgov/phdi/432

## Additional Information
I feel a little weird about having a run migrations endpoint, if anyone else has great ideas on how to run these once on deployment feel free to chime in!

[//]: # (PR title: Remember to name your PR descriptively!)