### PR TITLE
Add json formatter to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
     rev: v4.4.0
     hooks:
       - id: pretty-format-json
+        args: [ --autofix, --no-sort-keys ]
   - repo: local
     hooks:
       # run `terraform fmt` if tf files are modified and terraform is installed

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,10 @@ repos:
     rev: 6.0.0
     hooks:
       - id: flake8
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: pretty-format-json
   - repo: local
     hooks:
       # run `terraform fmt` if tf files are modified and terraform is installed

--- a/containers/ingestion/tests/assets/single_patient_bundle.json
+++ b/containers/ingestion/tests/assets/single_patient_bundle.json
@@ -1,47 +1,47 @@
 {
-    "resourceType": "Bundle",
-    "id": "bundle-transaction",
-    "meta": {
-        "lastUpdated": "2018-03-11T11:22:16Z"
-    },
-    "type": "transaction",
-    "entry": [
-        {
-            "resource": {
-                "resourceType": "Patient",
-                "name": [
-                    {
-                        "family": "Smith",
-                        "given": [
-                            "DeeDee"
-                        ],
-                        "use": "official"
-                    }
-                ],
-                "gender": "female",
-                "telecom": [
-                    {
-                        "system": "phone",
-                        "value": "8015557777"
-                    }
-                ],
-                "address": [
-                    {
-                        "line": [
-                            "123 Main St."
-                        ],
-                        "city": "Anycity",
-                        "state": "CA",
-                        "postalCode": "12345",
-                        "country": "USA"
-                    }
-                ],
-                "birthDate": "1955-11-05"
-            },
-            "request": {
-                "method": "POST",
-                "url": "Patient"
-            }
-        }
-    ]
+  "resourceType": "Bundle",
+  "id": "bundle-transaction",
+  "meta": {
+    "lastUpdated": "2018-03-11T11:22:16Z"
+  },
+  "type": "transaction",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "name": [
+          {
+            "family": "Smith",
+            "given": [
+              "DeeDee"
+            ],
+            "use": "official"
+          }
+        ],
+        "gender": "female",
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "8015557777"
+          }
+        ],
+        "address": [
+          {
+            "line": [
+              "123 Main St."
+            ],
+            "city": "Anycity",
+            "state": "CA",
+            "postalCode": "12345",
+            "country": "USA"
+          }
+        ],
+        "birthDate": "1955-11-05"
+      },
+      "request": {
+        "method": "POST",
+        "url": "Patient"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
# PULL REQUEST

## Summary
Add JSON formatter to our pre-commit hooks. 

## Related Issue
n/a

## Additional Information
We have a lot of JSON files floating around (mostly test FHIR bundles) and it would be nice not to need to manually format them.

Once this merges, folks may need to run `pre-commit autoupdate` to get the hook working again (at least, I needed to run it for some reason)

[//]: # (PR title: Remember to name your PR descriptively!)