### PR TITLE
fix test to close invalid json file

### DIFF
--- a/phdi/linkage/link.py
+++ b/phdi/linkage/link.py
@@ -946,12 +946,15 @@ def read_linkage_config(config_file: pathlib.Path) -> List[dict]:
       various parts of linkage pass function.
     """
     try:
-        algo_config = json.load(open(config_file))
-        # Need to convert function keys back to column indices, since
-        # JSON serializes dict keys as strings
-        for rl_pass in algo_config.get("algorithm"):
-            rl_pass["funcs"] = {int(col): f for (col, f) in rl_pass["funcs"].items()}
-        return algo_config.get("algorithm", [])
+        with open(config_file) as f:
+            algo_config = json.load(f)
+            # Need to convert function keys back to column indices, since
+            # JSON serializes dict keys as strings
+            for rl_pass in algo_config.get("algorithm"):
+                rl_pass["funcs"] = {
+                    int(col): f for (col, f) in rl_pass["funcs"].items()
+                }
+            return algo_config.get("algorithm", [])
     except FileNotFoundError:
         raise FileNotFoundError(f"No file exists at path {config_file}.")
     except json.decoder.JSONDecodeError as e:

--- a/tests/not_valid_json_test.json
+++ b/tests/not_valid_json_test.json
@@ -1,1 +1,0 @@
-this is a random string that is not in json format


### PR DESCRIPTION
# PULL REQUEST

## Summary
I added a context manager to `read_linkage_config` so that the config file would definitely be closed. On Windows machines, without the context manager the config was not closed. This created an issue in `test_read_algo_errors` where reading the `not_valid_json_test.json` as a config file left it open and thus were unable to remove it in the final line of the function. 

Here is the error that would occur when running tests locally on Windows machines:
```
FAILED linkage\test_linkage.py::test_read_algo_errors - PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'not_valid_json_test.json'   
```
## Related Issue
Fixes #

## Additional Information
Anything else the review team should know?

[//]: # (PR title: Remember to name your PR descriptively!)