### PR TITLE
Add seperate generate doc workflow

### DIFF
--- a/.github/workflows/createNewRelease.yaml
+++ b/.github/workflows/createNewRelease.yaml
@@ -136,116 +136,16 @@ jobs:
     uses: ./.github/workflows/buildReleaseContainers.yaml
     with:
       container-tag: ${{ needs.tag-release.outputs.version }}
-
-# Create updated PHDI docs for the latest release
+  
   generate-and-update-phdi-docs:
     needs: 
       - tag-release
       - build-containers-for-release
     permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: '0'
-          ref: ${{ needs.tag-release.outputs.version }}
-
-      - name: Install poetry and dependencies
-        run: |
-          pip install poetry
-          poetry install
-
-      - name: Generate docs and move to docs branch
-        run: |
-          poetry run pdoc ./phdi -o ./docs/${{ needs.tag-release.outputs.version }}/sdk
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: phdi-docs
-          path: ./docs/${{ needs.tag-release.outputs.version }}/sdk
-
-  # Create updated container docs for the latest release
-  list-containers:
-    needs: check-commit-message
-    if: ${{ needs.check-commit-message.outputs.contains_release == 'true' }}
-    uses: ./.github/workflows/listContainers.yaml
-  generate-and-update-container-docs:
-    needs:
-      - tag-release
-      - list-containers
-      - generate-and-update-phdi-docs
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        container: ${{fromJson(needs.list-containers.outputs.containers)}}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: '0'
-          ref: ${{ needs.tag-release.outputs.version }}
-
-      - name: Update Container Documenation
-        env:
-          MPI_DBNAME: testdb
-          MPI_PASSWORD: pw
-          MPI_DB_TYPE: postgres
-          MPI_HOST: localhost
-          MPI_USER: postgres
-          MPI_PORT: 5432
-          MPI_PATIENT_TABLE: patient
-          MPI_PERSON_TABLE: person
-        run: |
-          npm i -g redoc-cli
-          CONTAINER=${{ matrix.container }}
-          cd $GITHUB_WORKSPACE/containers/$CONTAINER
-          cp $GITHUB_WORKSPACE/utils/make_openapi_json.py .
-          pip install -r requirements.txt
-          python make_openapi_json.py
-          redoc-cli build -o $GITHUB_WORKSPACE/docs/${{ needs.tag-release.outputs.version }}/containers/$CONTAINER.html openapi.json
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: container-docs
-          path: ./docs/${{ needs.tag-release.outputs.version }}/containers
-
-  commit-docs:
-    needs:
-      - tag-release
-      - generate-and-update-phdi-docs
-      - generate-and-update-container-docs
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: docs
-
-      - name: Download phdi docs from artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: phdi-docs
-          path: ./docs/${{ needs.tag-release.outputs.version }}/sdk
-
-      - name: Download container docs from artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: container-docs
-          path: ./docs/${{ needs.tag-release.outputs.version }}/containers
-
-      - name: Copy to latest folder
-        run: |
-          rm -rf ./docs/latest
-          mkdir -p ./docs/latest/sdk
-          mkdir -p ./docs/latest/containers
-          cp -r ./docs/${{ needs.tag-release.outputs.version }}/sdk/* ./docs/latest/sdk
-          cp -r ./docs/${{ needs.tag-release.outputs.version }}/containers/* ./docs/latest/containers
-
-      - name: Commit New Documentation
-        uses: EndBug/add-and-commit@v9
-        with:
-          add: docs
-          message: Automated update of docs for ${{ needs.tag-release.outputs.version }} release.
+      contents: read
+      packages: write
+      id-token: write
+    uses: ./.github/workflows/generateAndUpdatePhdiDocs.yaml
+    with:
+      container-tag: ${{ needs.tag-release.outputs.version }}
+      contains-release: ${{ needs.check-commit-message.outputs.contains_release == 'true' }}

--- a/.github/workflows/generateAndUpdatePhdiDocs.yaml
+++ b/.github/workflows/generateAndUpdatePhdiDocs.yaml
@@ -1,0 +1,126 @@
+name: Create updated PHDI docs for the latest release
+
+on:
+  workflow_call:
+    inputs:
+      container-tag:
+        type: string
+        required: true
+      contains-release:
+        type: boolean
+        required: true
+  workflow_dispatch:
+    inputs:
+      container-tag:
+        type: string
+        required: true
+      contains-release:
+        type: boolean
+        required: true
+
+jobs:
+  generate-and-update-phdi-docs:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+          ref: ${{ inputs.container-tag }}
+
+      - name: Install poetry and dependencies
+        run: |
+          pip install poetry
+          poetry install
+
+      - name: Generate docs and move to docs branch
+        run: |
+          poetry run pdoc ./phdi -o ./docs/${{ inputs.container-tag }}/sdk
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: phdi-docs
+          path: ./docs/${{ inputs.container-tag }}/sdk
+
+  # Create updated container docs for the latest release
+  list-containers:
+    if: ${{ inputs.contains-release }}
+    uses: ./.github/workflows/listContainers.yaml
+  generate-and-update-container-docs:
+    needs:
+      - list-containers
+      - generate-and-update-phdi-docs
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        container: ${{fromJson(needs.list-containers.outputs.containers)}}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+          ref: ${{ inputs.container-tag }}
+
+      - name: Update Container Documenation
+        env:
+          MPI_DBNAME: testdb
+          MPI_PASSWORD: pw
+          MPI_DB_TYPE: postgres
+          MPI_HOST: localhost
+          MPI_USER: postgres
+          MPI_PORT: 5432
+          MPI_PATIENT_TABLE: patient
+          MPI_PERSON_TABLE: person
+        run: |
+          npm i -g redoc-cli
+          CONTAINER=${{ matrix.container }}
+          cd $GITHUB_WORKSPACE/containers/$CONTAINER
+          cp $GITHUB_WORKSPACE/utils/make_openapi_json.py .
+          pip install -r requirements.txt
+          python make_openapi_json.py
+          redoc-cli build -o $GITHUB_WORKSPACE/docs/${{ inputs.container-tag }}/containers/$CONTAINER.html openapi.json
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: container-docs
+          path: ./docs/${{ inputs.container-tag }}/containers
+
+  commit-docs:
+    needs:
+      - generate-and-update-phdi-docs
+      - generate-and-update-container-docs
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: docs
+
+      - name: Download phdi docs from artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: phdi-docs
+          path: ./docs/${{ inputs.container-tag }}/sdk
+
+      - name: Download container docs from artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: container-docs
+          path: ./docs/${{ inputs.container-tag }}/containers
+
+      - name: Copy to latest folder
+        run: |
+          rm -rf ./docs/latest
+          mkdir -p ./docs/latest/sdk
+          mkdir -p ./docs/latest/containers
+          cp -r ./docs/${{ inputs.container-tag }}/sdk/* ./docs/latest/sdk
+          cp -r ./docs/${{ inputs.container-tag }}/containers/* ./docs/latest/containers
+
+      - name: Commit New Documentation
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: docs
+          message: Automated update of docs for ${{ inputs.container-tag }} release.


### PR DESCRIPTION
# PULL REQUEST

## Summary
We need a way to generate docs when the release fails. This allows you to run just that

## Related Issue
Fixes #

## Additional Information
Anything else the review team should know?

[//]: # (PR title: Remember to name your PR descriptively!)