### PR TITLE
Add assets folders to containers to fix bootup

### DIFF
--- a/containers/fhir-converter/Dockerfile
+++ b/containers/fhir-converter/Dockerfile
@@ -30,6 +30,7 @@ RUN pip3 install -r requirements.txt
 
 # Copy FastAPI app
 COPY app/main.py .
+COPY assets /assets
 
 # Copy eCR templates
 COPY Templates/eCR /build/FHIR-Converter/data/Templates/eCR

--- a/containers/ingestion/Dockerfile
+++ b/containers/ingestion/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get remove -y git && \
     apt-get autoremove -y
 
 COPY ./app /code/app
+COPY ./assets /code/assets
 COPY ./description.md /code/description.md
 
 EXPOSE 8080

--- a/containers/message-parser/Dockerfile
+++ b/containers/message-parser/Dockerfile
@@ -5,11 +5,12 @@ WORKDIR /code
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y git
-    
+
 COPY ./requirements.txt /code/requirements.txt
 RUN pip install -r requirements.txt
 
 COPY ./app /code/app
+COPY ./assets /code/assets
 COPY ./description.md /code/description.md
 
 EXPOSE 8080

--- a/containers/validation/Dockerfile
+++ b/containers/validation/Dockerfile
@@ -10,6 +10,7 @@ COPY ./requirements.txt /code/requirements.txt
 RUN pip install -r requirements.txt
 
 COPY ./app /code/app
+COPY ./assets /code/assets
 COPY ./config /code/config
 COPY ./description.md /code/description.md
 


### PR DESCRIPTION
Containers currently won't boot up because assets folders aren't copied it, and it tries to read them for docs.