### PR TITLE
Make secondary_schema optional

### DIFF
--- a/containers/message-parser/app/main.py
+++ b/containers/message-parser/app/main.py
@@ -283,7 +283,7 @@ async def get_schema(parsing_schema_name: str, response: Response) -> GetSchemaR
 
 
 PARSING_SCHEMA_DATA_TYPES = Literal[
-    "string", "integer", "float", "boolean", "date", "timestamp"
+    "string", "integer", "float", "boolean", "date", "datetime", "array"
 ]
 
 

--- a/containers/message-parser/app/main.py
+++ b/containers/message-parser/app/main.py
@@ -364,7 +364,10 @@ async def upload_schema(
 
     # Convert Pydantic models to dicts so they can be serialized to JSON.
     for field in input.parsing_schema:
-        input.parsing_schema[field] = input.parsing_schema[field].dict()
+        field_dict = input.parsing_schema[field].dict()
+        if "secondary_schema" in field_dict and field_dict["secondary_schema"] is None:
+            del field_dict["secondary_schema"]
+        input.parsing_schema[field] = field_dict
 
     with open(file_path, "w") as file:
         json.dump(input.parsing_schema, file, indent=4)

--- a/containers/message-parser/app/main.py
+++ b/containers/message-parser/app/main.py
@@ -297,7 +297,7 @@ class ParsingSchemaFieldModel(BaseModel):
     fhir_path: str
     data_type: PARSING_SCHEMA_DATA_TYPES
     nullable: bool
-    secondary_schema: Dict[str, ParsingSchemaSecondaryFieldModel]
+    secondary_schema: Optional[Dict[str, ParsingSchemaSecondaryFieldModel]]
 
 
 class ParsingSchemaModel(BaseModel):

--- a/containers/message-parser/app/utils.py
+++ b/containers/message-parser/app/utils.py
@@ -80,12 +80,12 @@ def get_parsers(extraction_schema: frozendict) -> frozendict:
     """
     parsers = {}
 
-    for field, field_definiton in extraction_schema.items():
+    for field, field_definition in extraction_schema.items():
         parser = {}
-        parser["primary_parser"] = fhirpathpy.compile(field_definiton["fhir_path"])
-        if "secondary_schema" in field_definiton:
+        parser["primary_parser"] = fhirpathpy.compile(field_definition["fhir_path"])
+        if "secondary_schema" in field_definition:
             secondary_parsers = {}
-            for secondary_field, secondary_field_definition in field_definiton[
+            for secondary_field, secondary_field_definition in field_definition[
                 "secondary_schema"
             ].items():
                 secondary_parsers[secondary_field] = fhirpathpy.compile(

--- a/containers/message-parser/tests/test_schemas_endpoint.py
+++ b/containers/message-parser/tests/test_schemas_endpoint.py
@@ -99,3 +99,52 @@ def test_upload_schema():
         Path(__file__).parent.parent / "app" / "custom_schemas" / test_schema_name
     )
     parsing_schema.unlink()
+
+
+def test_upload_schema_no_secondary():
+    request_body = {
+        "parsing_schema": {
+            "my_field": {
+                "fhir_path": "some-path",
+                "data_type": "string",
+                "nullable": True,
+            }
+        }
+    }
+    test_schema_name = "test_schema1.json"
+
+    # Upload a new schema.
+    response = client.put(
+        f"/schemas/{test_schema_name}",
+        json=request_body,
+    )
+    assert response.status_code == 201
+    assert response.json() == {"message": "Schema uploaded successfully!"}
+
+    response = client.put(
+        "/schemas/test_schema1.json",
+        json=request_body,
+    )
+
+    # Attempt to upload a schema with name that already exists.
+    assert response.status_code == 400
+    assert response.json() == {
+        "message": f"A schema for the name '{test_schema_name}' already exists. "
+        "To proceed submit a new request with a different schema name or set the "
+        "'overwrite' field to 'true'."
+    }
+    request_body["overwrite"] = True
+    response = client.put(
+        "/schemas/test_schema1.json",
+        json=request_body,
+    )
+
+    # Upload a schema with name that already exists and overwrite it.
+    assert response.status_code == 200
+    assert response.json() == {"message": "Schema updated successfully!"}
+
+    # Delete the test schema to avoid conflicts with other tests.
+    parsing_schema = (
+        Path(__file__).parent.parent / "app" / "custom_schemas" / test_schema_name
+    )
+    parsing_schema.unlink()


### PR DESCRIPTION
# PULL REQUEST

## Summary
Make the `secondary_schema` key optional for parsing schema fields when adding new schemas to the message parser.
