### PR TITLE
Add external person id into MPI base functionality to provide mechanism for seeding to be able to add person and external person id at the same time

### DIFF
--- a/containers/record-linkage/app/main.py
+++ b/containers/record-linkage/app/main.py
@@ -204,7 +204,7 @@ async def link_record(input: LinkRecordInput, response: Response) -> LinkRecordR
     try:
         db_client = connect_to_mpi_with_env_vars()
         (found_match, new_person_id) = link_record_against_mpi(
-            record_to_link, algo_config, db_client, external_person_id=external_id
+            record_to_link, algo_config, db_client, external_id
         )
         updated_bundle = add_person_resource(
             new_person_id, record_to_link.get("id", ""), input_bundle

--- a/containers/record-linkage/app/main.py
+++ b/containers/record-linkage/app/main.py
@@ -91,7 +91,7 @@ class LinkRecordInput(BaseModel):
         "algorithm.",
         default={},
     )
-    external_person_id: str = Field(
+    external_person_id: Optional[str] = Field(
         description="The External Identifier, provided by the client,"
         " for a unique patient/person that is linked to patient(s)",
         default=None,
@@ -163,7 +163,7 @@ async def link_record(input: LinkRecordInput, response: Response) -> LinkRecordR
 
     input = dict(input)
     input_bundle = input.get("bundle", {})
-    external_id = input.get("external_person_id")
+    external_id = input.get("external_person_id", None)
 
     # Check that DB type is appropriately set up as Postgres so
     # we can fail fast if it's not

--- a/containers/record-linkage/app/main.py
+++ b/containers/record-linkage/app/main.py
@@ -91,6 +91,11 @@ class LinkRecordInput(BaseModel):
         "algorithm.",
         default={},
     )
+    external_person_id: str = Field(
+        description="The External Identifier, provided by the client,"
+        " for a unique patient/person that is linked to patient(s)",
+        default=None,
+    )
 
 
 class LinkRecordResponse(BaseModel):
@@ -158,6 +163,7 @@ async def link_record(input: LinkRecordInput, response: Response) -> LinkRecordR
 
     input = dict(input)
     input_bundle = input.get("bundle", {})
+    external_id = input.get("external_person_id")
 
     # Check that DB type is appropriately set up as Postgres so
     # we can fail fast if it's not

--- a/containers/record-linkage/app/main.py
+++ b/containers/record-linkage/app/main.py
@@ -204,7 +204,7 @@ async def link_record(input: LinkRecordInput, response: Response) -> LinkRecordR
     try:
         db_client = connect_to_mpi_with_env_vars()
         (found_match, new_person_id) = link_record_against_mpi(
-            record_to_link, algo_config, db_client
+            record_to_link, algo_config, db_client, external_person_id=external_id
         )
         updated_bundle = add_person_resource(
             new_person_id, record_to_link.get("id", ""), input_bundle

--- a/containers/record-linkage/app/main.py
+++ b/containers/record-linkage/app/main.py
@@ -163,7 +163,9 @@ async def link_record(input: LinkRecordInput, response: Response) -> LinkRecordR
 
     input = dict(input)
     input_bundle = input.get("bundle", {})
-    external_id = input.get("external_person_id", None)
+    # TODO: Once the code that includes the external_person_id in
+    # the sdk is merged, then bring back the external_id code here
+    # external_id = input.get("external_person_id", None)
 
     # Check that DB type is appropriately set up as Postgres so
     # we can fail fast if it's not
@@ -201,10 +203,12 @@ async def link_record(input: LinkRecordInput, response: Response) -> LinkRecordR
 
     # Initialize a DB connection for use with the MPI
     # Then, link away
+    # TODO: Once the code that includes the external_person_id in
+    # the sdk is merged, then bring back the external_id code here
     try:
         db_client = connect_to_mpi_with_env_vars()
         (found_match, new_person_id) = link_record_against_mpi(
-            record_to_link, algo_config, db_client, external_id
+            record_to_link, algo_config, db_client  # , external_id
         )
         updated_bundle = add_person_resource(
             new_person_id, record_to_link.get("id", ""), input_bundle

--- a/containers/record-linkage/description.md
+++ b/containers/record-linkage/description.md
@@ -18,7 +18,7 @@ Docker version 20.10.21, build baeda1f
 
 2. Navigate to the `containers/record-linkage` folder and start the service by running `docker compose up --build`
 
-Congratulations the FHIR Converter should now be running on `localhost:8080`!
+Congratulations the record-linkage should now be running on `localhost:8080`!
 
 #### Running with Docker
 

--- a/phdi/linkage/core.py
+++ b/phdi/linkage/core.py
@@ -37,9 +37,10 @@ class BaseMPIConnectorClient(ABC):
     def insert_match_patient() -> None:
         """
         If a matching person ID has been found in the MPI, inserts a new patient into
-        the patient table and updates the person table to link to the new patient; else
-        inserts a new patient into the patient table and inserts a new person into the
-        person table with a new personID, linking the new personID to the new patient.
+        the patient table, including the matched person id, to link the new patient
+        and matched person ID; else inserts a new patient into the patient table and
+        inserts a new person into the person table with a new person ID, linking the
+        new person ID to the new patient.
 
         """
         pass  # pragma: no cover
@@ -50,5 +51,21 @@ class BaseMPIConnectorClient(ABC):
         Generates a query for selecting a block of data from the patient table per the
         block_vals parameters. Accepted blocking fields include: first_name, last_name,
         birthdate, addess, city, state, zip, mrn, and sex.
+        """
+        pass  # pragma: no cover
+
+    @abstractmethod
+    def _insert_person() -> None:
+        """
+        If person id is not supplied and external person id is not supplied
+        then insert a new person record with an auto-generated person id (UUID)
+        with a Null external person id and return that new person id. If the
+        person id is not supplied but an external person id is supplied try
+        to find an existing person record with the external person id and
+        return that person id; otherwise add a new person record with an
+        auto-generated person id (UUID) with the supplied external person id
+        and return the new person id.  If person id and external person id are
+        both supplied then update the person records external person id if it
+        is Null and return the person id.
         """
         pass  # pragma: no cover

--- a/phdi/linkage/core.py
+++ b/phdi/linkage/core.py
@@ -55,7 +55,7 @@ class BaseMPIConnectorClient(ABC):
         pass  # pragma: no cover
 
     @abstractmethod
-    def _insert_person() -> None:
+    def _insert_person() -> tuple:
         """
         If person id is not supplied and external person id is not supplied
         then insert a new person record with an auto-generated person id (UUID)

--- a/phdi/linkage/link.py
+++ b/phdi/linkage/link.py
@@ -640,8 +640,10 @@ def link_record_against_mpi(
 
     # Didn't match any person in our database
     if len(linkage_scores) == 0:
-        new_person_id = db_client.insert_match_patient(record, person_id=None)
-        return (False, new_person_id)
+        (matched, new_person_id) = db_client.insert_match_patient(
+            record, person_id=None
+        )
+        return (matched, new_person_id)
 
     # Determine strongest match, upsert, then let the caller know
     else:

--- a/phdi/linkage/link.py
+++ b/phdi/linkage/link.py
@@ -546,6 +546,7 @@ def link_record_against_mpi(
     record: dict,
     algo_config: List[dict],
     db_client: BaseMPIConnectorClient,
+    external_person_id: str = None,
 ) -> tuple[bool, str]:
     """
     Runs record linkage on a single incoming record (extracted from a FHIR
@@ -641,14 +642,16 @@ def link_record_against_mpi(
     # Didn't match any person in our database
     if len(linkage_scores) == 0:
         (matched, new_person_id) = db_client.insert_match_patient(
-            record, person_id=None
+            record, person_id=None, external_person_id=external_person_id
         )
         return (matched, new_person_id)
 
     # Determine strongest match, upsert, then let the caller know
     else:
         best_person = _find_strongest_link(linkage_scores)
-        db_client.insert_match_patient(record, person_id=best_person)
+        db_client.insert_match_patient(
+            record, person_id=best_person, external_person_id=external_person_id
+        )
         return (True, best_person)
 
 

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -339,7 +339,7 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
                 matched = True
                 update_person_query = SQL(
                     "UPDATE {person_table} SET external_person_id = %s "
-                    "WHERE person_id = %s AND external_person_id = NULL"
+                    "WHERE person_id = %s AND external_person_id IS NULL"
                 ).format(person_table=Identifier(self.person_table))
                 update_data = [external_person_id, person_id]
                 db_cursor.execute(update_person_query, update_data)

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -310,7 +310,10 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
                 query_data = [external_person_id]
                 db_cursor.execute(person_query, query_data)
                 # Retrieve person_id that has the supplied external_person_id
-                found_person_id = db_cursor.fetchall()[0][0]
+                returned_data = db_cursor.fetchall()
+
+                if returned_data is not None and len(returned_data) > 0:
+                    found_person_id = returned_data[0][0]
 
                 if found_person_id and found_person_id is not None:
                     matched = True

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -310,7 +310,7 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
                 query_data = [external_person_id]
                 db_cursor.execute(person_query, query_data)
                 # Retrieve person_id that has the supplied external_person_id
-                found_person_id = db_cursor.fetchall()[0]
+                found_person_id = db_cursor.fetchall()[0][0]
 
                 if found_person_id and found_person_id is not None:
                     matched = True

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -310,7 +310,7 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
                 query_data = [external_person_id]
                 db_cursor.execute(person_query, query_data)
                 # Retrieve person_id that has the supplied external_person_id
-                found_person_id = db_cursor.fetchall()
+                found_person_id = db_cursor.fetchall()[0]
 
                 if found_person_id and found_person_id is not None:
                     matched = True

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -310,7 +310,7 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
                 query_data = [external_person_id]
                 db_cursor.execute(person_query, query_data)
                 # Retrieve person_id that has the supplied external_person_id
-                found_person_id = db_cursor.fetchall()[0]
+                found_person_id = db_cursor.fetchall()
 
                 if found_person_id and found_person_id is not None:
                     matched = True

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -310,7 +310,7 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
                 query_data = [external_person_id]
                 db_cursor.execute(person_query, query_data)
                 # Retrieve person_id that has the supplied external_person_id
-                found_person_id = db_cursor.fetchall()[0][0]
+                found_person_id = db_cursor.fetchall()[0]
 
                 if found_person_id and found_person_id is not None:
                     matched = True

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -342,9 +342,9 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
                 matched = True
                 update_person_query = SQL(
                     "UPDATE {person_table} SET external_person_id = %s "
-                    "WHERE external_person_id = 'NULL'"
+                    "WHERE person_id = %s AND external_person_id = 'NULL'"
                 ).format(person_table=Identifier(self.person_table))
-                update_data = [external_person_id]
+                update_data = [external_person_id, person_id]
                 db_cursor.execute(update_person_query, update_data)
 
         except Exception as error:  # pragma: no cover

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -339,7 +339,7 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
                 matched = True
                 update_person_query = SQL(
                     "UPDATE {person_table} SET external_person_id = %s "
-                    "WHERE person_id = %s AND external_person_id = 'NULL'"
+                    "WHERE person_id = %s AND external_person_id = NULL"
                 ).format(person_table=Identifier(self.person_table))
                 update_data = [external_person_id, person_id]
                 db_cursor.execute(update_person_query, update_data)

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -336,6 +336,9 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
             # and not none and a record with the external person id was not found
             #  then update the person record with the supplied external person id
             elif person_id is not None and external_person_id != "'NULL'":
+                print("HERE")
+                print(external_person_id)
+                print(person_id)
                 matched = True
                 update_person_query = SQL(
                     "UPDATE {person_table} SET external_person_id = %s "

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -121,7 +121,7 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
         patient_resource: Dict,
         person_id=None,
         external_person_id=None,
-    ) -> Union[None, str]:
+    ) -> Union[None, tuple]:
         """
         If a matching person ID has been found in the MPI, inserts a new patient into
         the patient table, including the matched person id, to link the new patient
@@ -136,6 +136,7 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
           the patient record if a match has been found in the MPI, defaults to None.
         :return: the person id
         """
+        matched = False
         db_cursor = None
         db_conn = None
         try:
@@ -176,7 +177,7 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
         finally:
             self._close_connections(db_conn=db_conn, db_cursor=db_cursor)
 
-        return person_id
+        return (matched, person_id)
 
     def _generate_block_query(self, block_vals: dict) -> Tuple[SQL, list[str]]:
         """

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -297,7 +297,9 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
           found within the person table or not based upon the external person id
         """
         matched = False
-        found_person_id = None
+        print("HERE")
+        print(external_person_id)
+        print(person_id)
         try:
             if external_person_id is None:
                 external_person_id = "'NULL'"
@@ -336,7 +338,7 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
             # and not none and a record with the external person id was not found
             #  then update the person record with the supplied external person id
             elif person_id is not None and external_person_id != "'NULL'":
-                print("HERE")
+                print("THERE")
                 print(external_person_id)
                 print(person_id)
                 matched = True

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -339,7 +339,7 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
                 matched = True
                 update_person_query = SQL(
                     "UPDATE {person_table} SET external_person_id = %s "
-                    "WHERE person_id = %s AND external_person_id = 'NULL'"
+                    "WHERE person_id = '%s' AND external_person_id = 'NULL'"
                 ).format(person_table=Identifier(self.person_table))
                 update_data = [external_person_id, person_id]
                 db_cursor.execute(update_person_query, update_data)

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -338,7 +338,7 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
             # otherwise if person id is supplied and the external person id is supplied
             # and not none and a record with the external person id was not found
             #  then update the person record with the supplied external person id
-            elif external_person_id != "'NULL'":
+            elif person_id is not None and external_person_id != "'NULL'":
                 matched = True
                 update_person_query = SQL(
                     "UPDATE {person_table} SET external_person_id = %s "

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -120,16 +120,21 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
         self,
         patient_resource: Dict,
         person_id=None,
+        external_person_id=None,
     ) -> Union[None, str]:
         """
         If a matching person ID has been found in the MPI, inserts a new patient into
-        the patient table and updates the person table to link to the new patient; else
-        inserts a new patient into the patient table and inserts a new person into the
-        person table with a new personID, linking the new personID to the new patient.
+        the patient table, including the matched person id, to link the new patient
+        and matched person ID; else inserts a new patient into the patient table and
+        inserts a new person into the person table with a new person ID, linking the
+        new person ID to the new patient.
 
         :param patient_resource: A FHIR patient resource.
-        :param person_id: The personID matching the patient record if a match has been
+        :param person_id: The person ID matching the patient record if a match has been
           found in the MPI, defaults to None.
+        :param external_person_id: The external person id for the person that matches
+          the patient record if a match has been found in the MPI, defaults to None.
+        :return: the person id
         """
         db_cursor = None
         db_conn = None
@@ -137,19 +142,15 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
             # Use context manager to handle commits and transactions
             with self.get_connection() as db_conn:
                 with db_conn.cursor() as db_cursor:
-                    # Match has not been found
-                    if person_id is None:
-                        # Insert a new record into person table to generate new
-                        # person_id
-                        insert_new_person = SQL(
-                            "INSERT INTO {person_table} (external_person_id) VALUES "
-                            "('NULL') RETURNING person_id;"
-                        ).format(person_table=Identifier(self.person_table))
-
-                        db_cursor.execute(insert_new_person)
-
-                        # Retrieve newly generated person_id
-                        person_id = db_cursor.fetchall()[0][0]
+                    # handle all logic whether to insert, update
+                    # or query to get an existing person record
+                    # then use the returned person_id to link
+                    #  to the newly create patient
+                    person_id = self._insert_person(
+                        db_cursor=db_cursor,
+                        person_id=person_id,
+                        external_person_id=external_person_id,
+                    )
 
                     # Insert into patient table
                     insert_new_patient = SQL(
@@ -267,3 +268,76 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
             db_cursor.close()
         if db_conn is not None:
             db_conn.close()
+
+    def _insert_person(
+        self,
+        db_cursor: Union[cursor, None] = None,
+        person_id: str = None,
+        external_person_id: str = None,
+    ) -> Union[None, str]:
+        """
+        If person id is not supplied and external person id is not supplied
+        then insert a new person record with an auto-generated person id (UUID)
+        with a Null external person id and return that new person id. If the
+        person id is not supplied but an external person id is supplied try
+        to find an existing person record with the external person id and
+        return that person id; otherwise add a new person record with an
+        auto-generated person id (UUID) with the supplied external person id
+        and return the new person id.  If person id and external person id are
+        both supplied then update the person records external person id if it
+        is Null and return the person id.
+
+        :param person_id: The person id for the person record to be inserted
+          or updated, defaults to None.
+        :param external_person_id: The external person id for the person record
+          to be inserted or updated, defaults to None.
+        :return: The person id either supplied or auto-generated
+        """
+
+        try:
+            if external_person_id is None:
+                external_person_id = "'NULL'"
+                found_person_id = None
+            else:
+                # if external person id is supplied then find if there is already
+                #  a person with that external person id already within the MPI
+                #  - if so, return that person id
+                person_query = SQL(
+                    "SELECT person_id FROM {person_table} WHERE external_person_id = %s"
+                ).format(person_table=Identifier(self.person_table))
+                query_data = [external_person_id]
+                db_cursor.execute(person_query, query_data)
+                # Retrieve person_id that has the supplied external_person_id
+                found_person_id = db_cursor.fetchall()[0][0]
+
+                if found_person_id and found_person_id is not None:
+                    return found_person_id
+
+            if person_id is None:
+                # Insert a new record into person table to generate new
+                # person_id with either the supplied external person id
+                #  or a null external person id
+                insert_new_person = SQL(
+                    "INSERT INTO {person_table} (external_person_id) VALUES "
+                    "(%s) RETURNING person_id;"
+                ).format(person_table=Identifier(self.person_table))
+                person_data = [external_person_id]
+
+                db_cursor.execute(insert_new_person, person_data)
+
+                # Retrieve newly generated person_id
+                person_id = db_cursor.fetchall()[0][0]
+            # otherwise if person id is supplied and the external person id is supplied
+            # and not none and a record with the external person id was not found
+            #  then update the person record with the supplied external person id
+            elif found_person_id is not None:
+                update_person_query = SQL(
+                    "UPDATE {person_table} SET external_person_id = %s "
+                    "WHERE external_person_id = 'NULL'"
+                ).format(person_table=Identifier(self.person_table))
+                update_data = [external_person_id]
+                db_cursor.execute(update_person_query, update_data)
+
+        except Exception as error:  # pragma: no cover
+            raise ValueError(f"{error}")
+        return person_id

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -339,7 +339,7 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
                 matched = True
                 update_person_query = SQL(
                     "UPDATE {person_table} SET external_person_id = %s "
-                    "WHERE person_id = %s AND external_person_id IS NULL"
+                    "WHERE person_id = %s AND external_person_id = 'NULL' "
                 ).format(person_table=Identifier(self.person_table))
                 update_data = [external_person_id, person_id]
                 db_cursor.execute(update_person_query, update_data)

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -318,7 +318,7 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
                 if returned_data is not None and len(returned_data) > 0:
                     found_person_id = returned_data[0][0]
                     matched = True
-                return matched, found_person_id
+                    return matched, found_person_id
 
             if person_id is None:
                 # Insert a new record into person table to generate new

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -339,7 +339,7 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
                 matched = True
                 update_person_query = SQL(
                     "UPDATE {person_table} SET external_person_id = %s "
-                    "WHERE person_id = '%s' AND external_person_id = 'NULL'"
+                    "WHERE person_id = %s AND external_person_id = 'NULL'"
                 ).format(person_table=Identifier(self.person_table))
                 update_data = [external_person_id, person_id]
                 db_cursor.execute(update_person_query, update_data)

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -297,9 +297,6 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
           found within the person table or not based upon the external person id
         """
         matched = False
-        print("HERE")
-        print(external_person_id)
-        print(person_id)
         try:
             if external_person_id is None:
                 external_person_id = "'NULL'"
@@ -338,9 +335,6 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
             # and not none and a record with the external person id was not found
             #  then update the person record with the supplied external person id
             elif person_id is not None and external_person_id != "'NULL'":
-                print("THERE")
-                print(external_person_id)
-                print(person_id)
                 matched = True
                 update_person_query = SQL(
                     "UPDATE {person_table} SET external_person_id = %s "

--- a/phdi/linkage/postgres.py
+++ b/phdi/linkage/postgres.py
@@ -314,8 +314,10 @@ class DIBBsConnectorClient(BaseMPIConnectorClient):
 
                 if returned_data is not None and len(returned_data) > 0:
                     found_person_id = returned_data[0][0]
+                else:
+                    found_person_id = None
 
-                if found_person_id and found_person_id is not None:
+                if found_person_id is not None:
                     matched = True
                     return matched, found_person_id
 

--- a/tests/linkage/test_postgres_mpi_connector.py
+++ b/tests/linkage/test_postgres_mpi_connector.py
@@ -498,6 +498,9 @@ def test_insert_person():
     )
 
     # Assert existing person_id from MPI
+    print("HERE")
+    print(actual_result)
+    print(actual_person_id)
     assert actual_result
     assert actual_person_id == expected_person_id
 

--- a/tests/linkage/test_postgres_mpi_connector.py
+++ b/tests/linkage/test_postgres_mpi_connector.py
@@ -439,19 +439,6 @@ def test_insert_person():
     postgres_client.connection = postgres_client.get_connection()
     postgres_client.cursor = postgres_client.connection.cursor()
 
-    raw_bundle = json.load(
-        open(
-            pathlib.Path(__file__).parent.parent.parent
-            / "tests"
-            / "assets"
-            / "general"
-            / "patient_bundle.json"
-        )
-    )
-
-    patient_resource = raw_bundle.get("entry")[1].get("resource")
-    patient_resource["id"] = "4d88cd35-5ee7-4419-a847-2818fdfeec50"
-
     # Generate test tables
     # Create test table and insert data
     funcs = {
@@ -489,7 +476,7 @@ def test_insert_person():
             postgres_client.connection.rollback()
 
     # Find the person based upon the external person id
-    external_person_id_test = "4d88cd35-5ee7-4419-a847-2818fdfeec88"
+    external_person_id_test = "4d88cd35-5ee7-4419-a847-2818fdfeec38"
     expected_person_id = "ce02326f-7ecd-47ea-83eb-71e8d7c39131"
 
     # send in null person_id and external_person_id populated and get back a person_id

--- a/tests/linkage/test_postgres_mpi_connector.py
+++ b/tests/linkage/test_postgres_mpi_connector.py
@@ -510,7 +510,7 @@ def test_insert_person():
     # should update the person record with the new external person id
     valid_person_id = "cb9dc379-38a9-4ed6-b3a7-a8a3db0e9e6c"
     new_external_person_id = "bbbbbbbb-38a9-4ed6-b3a7-a8a3db0e9e6c"
-    postgres_client._insert_person(
+    update_matched, update_person_id = postgres_client._insert_person(
         postgres_client.cursor, valid_person_id, new_external_person_id
     )
 
@@ -525,6 +525,8 @@ def test_insert_person():
     data = postgres_client.cursor.fetchall()[0][0]
 
     # Assert record was updated in table
+    assert update_matched
+    assert update_person_id == valid_person_id
     assert data == new_external_person_id
 
     # Clean up

--- a/tests/linkage/test_postgres_mpi_connector.py
+++ b/tests/linkage/test_postgres_mpi_connector.py
@@ -509,7 +509,7 @@ def test_insert_person():
     # for a person record where the external person id is null
     # should update the person record with the new external person id
     valid_person_id = "cb9dc379-38a9-4ed6-b3a7-a8a3db0e9e6c"
-    new_external_person_id = "'bbbbbbbb-38a9-4ed6-b3a7-a8a3db0e9e6c'"
+    new_external_person_id = "bbbbbbbb-38a9-4ed6-b3a7-a8a3db0e9e6c"
     postgres_client._insert_person(
         postgres_client.cursor, valid_person_id, new_external_person_id
     )

--- a/tests/linkage/test_postgres_mpi_connector.py
+++ b/tests/linkage/test_postgres_mpi_connector.py
@@ -497,7 +497,8 @@ def test_insert_person():
     )
     query_data = [new_person_id]
     postgres_client.cursor.execute(
-        f"SELECT * from {postgres_client.person_table} " "WHERE person_id = %s", data
+        f"SELECT * from {postgres_client.person_table} " "WHERE person_id = %s",
+        query_data,
     )
     postgres_client.connection.commit()
     data = postgres_client.cursor.fetchall()

--- a/tests/linkage/test_postgres_mpi_connector.py
+++ b/tests/linkage/test_postgres_mpi_connector.py
@@ -495,10 +495,9 @@ def test_insert_person():
     actual_result, new_person_id = postgres_client._insert_person(
         postgres_client.cursor, None, None
     )
-
+    query_data = [new_person_id]
     postgres_client.cursor.execute(
-        f"SELECT * from {postgres_client.person_table} "
-        "WHERE person_id = {new_person_id}"
+        f"SELECT * from {postgres_client.person_table} " "WHERE person_id = %s", data
     )
     postgres_client.connection.commit()
     data = postgres_client.cursor.fetchall()
@@ -516,15 +515,19 @@ def test_insert_person():
         postgres_client.cursor, valid_person_id, new_external_person_id
     )
 
+    query_data = [valid_person_id]
+
     postgres_client.cursor.execute(
-        f"SELECT * from {postgres_client.person_table} "
-        "WHERE external_person_id = {new_external_person_id}"
+        f"SELECT external_person_id from {postgres_client.person_table} "
+        "WHERE person_id = %s",
+        query_data,
     )
     postgres_client.connection.commit()
-    data = postgres_client.cursor.fetchall()
+    data = postgres_client.cursor.fetchall()[0][0]
 
     # Assert record was updated in table
     assert len(data) == 1
+    assert data == new_external_person_id
 
     # Clean up
     postgres_client.connection = postgres_client.get_connection()

--- a/tests/linkage/test_postgres_mpi_connector.py
+++ b/tests/linkage/test_postgres_mpi_connector.py
@@ -507,7 +507,8 @@ def test_insert_person():
     )
 
     postgres_client.cursor.execute(
-        f"SELECT * from {postgres_client.person_table} WHERE person_id = {new_person_id}"
+        f"SELECT * from {postgres_client.person_table} "
+        "WHERE person_id = {new_person_id}"
     )
     postgres_client.connection.commit()
     data = postgres_client.cursor.fetchall()
@@ -526,7 +527,8 @@ def test_insert_person():
     )
 
     postgres_client.cursor.execute(
-        f"SELECT * from {postgres_client.person_table} WHERE external_person_id = {new_external_person_id}"
+        f"SELECT * from {postgres_client.person_table} "
+        "WHERE external_person_id = {new_external_person_id}"
     )
     postgres_client.connection.commit()
     data = postgres_client.cursor.fetchall()

--- a/tests/linkage/test_postgres_mpi_connector.py
+++ b/tests/linkage/test_postgres_mpi_connector.py
@@ -432,3 +432,114 @@ def create_valid_mpi_client():
         patient_table="test_patient_mpi",
         person_table="test_person_mpi",
     )
+
+
+def test_insert_person():
+    postgres_client = create_valid_mpi_client()
+    postgres_client.connection = postgres_client.get_connection()
+    postgres_client.cursor = postgres_client.connection.cursor()
+
+    raw_bundle = json.load(
+        open(
+            pathlib.Path(__file__).parent.parent.parent
+            / "tests"
+            / "assets"
+            / "general"
+            / "patient_bundle.json"
+        )
+    )
+
+    patient_resource = raw_bundle.get("entry")[1].get("resource")
+    patient_resource["id"] = "4d88cd35-5ee7-4419-a847-2818fdfeec50"
+
+    # Generate test tables
+    # Create test table and insert data
+    funcs = {
+        "drop tables": (
+            f"""
+        DROP TABLE IF EXISTS {postgres_client.person_table};
+        """
+        ),
+        "create_person": (
+            """
+            BEGIN;
+
+            CREATE EXTENSION IF NOT EXISTS "uuid-ossp";"""
+            + f"CREATE TABLE IF NOT EXISTS {postgres_client.person_table} "
+            + "(person_id UUID DEFAULT uuid_generate_v4 (), "
+            + "external_person_id VARCHAR(100));"
+        ),
+        "insert_person": (
+            f"""INSERT INTO {postgres_client.person_table} (person_id, """
+            + "external_person_id) "
+            + """VALUES ('ce02326f-7ecd-47ea-83eb-71e8d7c39131',
+            '4d88cd35-5ee7-4419-a847-2818fdfeec38'),
+             ('cb9dc379-38a9-4ed6-b3a7-a8a3db0e9e6c',
+             'NULL');"""
+        ),
+    }
+
+    for command, statement in funcs.items():
+        try:
+            postgres_client.cursor.execute(statement)
+            postgres_client.connection.commit()
+        except Exception as e:
+            print(f"{command} was unsuccessful")
+            print(e)
+            postgres_client.connection.rollback()
+
+    # Find the person based upon the external person id
+    external_person_id_test = "4d88cd35-5ee7-4419-a847-2818fdfeec88"
+    expected_person_id = "ce02326f-7ecd-47ea-83eb-71e8d7c39131"
+
+    # send in null person_id and external_person_id populated and get back a person_id
+    actual_result, actual_person_id = postgres_client._insert_person(
+        postgres_client.cursor, None, external_person_id_test
+    )
+
+    # Assert existing person_id from MPI
+    assert actual_result
+    assert actual_person_id == expected_person_id
+
+    # Now we will insert a new person with a null external id
+    actual_result, new_person_id = postgres_client._insert_person(
+        postgres_client.cursor, None, None
+    )
+
+    postgres_client.cursor.execute(
+        f"SELECT * from {postgres_client.person_table} WHERE person_id = {new_person_id}"
+    )
+    postgres_client.connection.commit()
+    data = postgres_client.cursor.fetchall()
+
+    # Assert record was added to the table
+    assert len(data) == 1
+    assert new_person_id is not None
+
+    # Send in a valid person id and a new external person id
+    # for a person record where the external person id is null
+    # should update the person record with the new external person id
+    valid_person_id = "cb9dc379-38a9-4ed6-b3a7-a8a3db0e9e6c"
+    new_external_person_id = "'bbbbbbbb-38a9-4ed6-b3a7-a8a3db0e9e6c'"
+    postgres_client._insert_person(
+        postgres_client.cursor, valid_person_id, new_external_person_id
+    )
+
+    postgres_client.cursor.execute(
+        f"SELECT * from {postgres_client.person_table} WHERE external_person_id = {new_external_person_id}"
+    )
+    postgres_client.connection.commit()
+    data = postgres_client.cursor.fetchall()
+
+    # Assert record was updated in table
+    assert len(data) == 1
+
+    # Clean up
+    postgres_client.connection = postgres_client.get_connection()
+    postgres_client.cursor = postgres_client.connection.cursor()
+    postgres_client.cursor.execute(
+        f"DROP TABLE IF EXISTS {postgres_client.person_table}"
+    )
+    postgres_client.connection.commit()
+    postgres_client.cursor.close()
+    postgres_client.connection.close()

--- a/tests/linkage/test_postgres_mpi_connector.py
+++ b/tests/linkage/test_postgres_mpi_connector.py
@@ -485,9 +485,7 @@ def test_insert_person():
     )
 
     # Assert existing person_id from MPI
-    print("HERE")
-    print(actual_result)
-    print(actual_person_id)
+
     assert actual_result
     assert actual_person_id == expected_person_id
 

--- a/tests/linkage/test_postgres_mpi_connector.py
+++ b/tests/linkage/test_postgres_mpi_connector.py
@@ -527,7 +527,6 @@ def test_insert_person():
     data = postgres_client.cursor.fetchall()[0][0]
 
     # Assert record was updated in table
-    assert len(data) == 1
     assert data == new_external_person_id
 
     # Clean up


### PR DESCRIPTION
## Summary
We need to be able to pass in an external_person_id (From the STLT/Client... for example in LAC the iris_person_id) into our record linkage container and utilize it appropriately all the way down to the data access layer.  In the DAL I have added logic to handle the cases for when an external person id is supplied and when it should be inserted/updated.  I have included tests for this.  There will need to be another PR to handle the TODOs in this one, within the record-linkage container, since the current SDK on main doesn't have this new logic yet. 

## Related Issue
Fixes # ?
[//]: # (PR title: Remember to name your PR descriptively!)