### PR TITLE
Update _DiagnosticReport.liquid

### DIFF
--- a/containers/fhir-converter/Templates/eCR/Resource/_DiagnosticReport.liquid
+++ b/containers/fhir-converter/Templates/eCR/Resource/_DiagnosticReport.liquid
@@ -17,7 +17,7 @@
             {% if codeTranslations.first -%}
                 {% include 'DataType/CodeableConcept' CodeableConcept: codeTranslations.first -%}
             {% endif -%}
-            {% if diagnosticReport.code.translation == null and diagnosticReport.code and not diagnosticReport.code.nullFlavor -%}
+            {% if diagnosticReport.code.translation == null and diagnosticReport.code -%}
                 {% include 'DataType/CodeableConcept' CodeableConcept: diagnosticReport.code -%}
             {% endif -%}
         },

--- a/containers/fhir-converter/Templates/eCR/Resource/_DiagnosticReport.liquid
+++ b/containers/fhir-converter/Templates/eCR/Resource/_DiagnosticReport.liquid
@@ -13,11 +13,12 @@
         "status":"{{ diagnosticReport.statusCode.code | get_property: 'ValueSet/DiagnosticReportStatus' }}",
         "code":
         {
-            {% if diagnosticReport.code.translation -%}
-            {% include 'DataType/CodeableConcept' CodeableConcept: diagnosticReport.code.translation -%}
+            {% assign codeTranslations = diagnosticReport.code.translation | to_array -%}
+            {% if codeTranslations.first -%}
+                {% include 'DataType/CodeableConcept' CodeableConcept: codeTranslations.first -%}
             {% endif -%}
-            {% if diagnosticReport.code.translation == null and diagnosticReport.code -%}
-            {% include 'DataType/CodeableConcept' CodeableConcept: diagnosticReport.code -%}
+            {% if diagnosticReport.code.translation == null and diagnosticReport.code and not diagnosticReport.code.nullFlavor -%}
+                {% include 'DataType/CodeableConcept' CodeableConcept: diagnosticReport.code -%}
             {% endif -%}
         },
         "effectivePeriod":


### PR DESCRIPTION
## Summary
During the demo we had a FHIR Upload failure because the DiagnosticReport.code was missing for all DiagnosticReports within the bundle.  This was caused by the FHIR Converter where in the ECR under the Results section for each of the "Observations/Results" there were more than one code.translation tags (usually the code can be found either in a single code.translation tag or within the code tag itself).  This message had multiple translations, which is why it failed (SMH).  I updated the template to get the code for DiagnosticReport from the FIRST iteration of code.translations if present or otherwise just from the code tag itself.

