### PR TITLE
Run record linkage migrations on spin up not RL endpoint request

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -144,6 +144,15 @@ jobs:
           POSTGRES_PASSWORD: pw
           POSTGRES_DB: testdb
           POSTGRES_USER: postgres
+          MPI_DBNAME: testdb
+          MPI_PASSWORD: pw
+          MPI_DB_TYPE: postgres
+          MPI_HOST: localhost
+          MPI_USER: postgres
+          MPI_PORT: 5432
+          MPI_PATIENT_TABLE: patient
+          MPI_PERSON_TABLE: person
+
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -144,14 +144,6 @@ jobs:
           POSTGRES_PASSWORD: pw
           POSTGRES_DB: testdb
           POSTGRES_USER: postgres
-          MPI_DBNAME: testdb
-          MPI_PASSWORD: pw
-          MPI_DB_TYPE: postgres
-          MPI_HOST: localhost
-          MPI_USER: postgres
-          MPI_PORT: 5432
-          MPI_PATIENT_TABLE: patient
-          MPI_PERSON_TABLE: person
 
         # Set health checks to wait until postgres has started
         options: >-
@@ -180,6 +172,15 @@ jobs:
         run: |
           pip install -r requirements.txt
       - name: Run unit tests for containers
+          env:
+            MPI_DBNAME: testdb
+            MPI_PASSWORD: pw
+            MPI_DB_TYPE: postgres
+            MPI_HOST: localhost
+            MPI_USER: postgres
+            MPI_PORT: 5432
+            MPI_PATIENT_TABLE: patient
+            MPI_PERSON_TABLE: person
         working-directory: ./containers/${{matrix.container-to-test}}/tests
         run: |
           python -m pytest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -172,15 +172,15 @@ jobs:
         run: |
           pip install -r requirements.txt
       - name: Run unit tests for containers
-          env:
-            MPI_DBNAME: testdb
-            MPI_PASSWORD: pw
-            MPI_DB_TYPE: postgres
-            MPI_HOST: localhost
-            MPI_USER: postgres
-            MPI_PORT: 5432
-            MPI_PATIENT_TABLE: patient
-            MPI_PERSON_TABLE: person
+        env:
+          MPI_DBNAME: testdb
+          MPI_PASSWORD: pw
+          MPI_DB_TYPE: postgres
+          MPI_HOST: localhost
+          MPI_USER: postgres
+          MPI_PORT: 5432
+          MPI_PATIENT_TABLE: patient
+          MPI_PERSON_TABLE: person
         working-directory: ./containers/${{matrix.container-to-test}}/tests
         run: |
           python -m pytest

--- a/containers/record-linkage/app/main.py
+++ b/containers/record-linkage/app/main.py
@@ -62,6 +62,9 @@ def run_migrations():
             print_psycopg2_exception(err)
 
 
+#Run MPI migrations on spin up
+run_migrations()
+
 # Instantiate FastAPI and set metadata.
 description = (Path(__file__).parent.parent / "description.md").read_text(
     encoding="utf-8"
@@ -143,7 +146,7 @@ async def health_check() -> HealthCheckResponse:
     linkage service is available and running properly. The mpi_connection_status field
     contains a description of the connection health to the MPI database.
     """
-    run_migrations()
+
     try:
         connect_to_mpi_with_env_vars()
     except Exception as err:
@@ -166,7 +169,6 @@ async def link_record(input: LinkRecordInput, response: Response) -> LinkRecordR
 
     input = dict(input)
     input_bundle = input.get("bundle", {})
-    run_migrations()
 
     # Check that DB type is appropriately set up as Postgres so
     # we can fail fast if it's not

--- a/containers/record-linkage/app/main.py
+++ b/containers/record-linkage/app/main.py
@@ -62,7 +62,7 @@ def run_migrations():
             print_psycopg2_exception(err)
 
 
-#Run MPI migrations on spin up
+# Run MPI migrations on spin up
 run_migrations()
 
 # Instantiate FastAPI and set metadata.

--- a/containers/record-linkage/tests/test_record_linkage.py
+++ b/containers/record-linkage/tests/test_record_linkage.py
@@ -11,16 +11,6 @@ import pathlib
 import psycopg2
 import pytest
 
-client = TestClient(app)
-
-test_bundle = json.load(
-    open(
-        pathlib.Path(__file__).parent
-        / "assets"
-        / "patient_bundle_to_link_with_mpi.json"
-    )
-)
-
 
 def set_mpi_env_vars():
     os.environ["mpi_db_type"] = "postgres"
@@ -32,6 +22,20 @@ def set_mpi_env_vars():
     os.environ["mpi_patient_table"] = "patient"
     os.environ["mpi_person_table"] = "person"
     get_settings.cache_clear()
+
+
+set_mpi_env_vars()
+
+client = TestClient(app)
+
+
+test_bundle = json.load(
+    open(
+        pathlib.Path(__file__).parent
+        / "assets"
+        / "patient_bundle_to_link_with_mpi.json"
+    )
+)
 
 
 def pop_mpi_env_vars():
@@ -168,3 +172,6 @@ def test_linkage_success():
     dbconn.close()
 
     pop_mpi_env_vars()
+
+
+pop_mpi_env_vars()

--- a/containers/record-linkage/tests/test_record_linkage.py
+++ b/containers/record-linkage/tests/test_record_linkage.py
@@ -2,14 +2,12 @@ from fastapi import status
 from fastapi.testclient import TestClient
 from app.config import get_settings
 from app.main import app
-from pydantic import ValidationError
 
 import copy
 import json
 import os
 import pathlib
 import psycopg2
-import pytest
 
 
 def set_mpi_env_vars():
@@ -23,8 +21,6 @@ def set_mpi_env_vars():
     os.environ["mpi_person_table"] = "person"
     get_settings.cache_clear()
 
-
-set_mpi_env_vars()
 
 client = TestClient(app)
 
@@ -172,6 +168,3 @@ def test_linkage_success():
     dbconn.close()
 
     pop_mpi_env_vars()
-
-
-pop_mpi_env_vars()

--- a/containers/record-linkage/tests/test_record_linkage.py
+++ b/containers/record-linkage/tests/test_record_linkage.py
@@ -1,7 +1,7 @@
 from fastapi import status
 from fastapi.testclient import TestClient
 from app.config import get_settings
-from app.config import run_migrations
+from app.main import run_migrations
 from app.main import app
 from pydantic import ValidationError
 

--- a/containers/record-linkage/tests/test_record_linkage.py
+++ b/containers/record-linkage/tests/test_record_linkage.py
@@ -1,7 +1,6 @@
 from fastapi import status
 from fastapi.testclient import TestClient
 from app.config import get_settings
-from app.main import run_migrations
 from app.main import app
 from pydantic import ValidationError
 
@@ -52,7 +51,6 @@ def pop_mpi_env_vars():
 
 def test_health_check():
     set_mpi_env_vars()
-    run_migrations()
     actual_response = client.get("/")
     assert actual_response.status_code == 200
     assert actual_response.json() == {
@@ -64,7 +62,6 @@ def test_health_check():
 
 def test_linkage_bundle_with_no_patient():
     set_mpi_env_vars()
-    run_migrations()
     bad_bundle = {"entry": []}
     expected_response = {
         "message": "Supplied bundle contains no Patient resource to link on.",
@@ -82,7 +79,6 @@ def test_linkage_bundle_with_no_patient():
 
 def test_linkage_invalid_db_type():
     set_mpi_env_vars()
-    run_migrations()
     invalid_db_type = "mssql"
     os.environ["mpi_db_type"] = invalid_db_type
     get_settings.cache_clear()
@@ -104,7 +100,6 @@ def test_linkage_invalid_db_type():
 
 def test_linkage_success():
     set_mpi_env_vars()
-    run_migrations()
     entry_list = copy.deepcopy(test_bundle["entry"])
 
     bundle_1 = test_bundle

--- a/containers/record-linkage/tests/test_record_linkage.py
+++ b/containers/record-linkage/tests/test_record_linkage.py
@@ -168,32 +168,3 @@ def test_linkage_success():
     dbconn.close()
 
     pop_mpi_env_vars()
-
-
-def test_linkage_invalid_postgres_settings():
-    set_mpi_env_vars()
-    for setting in [
-        "mpi_dbname",
-        "mpi_user",
-        "mpi_password",
-        "mpi_host",
-        "mpi_port",
-        "mpi_patient_table",
-        "mpi_person_table",
-    ]:
-        removed_setting = os.environ[setting]
-        os.environ.pop(setting, None)
-        get_settings.cache_clear()
-
-        with pytest.raises(ValidationError) as e:
-            client.post("/link-record", json={"bundle": test_bundle})
-            assert "validation errors for Settings" in str(e.value)
-
-        os.environ[setting] = "invalid_value"
-        get_settings.cache_clear()
-        actual_response = client.post("/link-record", json={"bundle": test_bundle})
-        assert actual_response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "Could not connect to database" in actual_response.json()["message"]
-        os.environ[setting] = removed_setting
-
-    pop_mpi_env_vars()

--- a/containers/record-linkage/tests/test_record_linkage.py
+++ b/containers/record-linkage/tests/test_record_linkage.py
@@ -1,6 +1,7 @@
 from fastapi import status
 from fastapi.testclient import TestClient
 from app.config import get_settings
+from app.config import run_migrations
 from app.main import app
 from pydantic import ValidationError
 
@@ -51,6 +52,7 @@ def pop_mpi_env_vars():
 
 def test_health_check():
     set_mpi_env_vars()
+    run_migrations()
     actual_response = client.get("/")
     assert actual_response.status_code == 200
     assert actual_response.json() == {
@@ -62,6 +64,7 @@ def test_health_check():
 
 def test_linkage_bundle_with_no_patient():
     set_mpi_env_vars()
+    run_migrations()
     bad_bundle = {"entry": []}
     expected_response = {
         "message": "Supplied bundle contains no Patient resource to link on.",
@@ -79,6 +82,7 @@ def test_linkage_bundle_with_no_patient():
 
 def test_linkage_invalid_db_type():
     set_mpi_env_vars()
+    run_migrations()
     invalid_db_type = "mssql"
     os.environ["mpi_db_type"] = invalid_db_type
     get_settings.cache_clear()
@@ -100,6 +104,7 @@ def test_linkage_invalid_db_type():
 
 def test_linkage_success():
     set_mpi_env_vars()
+    run_migrations()
     entry_list = copy.deepcopy(test_bundle["entry"])
 
     bundle_1 = test_bundle


### PR DESCRIPTION
# PULL REQUEST

## Summary
Changing approach from last PR, not doing an endpoint, just running the migration function in main.py for record linkage. No need for a second PR in phdi-azure for this one.

## Related Issue
Fixes [#432](https://app.zenhub.com/workspaces/dibbs-63f7aa3e1ecdbb0011edb299/issues/gh/cdcgov/phdi/432)

## Additional Information
Anything else the review team should know?

[//]: # (PR title: Remember to name your PR descriptively!)