### PR TITLE
Last of the linkage bugs

### DIFF
--- a/phdi/linkage/link.py
+++ b/phdi/linkage/link.py
@@ -634,6 +634,9 @@ def link_record_against_mpi(
                             blocked_record[j] = ""
                             break
                         blocked_record[j] = blocked_record[j][0]
+                # Name / address come back as lists of one more depth than they should
+                else:
+                    blocked_record[j] = blocked_record[j][0]
 
         clusters = _group_patient_block_by_person(data_block)
 
@@ -1221,8 +1224,8 @@ def _compare_address_elements(
     """
     feature_comp = False
     idx = col_to_idx[feature_col]
-    for r in record[2:][idx]:
-        for m in mpi_patient[2:][idx]:
+    for r in record[idx]:
+        for m in mpi_patient[idx]:
             feature_comp = feature_funcs[feature_col](
                 [r], [m], feature_col, {feature_col: 0}, **kwargs
             )
@@ -1247,8 +1250,8 @@ def _compare_name_elements(
     """
     idx = col_to_idx[feature_col]
     feature_comp = feature_funcs[feature_col](
-        [" ".join(n for n in record[2:][idx])],
-        [" ".join(n for n in mpi_patient[2:][idx])],
+        [" ".join(n for n in record[idx])],
+        [" ".join(n for n in mpi_patient[idx])],
         feature_col,
         {feature_col: 0},
         **kwargs,

--- a/tests/assets/linkage/patient_bundle_to_link_with_mpi.json
+++ b/tests/assets/linkage/patient_bundle_to_link_with_mpi.json
@@ -1,332 +1,346 @@
 {
-  "resourceType": "Bundle",
-  "identifier": {
-    "value": "a very contrived FHIR bundle"
-  },
-  "entry": [
-    {
-      "resource": {
-        "resourceType": "Patient",
-        "id": "f6a16ff7-4a31-11eb-be7b-8344edc8f36b",
-        "identifier": [
-          {
-            "value": "1234567890",
-            "type": {
-              "coding": [
-                {
-                  "code": "MR",
-                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "display": "Medical record number"
-                }
-              ]
-            }
-          }
-        ],
-        "name": [
-          {
-            "family": "Shepard",
-            "given": [
-              "John",
-              "Tiberius"
-            ],
-            "use": "official"
-          }
-        ],
-        "birthDate": "2053-11-07",
-        "gender": "male",
-        "address": [
-          {
-            "line": [
-              "1234 Silversun Strip"
-            ],
-            "buildingNumber": "1234",
-            "city": "Zakera Ward",
-            "state": "Citadel",
-            "postalCode": "99999",
-            "use": "home"
-          }
-        ],
-        "telecom": [
-          {
-            "use": "home",
-            "system": "phone",
-            "value": "123-456-7890"
-          }
-        ]
-      }
+    "resourceType": "Bundle",
+    "identifier": {
+        "value": "a very contrived FHIR bundle"
     },
-    {
-      "resource": {
-        "resourceType": "Patient",
-        "id": "2fdd0b8b-4a70-11eb-99fd-ad786a821574",
-        "identifier": [
-          {
-            "value": "1234567890",
-            "type": {
-              "coding": [
-                {
-                  "code": "MR",
-                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "display": "Medical record number"
-                }
-              ]
+    "entry": [
+        {
+            "resource": {
+                "resourceType": "Patient",
+                "id": "f6a16ff7-4a31-11eb-be7b-8344edc8f36b",
+                "identifier": [
+                    {
+                        "value": "1234567890",
+                        "type": {
+                            "coding": [
+                                {
+                                    "code": "MR",
+                                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                                    "display": "Medical record number"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "name": [
+                    {
+                        "family": "Shepard",
+                        "given": [
+                            "John",
+                            "Tiberius"
+                        ],
+                        "use": "official"
+                    }
+                ],
+                "birthDate": "2053-11-07",
+                "gender": "male",
+                "address": [
+                    {
+                        "line": [
+                            "1234 Silversun Strip"
+                        ],
+                        "buildingNumber": "1234",
+                        "city": "Zakera Ward",
+                        "state": "Citadel",
+                        "postalCode": "99999",
+                        "use": "home"
+                    }
+                ],
+                "telecom": [
+                    {
+                        "use": "home",
+                        "system": "phone",
+                        "value": "123-456-7890"
+                    }
+                ]
             }
-          }
-        ],
-        "name": [
-          {
-            "family": "Sheperd",
-            "given": [
-              "Jon",
-              "Tiberius"
-            ],
-            "use": "official"
-          }
-        ],
-        "birthDate": "2053-11-07",
-        "gender": "male",
-        "address": [
-          {
-            "line": [
-              "1234 Silversun Strip",
-              "Apartment 2A",
-              "Building 3"
-            ],
-            "buildingNumber": "1234",
-            "city": "Zakera Ward",
-            "state": "Citadel",
-            "postalCode": "99999",
-            "use": "home"
-          }
-        ],
-        "telecom": [
-          {
-            "use": "home",
-            "system": "phone",
-            "value": "123-456-7890"
-          }
-        ]
-      }
-    },
-    {
-      "resource": {
-        "resourceType": "Patient",
-        "id": "2c6d5fd1-4a70-11eb-99fd-ad786a821574",
-        "identifier": [
-          {
-            "value": "649-555-0120",
-            "type": {
-              "coding": [
-                {
-                  "code": "SSN",
-                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "display": "Social security number"
-                }
-              ]
+        },
+        {
+            "resource": {
+                "resourceType": "Patient",
+                "id": "2fdd0b8b-4a70-11eb-99fd-ad786a821574",
+                "identifier": [
+                    {
+                        "value": "1234567890",
+                        "type": {
+                            "coding": [
+                                {
+                                    "code": "MR",
+                                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                                    "display": "Medical record number"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "name": [
+                    {
+                        "family": "Sheperd",
+                        "given": [
+                            "Jon",
+                            "Tiberius"
+                        ],
+                        "use": "official"
+                    }
+                ],
+                "birthDate": "2053-11-07",
+                "gender": "male",
+                "address": [
+                    {
+                        "line": [
+                            "1234 Silversun Strip",
+                            "Apartment 2A",
+                            "Building 3"
+                        ],
+                        "buildingNumber": "1234",
+                        "city": "Zakera Ward",
+                        "state": "Citadel",
+                        "postalCode": "99999",
+                        "use": "home"
+                    }
+                ],
+                "telecom": [
+                    {
+                        "use": "home",
+                        "system": "phone",
+                        "value": "123-456-7890"
+                    }
+                ]
             }
-          },
-          {
-            "value": "7894561235",
-            "type": {
-              "coding": [
-                {
-                  "code": "MR",
-                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "display": "Medical record number"
-                }
-              ]
+        },
+        {
+            "resource": {
+                "resourceType": "Patient",
+                "id": "2c6d5fd1-4a70-11eb-99fd-ad786a821574",
+                "identifier": [
+                    {
+                        "value": "649-555-0120",
+                        "type": {
+                            "coding": [
+                                {
+                                    "code": "SSN",
+                                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                                    "display": "Social security number"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "value": "7894561235",
+                        "type": {
+                            "coding": [
+                                {
+                                    "code": "MR",
+                                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                                    "display": "Medical record number"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "name": [
+                    {
+                        "family": "Vas Normandy",
+                        "given": [
+                            "Tali",
+                            "Zora"
+                        ],
+                        "use": "official"
+                    },
+                    {
+                        "family": "Vas Neema",
+                        "given": [
+                            "Tali",
+                            "Zora"
+                        ],
+                        "use": "official"
+                    },
+                    {
+                        "family": "Nar Raya",
+                        "given": [
+                            "Tali",
+                            "Zora"
+                        ],
+                        "use": "official"
+                    }
+                ],
+                "birthDate": "2060-05-14",
+                "gender": "female",
+                "address": [
+                    {
+                        "line": [
+                            "PO Box 1",
+                            "First Rock"
+                        ],
+                        "city": "Nar Raya",
+                        "state": "Ranoch",
+                        "postalCode": "11111",
+                        "use": "home"
+                    },
+                    {
+                        "line": [
+                            "Bay 16",
+                            "Ward Sector 24"
+                        ],
+                        "city": "Liveship",
+                        "state": "The Neema",
+                        "postalCode": "11111",
+                        "use": "previous"
+                    }
+                ]
             }
-          }
-        ],
-        "name": [
-          {
-            "family": "Vas Normandy",
-            "given": [
-              "Tali",
-              "Zora"
-            ],
-            "use": "official"
-          },
-          {
-            "family": "Vas Neema",
-            "given": [
-              "Tali",
-              "Zora"
-            ],
-            "use": "official"
-          },
-          {
-            "family": "Nar Raya",
-            "given": [
-              "Tali",
-              "Zora"
-            ],
-            "use": "official"
-          }
-        ],
-        "birthDate": "2060-05-14",
-        "gender": "female",
-        "address": [
-          {
-            "line": [
-              "PO Box 1",
-              "First Rock"
-            ],
-            "city": "Nar Raya",
-            "state": "Ranoch",
-            "postalCode": "11111",
-            "use": "home"
-          },
-          {
-            "line": [
-              "Bay 16",
-              "Ward Sector 24"
-            ],
-            "city": "Liveship",
-            "state": "The Neema",
-            "postalCode": "11111",
-            "use": "previous"
-          }
-        ]
-      }
-    },
-    {
-      "resource": {
-        "resourceType": "Patient",
-        "id": "fd645c21-4a6f-11eb-99fd-ad786a821574",
-        "identifier": [
-          {
-            "value": "7845451380",
-            "type": {
-              "coding": [
-                {
-                  "code": "MR",
-                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "display": "Medical record number"
-                }
-              ]
+        },
+        {
+            "resource": {
+                "resourceType": "Patient",
+                "id": "fd645c21-4a6f-11eb-99fd-ad786a821574",
+                "identifier": [
+                    {
+                        "value": "7845451380",
+                        "type": {
+                            "coding": [
+                                {
+                                    "code": "MR",
+                                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                                    "display": "Medical record number"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "name": [
+                    {
+                        "family": "Shepard",
+                        "given": [
+                            "John"
+                        ],
+                        "use": "official"
+                    }
+                ],
+                "birthDate": "2053-11-07",
+                "gender": "male",
+                "address": [
+                    {
+                        "line": [
+                            "1234 Silversun Strip"
+                        ],
+                        "buildingNumber": "1234",
+                        "city": "Zakera Ward",
+                        "state": "Citadel",
+                        "postalCode": "99999",
+                        "use": "home"
+                    }
+                ],
+                "telecom": [
+                    {
+                        "use": "home",
+                        "system": "phone",
+                        "value": "123-456-7890"
+                    }
+                ]
             }
-          }
-        ],
-        "name": [
-          {
-            "family": "Shepard",
-            "given": [
-              "John"
-            ],
-            "use": "official"
-          }
-        ],
-        "birthDate": "2053-11-07",
-        "gender": "male",
-        "address": [
-          {
-            "line": [
-              "1234 Silversun Strip"
-            ],
-            "buildingNumber": "1234",
-            "city": "Zakera Ward",
-            "state": "Citadel",
-            "postalCode": "99999",
-            "use": "home"
-          }
-        ],
-        "telecom": [
-          {
-            "use": "home",
-            "system": "phone",
-            "value": "123-456-7890"
-          }
-        ]
-      }
-    },
-    {
-      "resource": {
-        "resourceType": "Patient",
-        "id": "a81bc81b-dead-4e5d-abff-90865d1e13b1",
-        "name": [
-          {
-            "family": "Shepard",
-            "given": [
-              "John"
-            ],
-            "use": "official"
-          }
-        ],
-        "birthDate": "2053-11-07",
-        "gender": "female",
-        "address": [
-          {
-            "line": [
-              "PO Box 1",
-              "First Rock"
-            ],
-            "city": "Nar Raya",
-            "state": "Ranoch",
-            "postalCode": "11111",
-            "use": "home"
-          }
-        ]
-      }
-    },
-    {
-      "resource": {
-        "resourceType": "Patient",
-        "id": "a81bc81b-dead-4e5d-abff-90865d1e13b1",
-        "identifier": [
-          {
-            "value": "1234567890",
-            "type": {
-              "coding": [
-                {
-                  "code": "MR",
-                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "display": "Medical record number"
-                }
-              ]
+        },
+        {
+            "resource": {
+                "resourceType": "Patient",
+                "id": "a81bc81b-dead-4e5d-abff-90865d1e13b1",
+                "identifier": [
+                    {
+                        "value": "7894561235",
+                        "type": {
+                            "coding": [
+                                {
+                                    "code": "MR",
+                                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                                    "display": "Medical record number"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "name": [
+                    {
+                        "family": "Shepard",
+                        "given": [
+                            "John"
+                        ],
+                        "use": "official"
+                    }
+                ],
+                "birthDate": "2053-11-07",
+                "gender": "female",
+                "address": [
+                    {
+                        "line": [
+                            "PO Box 1",
+                            "First Rock"
+                        ],
+                        "city": "Nar Raya",
+                        "state": "Ranoch",
+                        "postalCode": "11111",
+                        "use": "home"
+                    }
+                ]
             }
-          }
-        ],
-        "name": [
-          {
-            "family": "Shepard",
-            "given": [
-              "John",
-              "Tiberia"
-            ],
-            "use": "official"
-          }
-        ],
-        "birthDate": "2053-11-07",
-        "gender": "female",
-        "address": [
-          {
-            "line": [
-              "1234 Silversun Strip"
-            ],
-            "city": "Nar Raya",
-            "state": "Ranoch",
-            "postalCode": "11111",
-            "use": "home"
-          },
-          {
-            "line": [
-              "Bay 16",
-              "Ward Sector 24"
-            ],
-            "city": "Liveship",
-            "state": "The Neema",
-            "postalCode": "11111",
-            "use": "previous"
-          }
-        ]
-      }
-    },
-    {
-      "request": {
-        "method": "GET",
-        "url": "testing for entry with no resource"
-      }
-    }
-  ]
+        },
+        {
+            "resource": {
+                "resourceType": "Patient",
+                "id": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+                "identifier": [
+                    {
+                        "value": "1234567890",
+                        "type": {
+                            "coding": [
+                                {
+                                    "code": "MR",
+                                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                                    "display": "Medical record number"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "name": [
+                    {
+                        "family": "Shepard",
+                        "given": [
+                            "John",
+                            "Tiberia"
+                        ],
+                        "use": "official"
+                    }
+                ],
+                "birthDate": "2053-11-07",
+                "gender": "female",
+                "address": [
+                    {
+                        "line": [
+                            "1234 Silversun Strip"
+                        ],
+                        "city": "Nar Raya",
+                        "state": "Ranoch",
+                        "postalCode": "11111",
+                        "use": "home"
+                    },
+                    {
+                        "line": [
+                            "Bay 16",
+                            "Ward Sector 24"
+                        ],
+                        "city": "Liveship",
+                        "state": "The Neema",
+                        "postalCode": "11111",
+                        "use": "previous"
+                    }
+                ]
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "url": "testing for entry with no resource"
+            }
+        }
+    ]
 }

--- a/tests/linkage/test_linkage.py
+++ b/tests/linkage/test_linkage.py
@@ -1272,24 +1272,24 @@ def test_compare_name_elements():
     ]
 
     same_name = _compare_name_elements(
-        record, record2, feature_funcs, "first", col_to_idx
+        record[2:], record2[2:], feature_funcs, "first", col_to_idx
     )
     assert same_name is True
 
     # Assert same first name with new middle name in record == true fuzzy match
     add_middle_name = _compare_name_elements(
-        record3, mpi_patient2, feature_funcs, "first", col_to_idx
+        record3[2:], mpi_patient2[2:], feature_funcs, "first", col_to_idx
     )
     assert add_middle_name is True
 
     add_middle_name = _compare_name_elements(
-        record, mpi_patient1, feature_funcs, "first", col_to_idx
+        record[2:], mpi_patient1[2:], feature_funcs, "first", col_to_idx
     )
     assert add_middle_name is True
 
     # Assert no match with different names
     different_names = _compare_name_elements(
-        record3, mpi_patient1, feature_funcs, "first", col_to_idx
+        record3[2:], mpi_patient1[2:], feature_funcs, "first", col_to_idx
     )
     assert different_names is False
 


### PR DESCRIPTION
# Oh, list indices, how we curse thee

## Summary
This is the last set of linkage bugs I discovered on the SDK side of record linkage while exposing the enhanced algorithm. We were over-list indexing some places and under-indexing others, leading to us secretly comparing the wrong fields during some parts of the algorithm as well as improperly concatenating joint address objects. This should now be fixed, with updated information in our test assets and our test cases to reflect this.