### PR TITLE
Handle empty lists when flattening blocks returned by the MPI during record linkage.

### DIFF
--- a/phdi/linkage/link.py
+++ b/phdi/linkage/link.py
@@ -603,6 +603,10 @@ def link_record_against_mpi(
                     continue
                 if idx_to_col[j - 2] != "first_name" and idx_to_col[j - 2] != "address":
                     while type(blocked_record[j]) == list:
+                        # Handle empty list edge case.
+                        if len(blocked_record[j]) == 0:
+                            blocked_record[j] = ""
+                            break
                         blocked_record[j] = blocked_record[j][0]
 
         clusters = _group_patient_block_by_person(data_block)

--- a/tests/assets/linkage/patient_bundle_to_link_with_mpi.json
+++ b/tests/assets/linkage/patient_bundle_to_link_with_mpi.json
@@ -244,20 +244,6 @@
       "resource": {
         "resourceType": "Patient",
         "id": "a81bc81b-dead-4e5d-abff-90865d1e13b1",
-        "identifier": [
-          {
-            "value": "7894561235",
-            "type": {
-              "coding": [
-                {
-                  "code": "MR",
-                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "display": "Medical record number"
-                }
-              ]
-            }
-          }
-        ],
         "name": [
           {
             "family": "Shepard",


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR allows us to handle flattening records returned in blocks during the blocking phase of record linkage that contain empty lists. Recent user testing in LAC demonstrated that we had not considered this edge case.

## Related Issue
Fixes CDCgov/phdi-azure#131

## Additional Information
During testing with LAC we encountered many `500 internal server errors` from the record linkage service. After investigation it was determined that these errors were caused by empty lists returned by the MPI in blocks for records that were missing an MRN. More details in the ZenHub ticket.

[//]: # (PR title: Remember to name your PR descriptively!)