### PR TITLE
Remove the DocumentReference from the EICR templates for the FHIR Converter

### DIFF
--- a/containers/fhir-converter/Templates/eCR/EICR.liquid
+++ b/containers/fhir-converter/Templates/eCR/EICR.liquid
@@ -20,8 +20,5 @@
 {% include 'Section/MentalStatus' -%}
 {% include 'Section/Nutrition' -%}
 {% include 'Section/Payer' -%}
-
-{% assign documentId = msg | to_json_string | generate_uuid -%}
-{% include 'Resource/DocumentReference' documentReference: msg ID: documentId -%}
 ]
 }


### PR DESCRIPTION
# PULL REQUEST

## Summary
During the LAC UAT data run for testing it was found that a single EICR message after it was converted into FHIR was too large for the Azure network to handle when passing into the standardization functionality in the pipeline.  To help prevent this error in the future we are removing one of the largest sections in the EICR FHIR Messages.  This is the DocumentReference resource that contained a full zip of the actual EICR message in it.  This is NOT required in the ECR FHIR Specifications as defined by HL7 and seems beyond redundant for our purposes.  We still may run into this same error if there is an extremely large EICR message, however, this will help prevent it from happing for the majority of EICR messages.

## Related Issue
Fixes #https://app.zenhub.com/workspaces/dibbs-63f7aa3e1ecdbb0011edb299/issues/gh/cdcgov/phdi-azure/129
