### PR TITLE
Fix floating point truthy bug in helper

### DIFF
--- a/phdi/linkage/link.py
+++ b/phdi/linkage/link.py
@@ -1226,7 +1226,7 @@ def _compare_address_elements(
             feature_comp = feature_funcs[feature_col](
                 [r], [m], feature_col, {feature_col: 0}, **kwargs
             )
-            if feature_comp is True:
+            if feature_comp:
                 break
         break
     return feature_comp


### PR DESCRIPTION
## Summary
This PR fixes a gnarly floating point representational error in one of our linkage helpers that was preventing the address comparison of the enhanced algorithm from ever registering as true. The TLDR is that in python, unlike ints which can be directly evaluated for truth value, floats get evaluated for _truthyness_. We had a line that checked `if feature is True`, which evaluates to False when feature is a floating point number returned from our enhanced algorithm. We need to evaluate it for truthiness, so the fix is `if feature:` which will satisfy the check. That was...fun lol