### PR TITLE
Point back to main

### DIFF
--- a/containers/alerts/requirements.txt
+++ b/containers/alerts/requirements.txt
@@ -5,7 +5,7 @@ azure-identity
 typing_extensions==4.5.0
 pydantic==1.10.9
 fastapi==0.96.0
-phdi @ git+https://github.com/CDCgov/phdi@python310
+phdi @ git+https://github.com/CDCgov/phdi@main
 uvicorn
 httpx
 slack_sdk

--- a/containers/ingestion/requirements.txt
+++ b/containers/ingestion/requirements.txt
@@ -1,6 +1,6 @@
 typing_extensions==4.6.3
 pydantic==1.10.9
 fastapi==0.96.0
-phdi @ git+https://github.com/CDCgov/phdi@python310
+phdi @ git+https://github.com/CDCgov/phdi@main
 uvicorn
 httpx

--- a/containers/message-parser/requirements.txt
+++ b/containers/message-parser/requirements.txt
@@ -1,7 +1,7 @@
 typing_extensions==4.5.0
 pydantic==1.10.9
 fastapi==0.96.0
-phdi @ git+https://github.com/CDCgov/phdi@python310
+phdi @ git+https://github.com/CDCgov/phdi@main
 uvicorn
 httpx
 pytest

--- a/containers/record-linkage/requirements.txt
+++ b/containers/record-linkage/requirements.txt
@@ -2,6 +2,6 @@ typing_extensions==4.5.0
 uvicorn
 pydantic==1.10.9
 fastapi==0.96.0
-phdi @ git+https://github.com/CDCgov/phdi@python310
+phdi @ git+https://github.com/CDCgov/phdi@main
 httpx
 pathlib

--- a/containers/tabulation/requirements.txt
+++ b/containers/tabulation/requirements.txt
@@ -1,7 +1,7 @@
 typing_extensions==4.5.0
 pydantic==1.10.9
 fastapi==0.96.0
-phdi @ git+https://github.com/CDCgov/phdi@python310
+phdi @ git+https://github.com/CDCgov/phdi@main
 uvicorn
 httpx
 pytest

--- a/containers/validation/requirements.txt
+++ b/containers/validation/requirements.txt
@@ -1,7 +1,7 @@
 typing_extensions==4.5.0
 pydantic==1.10.9
 fastapi==0.96.0
-phdi @ git+https://github.com/CDCgov/phdi@python310
+phdi @ git+https://github.com/CDCgov/phdi@main
 uvicorn
 httpx
 pytest

--- a/tutorials/python-update-tutorial.md
+++ b/tutorials/python-update-tutorial.md
@@ -11,7 +11,7 @@ For the test.yaml, update the `TEST_RUNNER_PYTHON_VERSION` to your new python ve
 ## Changing requirements.txt
 To upgrade python, understanding the current state of the repo is key. Currently as of June 2023, phdi is self-referential because the `requirements.txt` in the contianers/* folder points to the actual phdi pypi project itself. Therefore, when upgrading python, you have to point the requirements.txt to the current branch that has the new version of python. For example, if your branch is named `upgradepython3x`, then your requirements.txt file will have an entry named `phdi @ git+https://github.com/CDCgov/phdi@upgradepython3x`
 
-Once you push these changes into GitHub, you must change the `requirements.txt` file to point to main. Therefore it will be `phdi @ git+https://github.com/CDCgov/phdi@python310`
+Once you push these changes into GitHub, you must change the `requirements.txt` file to point to main. Therefore it will be `phdi @ git+https://github.com/CDCgov/phdi@main`
 
 The files that need to be changed are
 - containers/alerts/requirements.txt


### PR DESCRIPTION
After updating to python 3.10, we need to point back to main because python310 branch doesn't exist anymore