### PR TITLE
Add additional demographic data into ecr store schema

### DIFF
--- a/containers/message-parser/app/default_schemas/ecr.json
+++ b/containers/message-parser/app/default_schemas/ecr.json
@@ -39,6 +39,36 @@
       "data_type": "string",
       "nullable": true
    },
+   "street_address1": {
+      "fhir_path": "Bundle.entry.resource.where(resourceType = 'Patient').address.line[0]",
+      "data_type": "string",
+      "nullable": true
+   },
+   "street_address2": {
+      "fhir_path": "Bundle.entry.resource.where(resourceType = 'Patient').address.line[1]",
+      "data_type": "string",
+      "nullable": true
+   },
+   "state": {
+      "fhir_path": "Bundle.entry.resource.where(resourceType = 'Patient').address.state",
+      "data_type": "string",
+      "nullable": true
+   },
+   "zip": {
+      "fhir_path": "Bundle.entry.resource.where(resourceType = 'Patient').address.postalCode",
+      "data_type": "string",
+      "nullable": true
+   },
+   "lat": {
+      "fhir_path": "Bundle.entry.resource.where(resourceType = 'Patient').address.extension.where(url='http://hl7.org/fhir/StructureDefinition/geolocation').extension.where(url='latitude').valueDecimal",
+      "data_type": "number",
+      "nullable": true
+   },
+   "long": {
+      "fhir_path": "Bundle.entry.resource.where(resourceType = 'Patient').address.extension.where(url='http://hl7.org/fhir/StructureDefinition/geolocation').extension.where(url='longitude').valueDecimal",
+      "data_type": "number",
+      "nullable": true
+   },
    "rr_id": {
       "fhir_path": "Bundle.entry.resource.where(resourceType='Composition').section.where(title = 'Reportability Response Information Section').extension.where(url='http://hl7.org/fhir/us/ecr/StructureDefinition/rr-composition').valueIdentifier.where(use='official' and type.coding.code='88085-6').value",
       "data_type": "string",

--- a/containers/message-parser/app/default_schemas/ecr.json
+++ b/containers/message-parser/app/default_schemas/ecr.json
@@ -64,7 +64,7 @@
       "data_type": "number",
       "nullable": true
    },
-   "long": {
+   "longitude": {
       "fhir_path": "Bundle.entry.resource.where(resourceType = 'Patient').address.extension.where(url='http://hl7.org/fhir/StructureDefinition/geolocation').extension.where(url='longitude').valueDecimal",
       "data_type": "number",
       "nullable": true

--- a/containers/message-parser/app/default_schemas/ecr.json
+++ b/containers/message-parser/app/default_schemas/ecr.json
@@ -59,7 +59,7 @@
       "data_type": "string",
       "nullable": true
    },
-   "lat": {
+   "latitude": {
       "fhir_path": "Bundle.entry.resource.where(resourceType = 'Patient').address.extension.where(url='http://hl7.org/fhir/StructureDefinition/geolocation').extension.where(url='latitude').valueDecimal",
       "data_type": "number",
       "nullable": true


### PR DESCRIPTION
# PULL REQUEST

## Summary
Add additional demographic columns to the ECR Data Store schema, as requested by LAC and their respective FHIR Paths.  The following columns have been added:

- street address ( I created two columns for this)
- phone
- state
- zip
- lat
- long


## Related Issue
Fixes #[112](https://app.zenhub.com/workspaces/skylight-dibbs-viper-6480ba23b5a07644e0e46d23/issues/gh/cdcgov/phdi-google-cloud/112)

## Additional Information
