### PR TITLE
Generalize write blob to storage endpoint

### DIFF
--- a/containers/ingestion/app/routers/cloud_storage.py
+++ b/containers/ingestion/app/routers/cloud_storage.py
@@ -71,7 +71,7 @@ def write_blob_to_cloud_storage_endpoint(
 
     full_file_name = input["file_name"]
     cloud_provider_connection.upload_object(
-        message=input,
+        message=input["blob"],
         container_name=input["bucket_name"],
         filename=full_file_name,
     )

--- a/containers/ingestion/tests/test_cloud_storage.py
+++ b/containers/ingestion/tests/test_cloud_storage.py
@@ -34,7 +34,9 @@ def test_cloud_storage_params_success(patched_blob_write, patched_get_provider):
     actual_response = client.post(client_url, json=test_request)
 
     patched_get_provider.return_value.upload_object.assert_called_with(
-        message=test_request["blob"], container_name="test_bucket", filename="test_file_name"
+        message=test_request["blob"],
+        container_name="test_bucket",
+        filename="test_file_name",
     )
 
     expected_message = (

--- a/containers/ingestion/tests/test_cloud_storage.py
+++ b/containers/ingestion/tests/test_cloud_storage.py
@@ -34,7 +34,7 @@ def test_cloud_storage_params_success(patched_blob_write, patched_get_provider):
     actual_response = client.post(client_url, json=test_request)
 
     patched_get_provider.return_value.upload_object.assert_called_with(
-        message=test_request, container_name="test_bucket", filename="test_file_name"
+        message=test_request["blob"], container_name="test_bucket", filename="test_file_name"
     )
 
     expected_message = (


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR updates the `/write_blob_to_storage` endpoint on the ingestion container to write only the value of the `blob` key in the request to storage instead of the entire request. This generalize the usability of this endpoint.



[//]: # (PR title: Remember to name your PR descriptively!)