### PR TITLE
Point containers to pypi

### DIFF
--- a/containers/alerts/Dockerfile
+++ b/containers/alerts/Dockerfile
@@ -2,10 +2,6 @@ FROM python:3.10-slim
 
 WORKDIR /code
 
-RUN apt-get update && \
-  apt-get upgrade -y && \
-  apt-get install -y git 
-
 COPY ./requirements.txt /code/requirements.txt
 RUN pip install -r requirements.txt
 

--- a/containers/alerts/requirements.txt
+++ b/containers/alerts/requirements.txt
@@ -2,7 +2,7 @@ azure-communication-identity
 azure-communication-phonenumbers
 azure-communication-sms
 azure-identity
-phdi @ git+https://github.com/CDCgov/phdi.git@main
+phdi
 fastapi
 uvicorn
 httpx

--- a/containers/ingestion/Dockerfile
+++ b/containers/ingestion/Dockerfile
@@ -2,10 +2,6 @@ FROM python:3.10-slim
 
 WORKDIR /code
 
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y git
-
 COPY ./requirements.txt /code/requirements.txt
 RUN pip install -r requirements.txt
 

--- a/containers/ingestion/Dockerfile
+++ b/containers/ingestion/Dockerfile
@@ -5,9 +5,6 @@ WORKDIR /code
 COPY ./requirements.txt /code/requirements.txt
 RUN pip install -r requirements.txt
 
-RUN apt-get remove -y git && \
-    apt-get autoremove -y
-
 COPY ./app /code/app
 COPY ./description.md /code/description.md
 

--- a/containers/ingestion/requirements.txt
+++ b/containers/ingestion/requirements.txt
@@ -1,4 +1,4 @@
 fastapi
 uvicorn
-phdi @ git+https://github.com/CDCgov/phdi.git@main
+phdi
 httpx

--- a/containers/message-parser/Dockerfile
+++ b/containers/message-parser/Dockerfile
@@ -1,10 +1,6 @@
 FROM python:3.10-slim
 
 WORKDIR /code
-
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y git
     
 COPY ./requirements.txt /code/requirements.txt
 RUN pip install -r requirements.txt

--- a/containers/message-parser/requirements.txt
+++ b/containers/message-parser/requirements.txt
@@ -1,6 +1,6 @@
 fastapi
 uvicorn
-phdi @ git+https://github.com/CDCgov/phdi.git@main
+phdi
 httpx
 pytest
 frozendict

--- a/containers/record-linkage/Dockerfile
+++ b/containers/record-linkage/Dockerfile
@@ -2,10 +2,6 @@ FROM python:3.10-slim
 
 WORKDIR /code
 
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y git
-
 COPY ./requirements.txt /code/requirements.txt
 RUN pip install -r requirements.txt
 

--- a/containers/record-linkage/requirements.txt
+++ b/containers/record-linkage/requirements.txt
@@ -1,6 +1,6 @@
 fastapi
 uvicorn
-phdi @ git+https://github.com/CDCgov/phdi.git@main
+phdi
 httpx
 pathlib
 pydantic

--- a/containers/tabulation/Dockerfile
+++ b/containers/tabulation/Dockerfile
@@ -2,12 +2,6 @@ FROM python:3.10-slim
 
 WORKDIR /code
 
-# Install git.
-# TODO: remove this step when a PyPi release of PHDI is available that includes Tabulation.
-RUN apt-get -y update && \
-    apt-get upgrade -y && \
-    apt-get -y install git gcc
-
 COPY ./requirements.txt /code/requirements.txt
 RUN pip install -r requirements.txt
 

--- a/containers/tabulation/Dockerfile
+++ b/containers/tabulation/Dockerfile
@@ -2,10 +2,16 @@ FROM python:3.10-slim
 
 WORKDIR /code
 
+# Install git.
+# TODO: remove this step when a PyPi release of PHDI is available that includes Tabulation.
+RUN apt-get -y update && \
+    apt-get upgrade -y && \
+    apt-get -y install gcc
+
 COPY ./requirements.txt /code/requirements.txt
 RUN pip install -r requirements.txt
 
-RUN apt-get -y remove git gcc && \
+RUN apt-get -y remove gcc && \
     apt-get -y autoremove
 
 COPY ./app /code/app

--- a/containers/tabulation/requirements.txt
+++ b/containers/tabulation/requirements.txt
@@ -1,6 +1,6 @@
 fastapi
 uvicorn
-phdi @ git+https://github.com/CDCgov/phdi.git@main
+phdi
 httpx
 pytest
 jsonschema

--- a/containers/validation/Dockerfile
+++ b/containers/validation/Dockerfile
@@ -2,10 +2,6 @@ FROM python:3.10-slim
 
 WORKDIR /code
 
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y git
-
 COPY ./requirements.txt /code/requirements.txt
 RUN pip install -r requirements.txt
 

--- a/containers/validation/requirements.txt
+++ b/containers/validation/requirements.txt
@@ -1,6 +1,6 @@
 fastapi
 uvicorn
-phdi @ git+https://github.com/CDCgov/phdi.git@main
+phdi
 httpx
 pytest
 jsonschema

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "phdi"
-version = "v1.0.2"
+version = "v1.0.3"
 description = "Public health data infrastructure Building Blocks is a library to help public health departments work with their data"
 authors = ["Kenneth Chow <kenneth@skylight.digital>", "Brandon Mader <brandon@skylight.digital>", "Spencer Kathol <spencer@skylight.digital>", "Nick Clyde <nclyde@skylight.digital", "Dan Paseltiner <dan@skylight.digital>", "Brady Fausett <brady@skylight.digital>", "Marcelle Goggins <marcelle@skylight.digital", "Nick Bristow <nick@skylight.digital>", "Bryan Britten <bryan@skylight.digital>", "Emma Stephenson <emma@skylight.digital>" , "Gordon Farrell <gordon@skylight.digital>", "Robert Mitchell <rmitchell@skylight.digital>"]
 homepage = "https://github.com/CDCgov/phdi"


### PR DESCRIPTION
# PULL REQUEST

## Summary
Now that the release process is in place we can point all of our containers back to PyPi. This also means that we no longer need to install git in the containers.
