### PR TITLE
Update parquet to fhir bundle conversion

### DIFF
--- a/phdi/linkage/seed.py
+++ b/phdi/linkage/seed.py
@@ -79,8 +79,15 @@ def convert_to_patient_fhir_resources(data: Dict) -> Tuple:
 
     fhir_bundle = {
         "resourceType": "Bundle",
+        "type": "batch",
         "id": str(uuid.uuid4()),
-        "entry": [{"fullUrl": f"urn:uuid:{patient_id}", "resource": patient_resource}],
+        "entry": [
+            {
+                "fullUrl": f"urn:uuid:{patient_id}",
+                "resource": patient_resource,
+                "request": {"method": "PUT", "url": f"Patient/{patient_id}"},
+            },
+        ],
     }
 
     iris_id = data.get("iris_id", None)

--- a/phdi/linkage/seed.py
+++ b/phdi/linkage/seed.py
@@ -62,6 +62,7 @@ def convert_to_patient_fhir_resources(data: Dict) -> Tuple:
                 "value": f"{data.get('cell_phone',None)}",
                 "use": "mobile",
             },
+            {"value": f"{data.get('email',None)}", "system": "email"},
         ],
         "gender": f"{data.get('sex',None)}",
         "birthDate": f"{data.get('birthdate',None)}",

--- a/phdi/linkage/seed.py
+++ b/phdi/linkage/seed.py
@@ -83,4 +83,5 @@ def convert_to_patient_fhir_resources(data: Dict) -> Tuple:
         "entry": [{"fullUrl": f"urn:uuid:{patient_id}", "resource": patient_resource}],
     }
 
-    return (data["iris_id"], fhir_bundle)
+    iris_id = data.get("iris_id", None)
+    return (iris_id, fhir_bundle)

--- a/tests/linkage/test_seed.py
+++ b/tests/linkage/test_seed.py
@@ -26,3 +26,6 @@ def test_convert_to_patient_fhir_resources():
             "urn:uuid:" + returned_fhir_bundle["entry"][0]["resource"]["id"]
             == returned_fhir_bundle["entry"][0]["fullUrl"]
         )
+        assert (
+            "@" in returned_fhir_bundle["entry"][0]["resource"]["telecom"][2]["value"]
+        )


### PR DESCRIPTION
# Update convert_to_patient_fhir_resources()

## Summary
- Adds email to generate fhir bundle because LAC will provide it in the MPI.parquet file they upload
- Modifies the way that we extract `iris_id` from the parquet file to accommodate's LAC schema in which they do not include an `iris_id`
- Adds `request` section to fhir bundle per @BradySkylight's suggestion, i.e., should the bundle ever need to enter a FHIR server, it's ready to go
- Adds `type` section to fhir bundle per Brady's suggestion


## Related Issue
Fixes # phdi-azure#207

## Additional Information
I validated the formatting of the generated FHIR bundle using `azurehealthcareapis`

[//]: # (PR title: Remember to name your PR descriptively!)