### PR TITLE
Add filter to MRN values

### DIFF
--- a/phdi/linkage/link.py
+++ b/phdi/linkage/link.py
@@ -24,7 +24,7 @@ LINKING_FIELDS_TO_FHIRPATHS = {
     "city": "Patient.address.city",
     "state": "Patient.address.state",
     "sex": "Patient.gender",
-    "mrn": "Patient.identifier.value",
+    "mrn": "Patient.identifier.where(type.coding.code='MR').value",
 }
 
 

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -42,7 +42,7 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
             "city": """$.address[*].city""",
             "first_name": """$.name[*].given""",
             "last_name": """$.name[*].family""",
-            "mrn": """$.identifier.value""",
+            "mrn": """$.identifier ?(@.type.coding[0].code=="MR").value""",
             "sex": "$.gender",
             "state": """$.address[*].state""",
             "zip": """$.address[*].postalCode""",

--- a/tests/assets/patient_bundle_to_link_with_mpi.json
+++ b/tests/assets/patient_bundle_to_link_with_mpi.json
@@ -114,6 +114,18 @@
                 "id": "2c6d5fd1-4a70-11eb-99fd-ad786a821574",
                 "identifier": [
                     {
+                        "value": "649-555-0120",
+                        "type": {
+                            "coding": [
+                                {
+                                    "code": "SSN",
+                                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                                    "display": "Social security number"
+                                }
+                            ]
+                        }
+                    },
+                    {
                         "value": "7894561235",
                         "type": {
                             "coding": [

--- a/tests/linkage/test_linkage.py
+++ b/tests/linkage/test_linkage.py
@@ -1226,6 +1226,8 @@ def test_flatten_patient():
         for p in patients
         if p.get("resource", {}).get("resourceType", "") == "Patient"
     ]
+
+    # Use patient with multiple identifiers to also test MRN-specific filter
     assert _flatten_patient_resource(patients[2]) == [
         "2c6d5fd1-4a70-11eb-99fd-ad786a821574",
         None,

--- a/tests/linkage/test_postgres_mpi_connector.py
+++ b/tests/linkage/test_postgres_mpi_connector.py
@@ -33,7 +33,7 @@ def test_generate_block_query():
         "$.address[*].city",
         "$.name[*].given",
         "$.name[*].family",
-        "$.identifier.value",
+        '$.identifier ?(@.type.coding[0].code=="MR").value',
         "$.gender",
         "$.address[*].state",
         "$.address[*].postalCode",


### PR DESCRIPTION
# Correctly filter on identifier

## Summary
This PR corrects a bug in our JSON path querying and FHIR Path accessing where we were grabbing _any_ identifier the patient had, rather than MRN specifically. Now, we correctly filter on both the MPI query side as well as the incoming patient / flattening side for exclusively MRN.

## Related Issue
Fixes #509 
