### PR TITLE
Added code to handle floats properly when making a list in the message parser

### DIFF
--- a/containers/message-parser/app/default_schemas/test_schema.json
+++ b/containers/message-parser/app/default_schemas/test_schema.json
@@ -1,29 +1,39 @@
 {
-  "first_name": {
-    "fhir_path": "Bundle.entry.resource.where(resourceType = 'Patient').name.first().given.first()",
-    "data_type": "string",
-    "nullable": true
-  },
-  "last_name": {
-    "fhir_path": "Bundle.entry.resource.where(resourceType = 'Patient').name.first().family",
-    "data_type": "string",
-    "nullable": true
-  },
-  "active_problems": {
-    "fhir_path": "Bundle.entry.resource.where(resourceType='Condition').where(category.coding.code='problem-item-list')",
-    "data_type": "array",
-    "nullable": true,
-    "secondary_schema": {
-       "problem": {
-          "fhir_path": "Condition.code.coding.display",
-          "data_type": "string",
-          "nullable": true
-       },
-       "problem_date": {
-          "fhir_path": "Condition.onsetDateTime",
-          "data_type": "datetime",
-          "nullable": true
-       }
-    }
- }
+   "first_name": {
+      "fhir_path": "Bundle.entry.resource.where(resourceType = 'Patient').name.first().given.first()",
+      "data_type": "string",
+      "nullable": true
+   },
+   "last_name": {
+      "fhir_path": "Bundle.entry.resource.where(resourceType = 'Patient').name.first().family",
+      "data_type": "string",
+      "nullable": true
+   },
+   "latitude": {
+      "fhir_path": "Bundle.entry.resource.where(resourceType = 'Patient').address.extension.where(url='http://hl7.org/fhir/StructureDefinition/geolocation').extension.where(url='latitude').valueDecimal",
+      "data_type": "float",
+      "nullable": true
+   },
+   "longitude": {
+      "fhir_path": "Bundle.entry.resource.where(resourceType = 'Patient').address.extension.where(url='http://hl7.org/fhir/StructureDefinition/geolocation').extension.where(url='longitude').valueDecimal",
+      "data_type": "float",
+      "nullable": true
+   },
+   "active_problems": {
+      "fhir_path": "Bundle.entry.resource.where(resourceType='Condition').where(category.coding.code='problem-item-list')",
+      "data_type": "array",
+      "nullable": true,
+      "secondary_schema": {
+         "problem": {
+            "fhir_path": "Condition.code.coding.display",
+            "data_type": "string",
+            "nullable": true
+         },
+         "problem_date": {
+            "fhir_path": "Condition.onsetDateTime",
+            "data_type": "datetime",
+            "nullable": true
+         }
+      }
+   }
 }

--- a/containers/message-parser/app/main.py
+++ b/containers/message-parser/app/main.py
@@ -182,7 +182,7 @@ async def parse_message_endpoint(
             if len(value) == 0:
                 value = None
             else:
-                value = ",".join(value)
+                value = ",".join(map(str, value))
             parsed_values[field] = value
         else:
             inital_values = parser["primary_parser"](input.message)
@@ -196,7 +196,7 @@ async def parse_message_endpoint(
                         value[secondary_field] = None
                     else:
                         value[secondary_field] = ",".join(
-                            secondary_parser(initial_value)
+                            map(str, secondary_parser(initial_value))
                         )
                 values.append(value)
             parsed_values[field] = values

--- a/containers/message-parser/tests/test_parse_message_endpoint.py
+++ b/containers/message-parser/tests/test_parse_message_endpoint.py
@@ -15,8 +15,19 @@ fhir_bundle_path = (
     / "patient_bundle.json"
 )
 
+fhir_bundle_path_w_float = (
+    Path(__file__).parent.parent.parent.parent
+    / "tests"
+    / "assets"
+    / "general"
+    / "patient_bundle_w_floats.json"
+)
+
 with open(fhir_bundle_path, "r") as file:
     fhir_bundle = json.load(file)
+
+with open(fhir_bundle_path_w_float, "r") as file:
+    fhir_bundle_w_float = json.load(file)
 
 test_schema_path = (
     Path(__file__).parent.parent / "app" / "default_schemas" / "test_schema.json"
@@ -27,7 +38,24 @@ with open(test_schema_path, "r") as file:
 
 expected_successful_response = {
     "message": "Parsing succeeded!",
-    "parsed_values": {"first_name": "John ", "last_name": "doe", "active_problems": []},
+    "parsed_values": {
+        "first_name": "John ",
+        "last_name": "doe",
+        "latitude": None,
+        "longitude": None,
+        "active_problems": [],
+    },
+}
+
+expected_successful_response_floats = {
+    "message": "Parsing succeeded!",
+    "parsed_values": {
+        "first_name": "John ",
+        "last_name": "doe",
+        "latitude": "34.58002",
+        "longitude": "-118.08925",
+        "active_problems": [],
+    },
 }
 
 
@@ -41,6 +69,17 @@ def test_parse_message_success_internal_schema():
     actual_response = client.post("/parse_message", json=test_request)
     assert actual_response.status_code == 200
     assert actual_response.json() == expected_successful_response
+
+    test_request2 = {
+        "message_format": "fhir",
+        "parsing_schema_name": "test_schema.json",
+        "message": fhir_bundle_w_float,
+    }
+
+    actual_response2 = client.post("/parse_message", json=test_request2)
+    assert actual_response2.status_code == 200
+    print(actual_response2.json())
+    assert actual_response2.json() == expected_successful_response_floats
 
 
 def test_parse_message_success_external_schema():

--- a/tests/assets/general/patient_bundle_w_floats.json
+++ b/tests/assets/general/patient_bundle_w_floats.json
@@ -1,0 +1,91 @@
+{
+  "resourceType": "Bundle",
+  "identifier": {
+    "value": "a very contrived FHIR bundle"
+  },
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Organization",
+        "id": "some-org-we-dont-care-about"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "some-uuid",
+        "identifier": [
+          {
+            "value": "123456",
+            "type": {
+              "coding": [
+                {
+                  "code": "MR",
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "display": "Medical record number"
+                }
+              ]
+            },
+            "system": "urn...no idea"
+          }
+        ],
+        "name": [
+          {
+            "family": "doe",
+            "given": [
+              "John ",
+              " Danger "
+            ],
+            "use": "official"
+          }
+        ],
+        "birthDate": "1983-02-01",
+        "gender": "female",
+        "address": [
+          {
+            "line": [
+              "123 Fake St",
+              "Unit #F"
+            ],
+            "BuildingNumber": "123",
+            "city": "Faketon",
+            "state": "NY",
+            "postalCode": "10001-0001",
+            "country": "USA",
+            "use": "home",
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/geolocation",
+                "extension": [
+                  {
+                    "url": "latitude",
+                    "valueDecimal": 34.58002
+                  },
+                  {
+                    "url": "longitude",
+                    "valueDecimal": -118.08925
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "telecom": [
+          {
+            "use": "home",
+            "system": "phone",
+            "value": "123-456-7890"
+          },
+          {
+            "value": "johndanger@doe.net",
+            "system": "email"
+          }
+        ]
+      },
+      "request": {
+        "method": "GET",
+        "url": "testing for entry with no resource"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# PULL REQUEST

## Summary
Nick identified a bug where if float values are present in a bundle that is processed that they can't be converted to a comma separate list of floats.  The code now translates the floats into str to add them to a comma separated list.  I have added tests to cover this case as well as a updated the test schema to include elements that are floats, additionally I have added lat and long to a sample test bundle for this test case.

My only concern is if this will cause issues downstream where we are reading this data from the message parser into files that LAC can consume.  @m-goggins Can we confirm that this result will not break any of that functionality...if it does I can work with you on coming up with a solution.

See Error below:

![image](https://github.com/CDCgov/phdi/assets/109990072/2d396c8c-f414-44ad-bf87-2ad9c8e7fe87)


## Related Issue