### PR TITLE
Fix license_info on the BaseService class

### DIFF
--- a/phdi/containers/base_service.py
+++ b/phdi/containers/base_service.py
@@ -14,6 +14,12 @@ LICENSES = {"CreativeCommonsZero":{
     "MIT": {"name": "The MIT License", "url": "https://mit-license.org/"}
 }
 
+DIBBS_CONTACT = {
+        "name": "CDC Public Health Data Infrastructure",
+        "url": "https://cdcgov.github.io/phdi-site/",
+        "email": "dmibuildingblocks@cdc.gov",
+    }
+
 class BaseService:
     def __init__(
         self,
@@ -39,7 +45,7 @@ class BaseService:
         self.app = FastAPI(
             title=service_name,
             version=metadata.version("phdi"),
-            contact=self.DIBBS_CONTACT,
+            contact=DIBBS_CONTACT,
             license_info=LICENSES[license_info],
             description=description,
         )

--- a/phdi/containers/base_service.py
+++ b/phdi/containers/base_service.py
@@ -1,6 +1,5 @@
 from fastapi import FastAPI
 from pathlib import Path
-from enum import Enum
 from importlib import metadata
 from typing import Literal
 

--- a/phdi/containers/base_service.py
+++ b/phdi/containers/base_service.py
@@ -2,37 +2,25 @@ from fastapi import FastAPI
 from pathlib import Path
 from enum import Enum
 from importlib import metadata
+from typing import Literal
 
 
 # create a class with the DIBBs default Creative Commons Zero v1.0 and
 # MIT license to be used by the BaseService class
-class LicenseType(Enum):
-    CreativeCommonsZero = {
+LICENSES = {"CreativeCommonsZero":{
         "name": "Creative Commons Zero v1.0 Universal",
         "url": "https://creativecommons.org/publicdomain/zero/1.0/",
-    }
-    MIT = {"name": "The MIT License", "url": "https://mit-license.org/"}
-
+    },
+    "MIT": {"name": "The MIT License", "url": "https://mit-license.org/"}
+}
 
 class BaseService:
-    """
-    Base class for all DIBBs services. This class provides a FastAPI instance with DIBBs
-    metadata and optionally a health check endpoint.
-    """
-
-    LICENSE_INFO = LicenseType.CreativeCommonsZero
-    DIBBS_CONTACT = {
-        "name": "CDC Public Health Data Infrastructure",
-        "url": "https://cdcgov.github.io/phdi-site/",
-        "email": "dmibuildingblocks@cdc.gov",
-    }
-
     def __init__(
         self,
         service_name: str,
         description_path: str,
         include_health_check_endpoint: bool = True,
-        license_info: LicenseType = LICENSE_INFO,
+        license_info: Literal["CreativeCommonsZero", "MIT"] = "CreativeCommonsZero",
     ):
         """
         Initialize a BaseService instance.
@@ -52,7 +40,7 @@ class BaseService:
             title=service_name,
             version=metadata.version("phdi"),
             contact=self.DIBBS_CONTACT,
-            license_info=license_info,
+            license_info=LICENSES[license_info],
             description=description,
         )
 

--- a/phdi/containers/base_service.py
+++ b/phdi/containers/base_service.py
@@ -7,18 +7,20 @@ from typing import Literal
 
 # create a class with the DIBBs default Creative Commons Zero v1.0 and
 # MIT license to be used by the BaseService class
-LICENSES = {"CreativeCommonsZero":{
+LICENSES = {
+    "CreativeCommonsZero": {
         "name": "Creative Commons Zero v1.0 Universal",
         "url": "https://creativecommons.org/publicdomain/zero/1.0/",
     },
-    "MIT": {"name": "The MIT License", "url": "https://mit-license.org/"}
+    "MIT": {"name": "The MIT License", "url": "https://mit-license.org/"},
 }
 
 DIBBS_CONTACT = {
-        "name": "CDC Public Health Data Infrastructure",
-        "url": "https://cdcgov.github.io/phdi-site/",
-        "email": "dmibuildingblocks@cdc.gov",
-    }
+    "name": "CDC Public Health Data Infrastructure",
+    "url": "https://cdcgov.github.io/phdi-site/",
+    "email": "dmibuildingblocks@cdc.gov",
+}
+
 
 class BaseService:
     def __init__(

--- a/tests/containers/test_base_service.py
+++ b/tests/containers/test_base_service.py
@@ -1,12 +1,9 @@
-from phdi.containers.base_service import LicenseType, BaseService
+from phdi.containers.base_service import LICENSES, DIBBS_CONTACT, BaseService
 from fastapi.testclient import TestClient
 from pathlib import Path
 from importlib import metadata
 
 default_app_version = metadata.version("phdi")
-default_app_contact = BaseService.DIBBS_CONTACT
-default_app_license = LicenseType.CreativeCommonsZero
-alternate_app_license = LicenseType.MIT
 
 
 def test_base_service():
@@ -16,14 +13,17 @@ def test_base_service():
     )
     assert service.app.title == "test_service"
     assert service.app.version == default_app_version
-    assert service.app.contact == default_app_contact
-    assert service.app.license_info == default_app_license
+    assert service.app.contact == DIBBS_CONTACT
+    assert service.app.license_info == LICENSES["CreativeCommonsZero"]
     assert service.app.description == "This is a test description."
 
     client = TestClient(service.start())
     response = client.get("/")
     assert response.status_code == 200
     assert response.json() == {"status": "OK"}
+
+    response = client.get("/redoc")
+    assert response.status_code == 200
 
 
 def test_base_service_alternate_license():
@@ -33,10 +33,18 @@ def test_base_service_alternate_license():
         / "assets"
         / "containers"
         / "test_description.md",
-        license_info=alternate_app_license,
+        license_info="MIT",
     )
     assert service.app.title == "test_service"
     assert service.app.version == default_app_version
-    assert service.app.contact == default_app_contact
-    assert service.app.license_info == alternate_app_license
+    assert service.app.contact == DIBBS_CONTACT
+    assert service.app.license_info == LICENSES["MIT"]
     assert service.app.description == "This is a test description."
+
+    client = TestClient(service.start())
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"status": "OK"}
+
+    response = client.get("/redoc")
+    assert response.status_code == 200

--- a/utils/make_openapi_json.py
+++ b/utils/make_openapi_json.py
@@ -12,7 +12,7 @@ HTML version of the API documentation served by a FastAPI applications at the /d
 endpoint.
 """
 
-with open("openapi.json", "w") as f:
+with open("openapi.json", "w") as file:
     json.dump(
         get_openapi(
             title=app.title,
@@ -20,6 +20,8 @@ with open("openapi.json", "w") as f:
             openapi_version=app.openapi_version,
             description=app.description,
             routes=app.routes,
+            license_info=app.license_info,
+            contact=app.contact,
         ),
-        f,
+        file,
     )


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR ensures that we provide a `dict` to the `license_info` parameter in the `BaseService` class. Additionally, unit tests are updated to cover the `/redoc` endpoint to ensure that the `BaseService` can serve documentation appropriately. We also update our `make_openapi_json.py` script to include license and contact info in the docs we generate for the GitHub pages site.



[//]: # (PR title: Remember to name your PR descriptively!)