### PR TITLE
Link based on column names not indices

### DIFF
--- a/phdi/linkage/algorithms.py
+++ b/phdi/linkage/algorithms.py
@@ -1,16 +1,3 @@
-# Predefined columns that map to the DIBBs MPI
-IDX_TO_COL = {
-    0: "address",
-    1: "birthdate",
-    2: "city",
-    3: "first_name",
-    4: "last_name",
-    5: "mrn",
-    6: "sex",
-    7: "state",
-    8: "zip",
-}
-
 # Pre-computed log-odds points values for each of the DIBBs MPI
 # supported columns (derived from representative synthetic data)
 LOG_ODDS_SCORES = {
@@ -29,9 +16,9 @@ LOG_ODDS_SCORES = {
 DIBBS_BASIC = [
     {
         "funcs": {
-            1: "feature_match_fuzzy_string",
-            3: "feature_match_fuzzy_string",
-            4: "feature_match_fuzzy_string",
+            "first_name": "feature_match_fuzzy_string",
+            "last_name": "feature_match_fuzzy_string",
+            "birthdate": "feature_match_fuzzy_string",
         },
         "blocks": [
             {"value": "mrn", "transformation": "last4"},
@@ -42,8 +29,8 @@ DIBBS_BASIC = [
     },
     {
         "funcs": {
-            0: "feature_match_fuzzy_string",
-            2: "feature_match_fuzzy_string",
+            "address": "feature_match_fuzzy_string",
+            "city": "feature_match_fuzzy_string",
         },
         "blocks": [
             {"value": "first_name", "transformation": "first4"},
@@ -58,9 +45,9 @@ DIBBS_BASIC = [
 DIBBS_ENHANCED = [
     {
         "funcs": {
-            1: "feature_match_log_odds_fuzzy_compare",
-            3: "feature_match_log_odds_fuzzy_compare",
-            4: "feature_match_log_odds_fuzzy_compare",
+            "birthdate": "feature_match_log_odds_fuzzy_compare",
+            "first_name": "feature_match_log_odds_fuzzy_compare",
+            "last_name": "feature_match_log_odds_fuzzy_compare",
         },
         "blocks": [
             {"value": "mrn", "transformation": "last4"},
@@ -72,14 +59,13 @@ DIBBS_ENHANCED = [
             "similarity_measure": "JaroWinkler",
             "threshold": 0.7,
             "true_match_threshold": 16.5,
-            "idx_to_col": IDX_TO_COL,
             "log_odds": LOG_ODDS_SCORES,
         },
     },
     {
         "funcs": {
-            0: "feature_match_log_odds_fuzzy_compare",
-            2: "feature_match_log_odds_fuzzy_compare",
+            "address": "feature_match_log_odds_fuzzy_compare",
+            "city": "feature_match_log_odds_fuzzy_compare",
         },
         "blocks": [
             {"value": "first_name", "transformation": "first4"},
@@ -91,7 +77,6 @@ DIBBS_ENHANCED = [
             "similarity_measure": "JaroWinkler",
             "threshold": 0.7,
             "true_match_threshold": 7.0,
-            "idx_to_col": IDX_TO_COL,
             "log_odds": LOG_ODDS_SCORES,
         },
     },

--- a/phdi/linkage/link.py
+++ b/phdi/linkage/link.py
@@ -400,7 +400,11 @@ def extract_blocking_values_from_record(
 
 
 def feature_match_exact(
-    record_i: List, record_j: List, feature_x: int, **kwargs: dict
+    record_i: List,
+    record_j: List,
+    feature_col: str,
+    col_to_idx: dict[str, int],
+    **kwargs: dict,
 ) -> bool:
     """
     Determines whether a single feature in a given pair of records
@@ -408,15 +412,21 @@ def feature_match_exact(
 
     :param record_i: One of the records in the candidate pair to evaluate.
     :param record_j: The second record in the candidate pair.
-    :param feature_x: A number representing the index of the feature to
-      compare for equality.
+    :param feature_col: The name of the column being evaluated (e.g. "city").
+    :param col_to_idx: A dictionary mapping column names to the numeric index
+      in which they occur in order in the data.
     :return: A boolean indicating whether the features are an exact match.
     """
-    return record_i[feature_x] == record_j[feature_x]
+    idx = col_to_idx[feature_col]
+    return record_i[idx] == record_j[idx]
 
 
 def feature_match_four_char(
-    record_i: List, record_j: List, feature_x: int, **kwargs: dict
+    record_i: List,
+    record_j: List,
+    feature_col: str,
+    col_to_idx: dict[str, int],
+    **kwargs: dict,
 ) -> bool:
     """
     Determines whether a string feature in a pair of records exactly matches
@@ -424,17 +434,23 @@ def feature_match_four_char(
 
     :param record_i: One of the records in the candidate pair to evaluate.
     :param record_j: The second record in the candidate pair.
-    :param feature_x: A number representing the index of the feature to
-      compare.
+    :param feature_col: The name of the column being evaluated (e.g. "city").
+    :param col_to_idx: A dictionary mapping column names to the numeric index
+      in which they occur in order in the data.
     :return: A boolean indicating whether the features are a match.
     """
-    first_four_i = record_i[feature_x][: min(4, len(record_i[feature_x]))]
-    first_four_j = record_j[feature_x][: min(4, len(record_j[feature_x]))]
+    idx = col_to_idx[feature_col]
+    first_four_i = record_i[idx][: min(4, len(record_i[idx]))]
+    first_four_j = record_j[idx][: min(4, len(record_j[idx]))]
     return first_four_i == first_four_j
 
 
 def feature_match_fuzzy_string(
-    record_i: List, record_j: List, feature_x: int, **kwargs: dict
+    record_i: List,
+    record_j: List,
+    feature_col: str,
+    col_to_idx: dict[str, int],
+    **kwargs: dict,
 ) -> bool:
     """
     Determines whether two strings in a given pair of records are close
@@ -445,18 +461,21 @@ def feature_match_fuzzy_string(
 
     :param record_i: One of the records in the candidate pair to evaluate.
     :param record_j: The second record in the candidate pair.
-    :param feature_x: A number representing the index of the feature to
-      compare for a partial match.
+    :param feature_col: The name of the column being evaluated (e.g. "city").
+    :param col_to_idx: A dictionary mapping column names to the numeric index
+      in which they occur in order in the data.
     :param **kwargs: Optionally, a dictionary including specifications for
       the string comparison metric to use, as well as the cutoff score
       beyond which to classify the strings as a partial match.
     :return: A boolean indicating whether the features are a fuzzy match.
     """
+    idx = col_to_idx[feature_col]
+
     # Special case for two empty strings, since we don't want vacuous
     # equality (or in-) to penalize the score
-    if record_i[feature_x] == "" and record_j[feature_x] == "":
+    if record_i[idx] == "" and record_j[idx] == "":
         return True
-    if record_i[feature_x] is None and record_j[feature_x] is None:
+    if record_i[idx] is None and record_j[idx] is None:
         return True
 
     similarity_measure = "JaroWinkler"
@@ -465,14 +484,16 @@ def feature_match_fuzzy_string(
     threshold = 0.7
     if "threshold" in kwargs:
         threshold = kwargs["threshold"]
-    score = compare_strings(
-        record_i[feature_x], record_j[feature_x], similarity_measure
-    )
+    score = compare_strings(record_i[idx], record_j[idx], similarity_measure)
     return score >= threshold
 
 
 def feature_match_log_odds_exact(
-    record_i: List, record_j: List, feature_x: int, **kwargs: dict
+    record_i: List,
+    record_j: List,
+    feature_col: str,
+    col_to_idx: dict[str, int],
+    **kwargs: dict,
 ) -> float:
     """
     Determines whether two feature values in two records should earn the full
@@ -482,24 +503,27 @@ def feature_match_log_odds_exact(
 
     :param record_i: One of the records in the candidate pair to evaluate.
     :param record_j: The second record in the candidate pair.
-    :param feature_x: A number representing the index of the feature to
-      compare for a partial match.
+    :param feature_col: The name of the column being evaluated (e.g. "city").
+    :param col_to_idx: A dictionary mapping column names to the numeric index
+      in which they occur in order in the data.
     :return: A float of the score the feature comparison earned.
     """
-    if "idx_to_col" not in kwargs:
-        raise KeyError("Mapping of indices to column names must be provided.")
     if "log_odds" not in kwargs:
         raise KeyError("Mapping of columns to m/u log-odds must be provided.")
-    col = kwargs["idx_to_col"][feature_x]
-    col_odds = kwargs["log_odds"][col]
-    if record_i[feature_x] == record_j[feature_x]:
+    col_odds = kwargs["log_odds"][feature_col]
+    idx = col_to_idx[feature_col]
+    if record_i[idx] == record_j[idx]:
         return col_odds
     else:
         return 0.0
 
 
 def feature_match_log_odds_fuzzy_compare(
-    record_i: List, record_j: List, feature_x: int, **kwargs: dict
+    record_i: List,
+    record_j: List,
+    feature_col: str,
+    col_to_idx: dict[str, int],
+    **kwargs: dict,
 ) -> float:
     """
     Determines the weighted string-odds similarly score earned by two
@@ -511,17 +535,16 @@ def feature_match_log_odds_fuzzy_compare(
 
     :param record_i: One of the records in the candidate pair to evaluate.
     :param record_j: The second record in the candidate pair.
-    :param feature_x: A number representing the index of the feature to
-      compare for a partial match.
+    :param feature_col: The name of the column being evaluated (e.g. "city").
+    :param col_to_idx: A dictionary mapping column names to the numeric index
+      in which they occur in order in the data.
     :return: A float of the score the feature comparison earned.
     """
-    if "idx_to_col" not in kwargs:
-        raise KeyError("Mapping of indices to column names must be provided.")
     if "log_odds" not in kwargs:
         raise KeyError("Mapping of columns to m/u log-odds must be provided.")
-    col = kwargs["idx_to_col"][feature_x]
-    col_odds = kwargs["log_odds"][col]
-    score = compare_strings(record_i[feature_x], record_j[feature_x], "JaroWinkler")
+    col_odds = kwargs["log_odds"][feature_col]
+    idx = col_to_idx[feature_col]
+    score = compare_strings(record_i[idx], record_j[idx], "JaroWinkler")
     return score * col_odds
 
 
@@ -590,8 +613,8 @@ def link_record_against_mpi(
         data_block = db_client.block_data(field_blocks)
 
         # First row of returned block is column headers
-        # Map idx to column name, not including patient/person IDs
-        idx_to_col = {k: v for k, v in enumerate(data_block[0][2:])}
+        # Map column name to idx, not including patient/person IDs
+        col_to_idx = {v: k for k, v in enumerate(data_block[0][2:])}
         data_block = data_block[1:]
 
         # Blocked fields are returned as LoLoL, but only name / address
@@ -599,10 +622,12 @@ def link_record_against_mpi(
         for i in range(len(data_block)):
             blocked_record = data_block[i]
             for j in range(len(blocked_record)):
-                # patient_id, person_id not included in idx->col mapping
+                # patient_id, person_id not included in col->idx mapping
                 if j < 2:
                     continue
-                if idx_to_col[j - 2] != "first_name" and idx_to_col[j - 2] != "address":
+                if col_to_idx["first_name"] != (j - 2) and col_to_idx["address"] != (
+                    j - 2
+                ):
                     while type(blocked_record[j]) == list:
                         # Handle empty list edge case.
                         if len(blocked_record[j]) == 0:
@@ -621,7 +646,7 @@ def link_record_against_mpi(
                     flattened_record,
                     linked_patient,
                     linkage_pass["funcs"],
-                    idx_to_col,
+                    col_to_idx,
                     linkage_pass["matching_rule"],
                     **kwargs,
                 )
@@ -683,7 +708,8 @@ def load_json_probs(path: pathlib.Path):
 
 def match_within_block(
     block: List[List],
-    feature_funcs: dict[int, Callable],
+    feature_funcs: dict[str, Callable],
+    col_to_idx: dict[str, int],
     match_eval: Callable,
     **kwargs,
 ) -> List[tuple]:
@@ -713,6 +739,8 @@ def match_within_block(
       record must be an "id" for the record.
     :param feature_funcs: A dictionary mapping feature indices to functions
       used to evaluate those features for a match.
+    :param col_to_idx: A dictionary mapping column names to the numeric index
+      in which they occur in order in the data.
     :param match_eval: A function for determining whether a given set of
       feature comparisons constitutes a match for linkage.
     :return: A list of 2-tuples of the form (i,j), where i,j give the indices
@@ -726,9 +754,10 @@ def match_within_block(
         for j in range(i + 1, len(block)):
             record_j = block[j]
             feature_comps = [
-                feature_funcs[x](record_i, record_j, x, **kwargs)
-                for x in range(len(record_i))
-                if x in feature_funcs
+                feature_funcs[feature_col](
+                    record_i, record_j, feature_col, col_to_idx, **kwargs
+                )
+                for feature_col in feature_funcs
             ]
 
             # If it's a match, store the result
@@ -746,7 +775,7 @@ def match_within_block(
 def perform_linkage_pass(
     data: pd.DataFrame,
     blocks: List,
-    feature_funcs: dict[int, Callable],
+    feature_funcs: dict[str, Callable],
     matching_rule: Callable,
     cluster_ratio: Union[float, None] = None,
     **kwargs,
@@ -770,6 +799,10 @@ def perform_linkage_pass(
     :return: A dictionary mapping each block found in the pass to the matches
       discovered within that block.
     """
+    # Retrieve indices of columns
+    cols = list(data.columns.values)
+    col_to_idx = dict(zip(cols, range(len(cols))))
+
     blocked_data = block_data(data, blocks)
     matches = {}
     for block in blocked_data:
@@ -778,12 +811,13 @@ def perform_linkage_pass(
                 blocked_data[block],
                 cluster_ratio,
                 feature_funcs,
+                col_to_idx,
                 matching_rule,
                 **kwargs,
             )
         else:
             matches_in_block = match_within_block(
-                blocked_data[block], feature_funcs, matching_rule, **kwargs
+                blocked_data[block], feature_funcs, col_to_idx, matching_rule, **kwargs
             )
         matches_in_block = _map_matches_to_record_ids(
             matches_in_block, blocked_data[block], cluster_ratio is not None
@@ -1091,7 +1125,8 @@ def _eval_record_in_cluster(
     i: int,
     cluster: set,
     cluster_ratio: float,
-    feature_funcs: dict[int, Callable],
+    feature_funcs: dict[str, Callable],
+    col_to_idx: dict[str, int],
     match_eval: Callable,
     **kwargs,
 ):
@@ -1105,9 +1140,10 @@ def _eval_record_in_cluster(
     for j in cluster:
         record_j = block[j]
         feature_comps = [
-            feature_funcs[x](record_i, record_j, x, **kwargs)
-            for x in range(len(record_i))
-            if x in feature_funcs
+            feature_funcs[feature_col](
+                record_i, record_j, feature_col, col_to_idx, **kwargs
+            )
+            for feature_col in feature_funcs
         ]
 
         is_match = match_eval(feature_comps)
@@ -1122,7 +1158,7 @@ def _compare_records(
     record: List,
     mpi_patient: List,
     feature_funcs: dict,
-    idx_to_col: dict,
+    col_to_idx: dict[str, int],
     matching_rule: callable,
     **kwargs,
 ) -> bool:
@@ -1135,9 +1171,14 @@ def _compare_records(
     # Don't use the first two ID cols when linking
     feature_comps = [
         _compare_records_field_helper(
-            record[2:], mpi_patient[2:], x, idx_to_col, feature_funcs, **kwargs
+            record[2:],
+            mpi_patient[2:],
+            feature_col,
+            col_to_idx,
+            feature_funcs,
+            **kwargs,
         )
-        for x in feature_funcs
+        for feature_col in feature_funcs
     ]
     is_match = matching_rule(feature_comps, **kwargs)
     return is_match
@@ -1146,26 +1187,31 @@ def _compare_records(
 def _compare_records_field_helper(
     record: List,
     mpi_patient: List,
-    idx: int,
-    idx_to_col: dict,
+    feature_col: str,
+    col_to_idx: dict[str, int],
     feature_funcs: dict,
     **kwargs,
 ) -> bool:
-    if idx_to_col[idx] == "first_name":
-        return _compare_name_elements(record, mpi_patient, feature_funcs, idx, **kwargs)
-    elif idx_to_col[idx] == "address":
+    if feature_col == "first_name":
+        return _compare_name_elements(
+            record, mpi_patient, feature_funcs, feature_col, col_to_idx, **kwargs
+        )
+    elif feature_col == "address":
         return _compare_address_elements(
-            record, mpi_patient, feature_funcs, idx, **kwargs
+            record, mpi_patient, feature_funcs, feature_col, col_to_idx, **kwargs
         )
     else:
-        return feature_funcs[idx](record, mpi_patient, idx, **kwargs)
+        return feature_funcs[feature_col](
+            record, mpi_patient, feature_col, col_to_idx, **kwargs
+        )
 
 
 def _compare_address_elements(
     record: List,
     mpi_patient: List,
-    feature_func: dict,
-    x,
+    feature_funcs: dict,
+    feature_col: str,
+    col_to_idx: dict[str, int],
     **kwargs,
 ) -> bool:
     """
@@ -1174,9 +1220,12 @@ def _compare_address_elements(
     the MPI.
     """
     feature_comp = False
-    for r in record[2:][x]:
-        for m in mpi_patient[2:][x]:
-            feature_comp = feature_func[x]([r], [m], 0, **kwargs)
+    idx = col_to_idx[feature_col]
+    for r in record[2:][idx]:
+        for m in mpi_patient[2:][idx]:
+            feature_comp = feature_funcs[feature_col](
+                [r], [m], "eval_col", {"eval_col": 0}, **kwargs
+            )
             if feature_comp is True:
                 break
         break
@@ -1186,8 +1235,9 @@ def _compare_address_elements(
 def _compare_name_elements(
     record: List,
     mpi_patient: List,
-    feature_func: dict,
-    x,
+    feature_funcs: dict,
+    feature_col: str,
+    col_to_idx: dict[str, int],
     **kwargs,
 ) -> bool:
     """
@@ -1195,11 +1245,12 @@ def _compare_name_elements(
     new patient record's name(s) to all elements of the flattened
     patient's name(s) pulled from the MPI.
     """
-
-    feature_comp = feature_func[x](
-        [" ".join(n for n in record[2:][x])],
-        [" ".join(n for n in mpi_patient[2:][x])],
-        0,
+    idx = col_to_idx[feature_col]
+    feature_comp = feature_funcs[feature_col](
+        [" ".join(n for n in record[2:][idx])],
+        [" ".join(n for n in mpi_patient[2:][idx])],
+        "eval_col",
+        {"eval_col": 0},
         **kwargs,
     )
     return feature_comp
@@ -1311,7 +1362,8 @@ def _map_matches_to_record_ids(
 def _match_within_block_cluster_ratio(
     block: List[List],
     cluster_ratio: float,
-    feature_funcs: dict[int, Callable],
+    feature_funcs: dict[str, Callable],
+    col_to_idx: dict[str, int],
     match_eval: Callable,
     **kwargs,
 ) -> List[set]:
@@ -1334,6 +1386,8 @@ def _match_within_block_cluster_ratio(
       to qualify for membership in the cluster.
     :param feature_funcs: A dictionary mapping feature indices to functions
       used to evaluate those features for a match.
+    :param col_to_idx: A dictionary mapping column names to the numeric index
+      in which they occur in order in the data.
     :param match_eval: A function for determining whether a given set of
       feature comparisons constitutes a match for linkage.
     :return: A list of 2-tuples of the form (i,j), where i,j give the indices
@@ -1350,7 +1404,14 @@ def _match_within_block_cluster_ratio(
         # Iterate through clusters to find one that we match with
         for cluster in clusters:
             belongs = _eval_record_in_cluster(
-                block, i, cluster, cluster_ratio, feature_funcs, match_eval, **kwargs
+                block,
+                i,
+                cluster,
+                cluster_ratio,
+                feature_funcs,
+                col_to_idx,
+                match_eval,
+                **kwargs,
             )
             if belongs:
                 found_master_cluster = True

--- a/tests/linkage/test_linkage.py
+++ b/tests/linkage/test_linkage.py
@@ -202,30 +202,37 @@ def test_feature_match_exact():
     record_j = [1, 0, -1, "blah", "", True]
     record_k = [2, 10, -10, "no match", "null", False]
 
+    cols = {"col_1": 0, "col_2": 1, "col_3": 2, "col_4": 3, "col_5": 4, "col_6": 5}
+
     # Simultaneously test matches and non-matches of different data types
-    for i in range(len(record_i)):
-        assert feature_match_exact(record_i, record_j, i)
-        assert not feature_match_exact(record_i, record_k, i)
+    for c in cols:
+        assert feature_match_exact(record_i, record_j, c, cols)
+        assert not feature_match_exact(record_i, record_k, c, cols)
 
     # Special case for matching None--None == None is vacuous
-    assert feature_match_exact([None], [None], 0)
+    assert feature_match_exact([None], [None], "col_7", {"col_7": 0})
 
 
 def test_feature_match_fuzzy_string():
     record_i = ["string1", "John", "John", "", None]
     record_j = ["string2", "Jhon", "Jon", "", None]
-    for i in range(len(record_i)):
+
+    cols = {"col_1": 0, "col_2": 1, "col_3": 2, "col_4": 3}
+
+    for c in cols:
         assert feature_match_fuzzy_string(
             record_i,
             record_j,
-            i,
+            c,
+            cols,
             similarity_measure="JaroWinkler",
             threshold=0.7,
         )
     assert not feature_match_fuzzy_string(
         ["no match"],
         ["dont match me bro"],
-        0,
+        "col_5",
+        {"col_5": 0},
         similarity_measure="JaroWinkler",
         threshold=0.7,
     )
@@ -256,21 +263,22 @@ def test_match_within_block_cluster_ratio():
 
     eval_rule = eval_perfect_match
     funcs = {
-        1: feature_match_fuzzy_string,
-        2: feature_match_fuzzy_string,
-        3: feature_match_exact,
-        4: feature_match_exact,
+        "first": feature_match_fuzzy_string,
+        "last": feature_match_fuzzy_string,
+        "dob": feature_match_exact,
+        "zip": feature_match_exact,
     }
+    col_to_idx = {"first": 1, "last": 2, "dob": 3, "zip": 4}
 
     # Do a test run requiring total membership match
     matches = _match_within_block_cluster_ratio(
-        data, 1.0, funcs, eval_rule, threshold=0.8
+        data, 1.0, funcs, col_to_idx, eval_rule, threshold=0.8
     )
     assert matches == [{0, 1, 2}, {3}, {4}, {5}, {6}, {7, 8, 10}, {9}, {11}]
 
     # Now do a test showing different cluster groupings
     matches = _match_within_block_cluster_ratio(
-        data, 0.6, funcs, eval_rule, threshold=0.8
+        data, 0.6, funcs, col_to_idx, eval_rule, threshold=0.8
     )
     assert matches == [{0, 1, 2, 3}, {4}, {5}, {6}, {7, 8, 10, 11}, {9}]
 
@@ -294,26 +302,32 @@ def test_match_within_block():
     # First, require exact matches on everything to match
     # Expect 0 pairs
     funcs = {
-        1: feature_match_exact,
-        2: feature_match_exact,
-        3: feature_match_exact,
-        4: feature_match_exact,
+        "first": feature_match_exact,
+        "last": feature_match_exact,
+        "dob": feature_match_exact,
+        "zip": feature_match_exact,
     }
-    match_pairs = match_within_block(data, funcs, eval_rule)
+    col_to_idx = {"first": 1, "last": 2, "dob": 3, "zip": 4}
+    match_pairs = match_within_block(data, funcs, col_to_idx, eval_rule)
     assert len(match_pairs) == 0
 
     # Now, require exact on DOB and zip, but allow fuzzy on first and last
     # Expect 6 matches
-    funcs[1] = feature_match_fuzzy_string
-    funcs[2] = feature_match_fuzzy_string
-    match_pairs = match_within_block(data, funcs, eval_rule)
+    funcs["first"] = feature_match_fuzzy_string
+    funcs["last"] = feature_match_fuzzy_string
+    match_pairs = match_within_block(data, funcs, col_to_idx, eval_rule)
     assert match_pairs == [(0, 1), (0, 2), (1, 2), (5, 6), (5, 8), (6, 8)]
 
     # As above, but let's be explicit about string comparison and threshold
     # Expect three matches, but none with the "Johns"
     # Note the difference in returned results by changing distance function
     match_pairs = match_within_block(
-        data, funcs, eval_rule, similarity_measure="Levenshtein", threshold=0.8
+        data,
+        funcs,
+        col_to_idx,
+        eval_rule,
+        similarity_measure="Levenshtein",
+        threshold=0.8,
     )
     assert match_pairs == [(5, 6), (5, 8), (6, 8)]
 
@@ -382,18 +396,18 @@ def test_compile_match_lists():
         ],
     )
     funcs = {
-        1: feature_match_four_char,
-        2: feature_match_four_char,
-        3: feature_match_exact,
+        "FIRST": feature_match_four_char,
+        "LAST": feature_match_four_char,
+        "GENDER": feature_match_exact,
     }
     matches_1 = perform_linkage_pass(data, ["ZIP"], funcs, eval_perfect_match)
     funcs = {
-        1: feature_match_four_char,
-        2: feature_match_four_char,
-        4: feature_match_four_char,
+        "FIRST": feature_match_four_char,
+        "LAST": feature_match_four_char,
+        "ADDRESS": feature_match_four_char,
     }
     matches_2 = perform_linkage_pass(data, ["BIRTHDATE"], funcs, eval_perfect_match)
-    funcs = {3: feature_match_exact}
+    funcs = {"GENDER": feature_match_exact}
     matches_3 = perform_linkage_pass(data, ["ZIP"], funcs, eval_perfect_match)
     assert compile_match_lists([matches_1, matches_2, matches_3], False) == {
         1: {5, 11, 12, 13},
@@ -411,10 +425,12 @@ def test_feature_match_four_char():
     record_j = ["John", "Sheperd"]
     record_k = ["Jhon", "Sehpard"]
 
+    cols = {"first": 0, "last": 1}
+
     # Simultaneously test matches and non-matches of different data types
-    for i in range(len(record_i)):
-        assert feature_match_four_char(record_i, record_j, i)
-        assert not feature_match_four_char(record_i, record_k, i)
+    for c in cols:
+        assert feature_match_four_char(record_i, record_j, c, cols)
+        assert not feature_match_four_char(record_i, record_k, c, cols)
 
 
 def test_map_matches_to_ids():
@@ -506,9 +522,9 @@ def test_perform_linkage_pass():
         ],
     )
     funcs = {
-        1: feature_match_four_char,
-        2: feature_match_four_char,
-        3: feature_match_exact,
+        "FIRST": feature_match_four_char,
+        "LAST": feature_match_four_char,
+        "GENDER": feature_match_exact,
     }
     matches = perform_linkage_pass(data, ["ZIP"], funcs, eval_perfect_match, None)
     assert matches == {
@@ -753,49 +769,40 @@ def test_eval_log_odds_cutoff():
 
 def test_feature_match_log_odds_exact():
     with pytest.raises(KeyError) as e:
-        feature_match_log_odds_exact([], [], 0)
-    assert "Mapping of indices to column names must be provided" in str(e.value)
-    with pytest.raises(KeyError) as e:
-        feature_match_log_odds_exact([], [], 0, idx_to_col={})
+        feature_match_log_odds_exact([], [], "c", {})
     assert "Mapping of columns to m/u log-odds must be provided" in str(e.value)
 
     ri = ["John", "Shepard", "11-07-1980", "1234 Silversun Strip"]
     rj = ["John", 6.0, None, "2345 Goldmoon Ave."]
-    idx_to_col = {0: "first", 1: "last", 2: "birthdate", 3: "address"}
+    col_to_idx = {"first": 0, "last": 1, "birthdate": 2, "address": 3}
     log_odds = {"first": 4.0, "last": 6.5, "birthdate": 9.8, "address": 3.7}
 
     assert (
-        feature_match_log_odds_exact(
-            ri, rj, 0, idx_to_col=idx_to_col, log_odds=log_odds
-        )
+        feature_match_log_odds_exact(ri, rj, "first", col_to_idx, log_odds=log_odds)
         == 4.0
     )
 
-    for i in range(1, 4):
-        assert (
-            feature_match_log_odds_exact(
-                ri, rj, i, idx_to_col=idx_to_col, log_odds=log_odds
+    for c in col_to_idx:
+        if c != "first":
+            assert (
+                feature_match_log_odds_exact(ri, rj, c, col_to_idx, log_odds=log_odds)
+                == 0.0
             )
-            == 0.0
-        )
 
 
 def test_feature_match_log_odds_fuzzy():
     with pytest.raises(KeyError) as e:
-        feature_match_log_odds_fuzzy_compare([], [], 0)
-    assert "Mapping of indices to column names must be provided" in str(e.value)
-    with pytest.raises(KeyError) as e:
-        feature_match_log_odds_fuzzy_compare([], [], 0, idx_to_col={})
+        feature_match_log_odds_fuzzy_compare([], [], "c", {})
     assert "Mapping of columns to m/u log-odds must be provided" in str(e.value)
 
     ri = ["John", "Shepard", "11-07-1980", "1234 Silversun Strip"]
     rj = ["John", "Sheperd", "06-08-2000", "asdfghjeki"]
-    idx_to_col = {0: "first", 1: "last", 2: "birthdate", 3: "address"}
+    col_to_idx = {"first": 0, "last": 1, "birthdate": 2, "address": 3}
     log_odds = {"first": 4.0, "last": 6.5, "birthdate": 9.8, "address": 3.7}
 
     assert (
         feature_match_log_odds_fuzzy_compare(
-            ri, rj, 0, idx_to_col=idx_to_col, log_odds=log_odds
+            ri, rj, "first", col_to_idx, log_odds=log_odds
         )
         == 4.0
     )
@@ -803,7 +810,7 @@ def test_feature_match_log_odds_fuzzy():
     assert (
         round(
             feature_match_log_odds_fuzzy_compare(
-                ri, rj, 1, idx_to_col=idx_to_col, log_odds=log_odds
+                ri, rj, "last", col_to_idx, log_odds=log_odds
             ),
             3,
         )
@@ -813,7 +820,7 @@ def test_feature_match_log_odds_fuzzy():
     assert (
         round(
             feature_match_log_odds_fuzzy_compare(
-                ri, rj, 2, idx_to_col=idx_to_col, log_odds=log_odds
+                ri, rj, "birthdate", col_to_idx, log_odds=log_odds
             ),
             3,
         )
@@ -823,7 +830,7 @@ def test_feature_match_log_odds_fuzzy():
     assert (
         round(
             feature_match_log_odds_fuzzy_compare(
-                ri, rj, 3, idx_to_col=idx_to_col, log_odds=log_odds
+                ri, rj, "address", col_to_idx, log_odds=log_odds
             ),
             3,
         )
@@ -1093,9 +1100,9 @@ def test_add_person_resource():
 
 def test_compare_address_elements():
     feature_funcs = {
-        2: feature_match_four_char,
+        "address": feature_match_four_char,
     }
-    x = 2
+    col_to_idx = {"address": 2}
     record = [
         ["123"],
         ["1"],
@@ -1126,24 +1133,24 @@ def test_compare_address_elements():
     ]
 
     same_address = _compare_address_elements(
-        record=record, mpi_patient=mpi_patient1, feature_func=feature_funcs, x=x
+        record, mpi_patient1, feature_funcs, "address", col_to_idx
     )
     assert same_address is True
 
     same_address = _compare_address_elements(
-        record=record2, mpi_patient=mpi_patient1, feature_func=feature_funcs, x=x
+        record2, mpi_patient1, feature_funcs, "address", col_to_idx
     )
     assert same_address is True
 
     different_address = _compare_address_elements(
-        record=record, mpi_patient=mpi_patient2, feature_func=feature_funcs, x=x
+        record, mpi_patient2, feature_funcs, "address", col_to_idx
     )
     assert different_address is False
 
 
 def test_compare_name_elements():
-    feature_funcs = {0: feature_match_fuzzy_string}
-    x = 0
+    feature_funcs = {"first": feature_match_fuzzy_string}
+    col_to_idx = {"first": 0}
     record = [
         ["123"],
         ["1"],
@@ -1181,24 +1188,24 @@ def test_compare_name_elements():
     ]
 
     same_name = _compare_name_elements(
-        record=record, mpi_patient=record2, feature_func=feature_funcs, x=x
+        record, record2, feature_funcs, "first", col_to_idx
     )
     assert same_name is True
 
     # Assert same first name with new middle name in record == true fuzzy match
     add_middle_name = _compare_name_elements(
-        record=record3, mpi_patient=mpi_patient2, feature_func=feature_funcs, x=x
+        record3, mpi_patient2, feature_funcs, "first", col_to_idx
     )
     assert add_middle_name is True
 
     add_middle_name = _compare_name_elements(
-        record=record, mpi_patient=mpi_patient1, feature_func=feature_funcs, x=x
+        record, mpi_patient1, feature_funcs, "first", col_to_idx
     )
     assert add_middle_name is True
 
     # Assert no match with different names
     different_names = _compare_name_elements(
-        record=record3, mpi_patient=mpi_patient1, feature_func=feature_funcs, x=x
+        record3, mpi_patient1, feature_funcs, "first", col_to_idx
     )
     assert different_names is False
 


### PR DESCRIPTION
## Summary
This PR changes the linkage code base to work off of column name rather than column index. Previously a user had to specify numerically in some places which operations they wanted to perform on which columns, but in other places, that specification used the column name. Moreover, indexing on column number rather than name exposed us to brittleness in the future, because if the schema changes all the column mappings are shot. These changes push all conversion between column names and numbers into the codebase so that it can adapt to results returned from the DB, when needed, and more importantly, so that everything is now standard from the user's perspective. All function transformations and feature specifications now use the column name, and all feature evaluation functions now follow the same input signature (before, the enhanced algorithm had different inputs, which caused problems and necessitated this PR before changing the API endpoint).

## Related Issue
Fixes #327 
