### PR TITLE
Update integration tests to run at the current commit in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -193,14 +193,10 @@ jobs:
         # When running as a PR check, instead of importing the SDK from @main,
         # import it from the current commit.
         run: | 
-          if [[ $GITHUB_REF == "main" ]]; then
-               echo $GITHUB_REF
-               echo "running on main!"
+          if [[ $GITHUB_REF == "refs/heads/main" ]]; then
                pwd
                pip install -r requirements.txt
           else
-               echo $GITHUB_REF
-               echo "not running on main"
                pwd
                commit_hash=$(git rev-parse HEAD)
                cp requirements.txt ci_requirements.txt

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -190,14 +190,19 @@ jobs:
         run: pip install pytest
       - name: Install dependencies
         working-directory: ./containers/${{matrix.directories-to-test}}
-        # Instead of importing the SDK from @main, import it from
-        # the current commit.
+        # When running as a PR check, instead of importing the SDK from @main,
+        # import it from the current commit.
         run: | 
-          pwd
-          commit_hash=$(git rev-parse HEAD)
-          cp requirements.txt ci_requirements.txt
-          sed -i -e "s/phdi@main/phdi@${commit_hash}/g" ci_requirements.txt
-          pip install -r ci_requirements.txt
+          if [[ git rev-parse --abbrev-ref HEAD == "main" ]]; then
+               pwd
+               pip install -r requirements.txt
+          else
+               pwd
+               commit_hash=$(git rev-parse HEAD)
+               cp requirements.txt ci_requirements.txt
+               sed -i -e "s/phdi@main/phdi@${commit_hash}/g" ci_requirements.txt
+               pip install -r ci_requirements.txt
+          fi
       - name: Run integration tests for containers
         working-directory: ./containers/${{matrix.directories-to-test}}/tests/integration
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -193,10 +193,14 @@ jobs:
         # When running as a PR check, instead of importing the SDK from @main,
         # import it from the current commit.
         run: | 
-          if [[ git rev-parse --abbrev-ref HEAD == "main" ]]; then
+          if [[ GITHUB_REF == "main" ]]; then
+               echo GITHUB_REF
+               echo "running on main!"
                pwd
                pip install -r requirements.txt
           else
+               echo GITHUB_REF
+               echo "not running on main"
                pwd
                commit_hash=$(git rev-parse HEAD)
                cp requirements.txt ci_requirements.txt

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -193,13 +193,13 @@ jobs:
         # When running as a PR check, instead of importing the SDK from @main,
         # import it from the current commit.
         run: | 
-          if [[ GITHUB_REF == "main" ]]; then
-               echo GITHUB_REF
+          if [[ $GITHUB_REF == "main" ]]; then
+               echo $GITHUB_REF
                echo "running on main!"
                pwd
                pip install -r requirements.txt
           else
-               echo GITHUB_REF
+               echo $GITHUB_REF
                echo "not running on main"
                pwd
                commit_hash=$(git rev-parse HEAD)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -190,9 +190,14 @@ jobs:
         run: pip install pytest
       - name: Install dependencies
         working-directory: ./containers/${{matrix.directories-to-test}}
-        run: |
+        # Instead of importing the SDK from @main, import it from
+        # the current commit.
+        run: | 
           pwd
-          pip install -r requirements.txt
+          commit_hash=$(git rev-parse HEAD)
+          cp requirements.txt ci_requirements.txt
+          sed -i -e "s/phdi@main/phdi@${commit_hash}/g" ci_requirements.txt
+          pip install -r ci_requirements.txt
       - name: Run integration tests for containers
         working-directory: ./containers/${{matrix.directories-to-test}}/tests/integration
         run: |


### PR DESCRIPTION
# PULL REQUEST

## Summary
When running tests in CI, install from `@{current_commit}` instead of `main`. 

## Related Issue
This fixes an issue where a breaking SDK change for the containers is only discovered after merge to `main`. For instance:

1. An SDK change is made; integration tests pass locally and on CI (because they're installing PHDI from `@main`)
2. The SDK PR is merged into `main`
3. Container integration tests run and fail, because `main@phdi` now contains breaking changes.

## Additional Information
This will only affect integration tests running in CI - local tests will still install from `@main`. (Warning here in case of future "it works on my machine")

CI before:
![Screenshot 2023-10-17 at 4 44 28 PM](https://github.com/CDCgov/phdi/assets/80282552/7ecaf6d9-c811-4cc8-8bcb-b91168aab750)

CI after:
![Screenshot 2023-10-17 at 4 43 36 PM](https://github.com/CDCgov/phdi/assets/80282552/776ee511-6091-474a-bd08-e30059326b29)


## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
