### PR TITLE
Add postgres service to container doc generation job

### DIFF
--- a/.github/workflows/createNewRelease.yaml
+++ b/.github/workflows/createNewRelease.yaml
@@ -178,6 +178,22 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    services:
+      test-db:
+        image: postgres:13-alpine3.16
+        env:
+          POSTGRES_PASSWORD: pw
+          POSTGRES_DB: testdb
+          POSTGRES_USER: postgres
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+          --name testdb
+        ports:
+          - 5432:5432
     strategy:
       matrix:
         container: ${{fromJson(needs.list-containers.outputs.containers)}}


### PR DESCRIPTION
This should resolve this issue that came up on the latest release workflow:

https://github.com/CDCgov/phdi/actions/runs/6317099298/job/17154276278

Basically, now that the RL container uses Pyway to run migrations, it's attempting to connect to a db at the startup when generating container docs, but we aren't running a DB container for that job. This just adds a DB container so that it can run the migrations and then generate the container docs.