### PR TITLE
Clear out MPI ahead of testing

### DIFF
--- a/containers/record-linkage/tests/test_record_linkage.py
+++ b/containers/record-linkage/tests/test_record_linkage.py
@@ -45,6 +45,19 @@ def pop_mpi_env_vars():
     os.environ.pop("mpi_person_table", None)
 
 
+def clean_up_db():
+    dbconn = psycopg2.connect(
+        dbname="testdb", user="postgres", password="pw", host="localhost", port="5432"
+    )
+    cursor = dbconn.cursor()
+    cursor.execute("DROP TABLE IF EXISTS patient")
+    dbconn.commit()
+    cursor.execute("DROP TABLE IF EXISTS person")
+    dbconn.commit()
+    cursor.close()
+    dbconn.close()
+
+
 def test_health_check():
     set_mpi_env_vars()
     actual_response = client.get("/")
@@ -95,19 +108,10 @@ def test_linkage_invalid_db_type():
 
 
 def test_linkage_success():
-    set_mpi_env_vars()
-
     # Clear MPI ahead of testing
-    dbconn = psycopg2.connect(
-        dbname="testdb", user="postgres", password="pw", host="localhost", port="5432"
-    )
-    cursor = dbconn.cursor()
-    cursor.execute("DELETE FROM patient;")
-    dbconn.commit()
-    cursor.execute("DELETE FROM person;")
-    dbconn.commit()
-    cursor.close()
-    dbconn.close()
+    clean_up_db()
+
+    set_mpi_env_vars()
 
     entry_list = copy.deepcopy(test_bundle["entry"])
 

--- a/containers/record-linkage/tests/test_record_linkage.py
+++ b/containers/record-linkage/tests/test_record_linkage.py
@@ -102,9 +102,9 @@ def test_linkage_success():
         dbname="testdb", user="postgres", password="pw", host="localhost", port="5432"
     )
     cursor = dbconn.cursor()
-    cursor.execute("DELETE IGNORE FROM patient;")
+    cursor.execute("DELETE FROM patient;")
     dbconn.commit()
-    cursor.execute("DELETE IGNORE FROM person;")
+    cursor.execute("DELETE FROM person;")
     dbconn.commit()
     cursor.close()
     dbconn.close()

--- a/containers/record-linkage/tests/test_record_linkage.py
+++ b/containers/record-linkage/tests/test_record_linkage.py
@@ -102,9 +102,9 @@ def test_linkage_success():
         dbname="testdb", user="postgres", password="pw", host="localhost", port="5432"
     )
     cursor = dbconn.cursor()
-    cursor.execute("DROP TABLE IF EXISTS patient")
+    cursor.execute("DELETE IGNORE FROM patient;")
     dbconn.commit()
-    cursor.execute("DROP TABLE IF EXISTS person")
+    cursor.execute("DELETE IGNORE FROM person;")
     dbconn.commit()
     cursor.close()
     dbconn.close()

--- a/containers/record-linkage/tests/test_record_linkage.py
+++ b/containers/record-linkage/tests/test_record_linkage.py
@@ -97,17 +97,17 @@ def test_linkage_invalid_db_type():
 def test_linkage_success():
     set_mpi_env_vars()
 
-    # Clear MPI ahead of testing
-    dbconn = psycopg2.connect(
-        dbname="testdb", user="postgres", password="pw", host="localhost", port="5432"
-    )
-    cursor = dbconn.cursor()
-    cursor.execute("DROP TABLE IF EXISTS patient")
-    dbconn.commit()
-    cursor.execute("DROP TABLE IF EXISTS person")
-    dbconn.commit()
-    cursor.close()
-    dbconn.close()
+    # # Clear MPI ahead of testing
+    # dbconn = psycopg2.connect(
+    #     dbname="testdb", user="postgres", password="pw", host="localhost", port="5432"
+    # )
+    # cursor = dbconn.cursor()
+    # cursor.execute("DROP TABLE IF EXISTS patient")
+    # dbconn.commit()
+    # cursor.execute("DROP TABLE IF EXISTS person")
+    # dbconn.commit()
+    # cursor.close()
+    # dbconn.close()
 
     entry_list = copy.deepcopy(test_bundle["entry"])
 

--- a/containers/record-linkage/tests/test_record_linkage.py
+++ b/containers/record-linkage/tests/test_record_linkage.py
@@ -97,17 +97,17 @@ def test_linkage_invalid_db_type():
 def test_linkage_success():
     set_mpi_env_vars()
 
-    # # Clear MPI ahead of testing
-    # dbconn = psycopg2.connect(
-    #     dbname="testdb", user="postgres", password="pw", host="localhost", port="5432"
-    # )
-    # cursor = dbconn.cursor()
-    # cursor.execute("DROP TABLE IF EXISTS patient")
-    # dbconn.commit()
-    # cursor.execute("DROP TABLE IF EXISTS person")
-    # dbconn.commit()
-    # cursor.close()
-    # dbconn.close()
+    # Clear MPI ahead of testing
+    dbconn = psycopg2.connect(
+        dbname="testdb", user="postgres", password="pw", host="localhost", port="5432"
+    )
+    cursor = dbconn.cursor()
+    cursor.execute("DROP TABLE IF EXISTS patient")
+    dbconn.commit()
+    cursor.execute("DROP TABLE IF EXISTS person")
+    dbconn.commit()
+    cursor.close()
+    dbconn.close()
 
     entry_list = copy.deepcopy(test_bundle["entry"])
 

--- a/containers/record-linkage/tests/test_record_linkage.py
+++ b/containers/record-linkage/tests/test_record_linkage.py
@@ -96,6 +96,19 @@ def test_linkage_invalid_db_type():
 
 def test_linkage_success():
     set_mpi_env_vars()
+
+    # Clear MPI ahead of testing
+    dbconn = psycopg2.connect(
+        dbname="testdb", user="postgres", password="pw", host="localhost", port="5432"
+    )
+    cursor = dbconn.cursor()
+    cursor.execute("DROP TABLE IF EXISTS patient")
+    dbconn.commit()
+    cursor.execute("DROP TABLE IF EXISTS person")
+    dbconn.commit()
+    cursor.close()
+    dbconn.close()
+
     entry_list = copy.deepcopy(test_bundle["entry"])
 
     bundle_1 = test_bundle

--- a/containers/record-linkage/tests/test_record_linkage.py
+++ b/containers/record-linkage/tests/test_record_linkage.py
@@ -1,7 +1,7 @@
 from fastapi import status
 from fastapi.testclient import TestClient
 from app.config import get_settings
-from app.main import app
+from app.main import app, run_migrations
 
 import copy
 import json
@@ -25,13 +25,15 @@ def set_mpi_env_vars():
 client = TestClient(app)
 
 
-test_bundle = json.load(
-    open(
-        pathlib.Path(__file__).parent
-        / "assets"
-        / "patient_bundle_to_link_with_mpi.json"
+def load_test_bundle():
+    test_bundle = json.load(
+        open(
+            pathlib.Path(__file__).parent
+            / "assets"
+            / "patient_bundle_to_link_with_mpi.json"
+        )
     )
-)
+    return test_bundle
 
 
 def pop_mpi_env_vars():
@@ -92,6 +94,8 @@ def test_linkage_invalid_db_type():
     os.environ["mpi_db_type"] = invalid_db_type
     get_settings.cache_clear()
 
+    test_bundle = load_test_bundle()
+
     expected_response = {
         "message": f"Unsupported database type {invalid_db_type} supplied. "
         + "Make sure your environment variables include an entry "
@@ -110,6 +114,8 @@ def test_linkage_invalid_db_type():
 def test_linkage_success():
     # Clear MPI ahead of testing
     clean_up_db()
+    run_migrations()
+    test_bundle = load_test_bundle()
 
     set_mpi_env_vars()
 
@@ -173,15 +179,6 @@ def test_linkage_success():
     assert person_6.get("id") == person_1.get("id")
 
     # Clean up
-    dbconn = psycopg2.connect(
-        dbname="testdb", user="postgres", password="pw", host="localhost", port="5432"
-    )
-    cursor = dbconn.cursor()
-    cursor.execute("DROP TABLE IF EXISTS patient")
-    dbconn.commit()
-    cursor.execute("DROP TABLE IF EXISTS person")
-    dbconn.commit()
-    cursor.close()
-    dbconn.close()
+    clean_up_db()
 
     pop_mpi_env_vars()


### PR DESCRIPTION
# PULL REQUEST

## Summary
Clears MPI at the start of `test_linkage_success` to prevent other tests from failing in the case that the test is stopped part way through. This PR implements `DELETE` to remove all rows in the patient and person tables but not the tables themselves.

## Related Issue
Fixes #547 

## Additional Information
n/a

[//]: # (PR title: Remember to name your PR descriptively!)