### PR TITLE
Install phdi from PyPI in all containers

### DIFF
--- a/.github/workflows/createNewRelease.yaml
+++ b/.github/workflows/createNewRelease.yaml
@@ -126,7 +126,9 @@ jobs:
 
 # Rebuild all containers for the new release
   build-containers-for-release:
-    needs: tag-release
+    needs: 
+      - tag-release
+      - release-to-pypi
     permissions:
       contents: read
       packages: write

--- a/containers/alerts/requirements.txt
+++ b/containers/alerts/requirements.txt
@@ -2,11 +2,10 @@ azure-communication-identity
 azure-communication-phonenumbers
 azure-communication-sms
 azure-identity
-phdi @ git+https://github.com/CDCgov/phdi.git@main
+phdi
 fastapi
 uvicorn
 httpx
 slack_sdk
 pymsteams
 pytest
-phdi @ git+https://github.com/CDCgov/phdi.git@main

--- a/containers/fhir-converter/Dockerfile
+++ b/containers/fhir-converter/Dockerfile
@@ -20,7 +20,7 @@ COPY --from=build /build/FHIR-Converter/data/Templates /build/FHIR-Converter/dat
 
 # Install python/pip
 ENV PYTHONUNBUFFERED=1
-RUN apt-get update && apt-get install -y python3 python3-pip
+RUN apt-get update && apt-get install -y python3 python3-pip git
 RUN pip3 install --no-cache --upgrade pip setuptools
 
 # Install requirements

--- a/containers/fhir-converter/requirements.txt
+++ b/containers/fhir-converter/requirements.txt
@@ -15,7 +15,7 @@ Jinja2
 MarkupSafe
 orjson
 packaging
-phdi @ git+https://github.com/CDCgov/phdi.git@main
+phdi
 pluggy
 py
 pydantic

--- a/containers/ingestion/requirements.txt
+++ b/containers/ingestion/requirements.txt
@@ -1,4 +1,4 @@
 fastapi
 uvicorn
-phdi @ git+https://github.com/CDCgov/phdi.git@main
+phdi
 httpx

--- a/containers/kafka-to-delta-table/requirements.txt
+++ b/containers/kafka-to-delta-table/requirements.txt
@@ -4,6 +4,6 @@ argparse
 pytest
 uvicorn
 httpx
-phdi @ git+https://github.com/CDCgov/phdi.git@main
+phdi
 py4j==0.10.9.5
 requests

--- a/containers/message-parser/requirements.txt
+++ b/containers/message-parser/requirements.txt
@@ -1,7 +1,6 @@
 fastapi
 uvicorn
-# TODO: Install phdi from PyPi when release that includes that Tabulation module is available.
-phdi @ git+https://github.com/CDCgov/phdi@main
+phdi
 httpx
 pytest
 frozendict

--- a/containers/record-linkage/requirements.txt
+++ b/containers/record-linkage/requirements.txt
@@ -1,6 +1,6 @@
 fastapi
 uvicorn
-phdi @ git+https://github.com/CDCgov/phdi.git@main
+phdi
 httpx
 pathlib
 pydantic

--- a/containers/tabulation/requirements.txt
+++ b/containers/tabulation/requirements.txt
@@ -1,7 +1,6 @@
 fastapi
 uvicorn
-# TODO: Install phdi from PyPi when release that includes that Tabulation module is available.
-phdi @ git+https://github.com/CDCgov/phdi.git@main
+phdi
 httpx
 pytest
 jsonschema

--- a/containers/validation/requirements.txt
+++ b/containers/validation/requirements.txt
@@ -1,7 +1,6 @@
 fastapi
 uvicorn
-# TODO: Install phdi from PyPi when release that includes that Validation module is available.
-phdi @ git+https://github.com/CDCgov/phdi@main
+phdi
 httpx
 pytest
 jsonschema


### PR DESCRIPTION
Now that PyPI releases are working properly, we can just install `phdi` from PyPI in all of our containers.