### PR TITLE
Threshold log odds weights

### DIFF
--- a/phdi/linkage/link.py
+++ b/phdi/linkage/link.py
@@ -1212,7 +1212,7 @@ def _compare_name_elements(
     """
     idx = col_to_idx[feature_col]
     feature_comp = feature_funcs[feature_col](
-        [record[idx][0]],
+        [" ".join(record[idx])],
         [mpi_patient[idx]],
         feature_col,
         {feature_col: 0},

--- a/phdi/linkage/link.py
+++ b/phdi/linkage/link.py
@@ -503,6 +503,9 @@ def feature_match_log_odds_fuzzy_compare(
     """
     if "log_odds" not in kwargs:
         raise KeyError("Mapping of columns to m/u log-odds must be provided.")
+    threshold = 0.7
+    if "threshold" in kwargs:
+        threshold = kwargs["threshold"]
     col_odds = kwargs["log_odds"][feature_col]
     idx = col_to_idx[feature_col]
 
@@ -512,6 +515,8 @@ def feature_match_log_odds_fuzzy_compare(
         record_j[idx] = datetime_to_str(record_j[idx])
 
     score = compare_strings(record_i[idx], record_j[idx], "JaroWinkler")
+    if score < threshold:
+        score = 0.0
     return score * col_odds
 
 

--- a/tests/linkage/test_linkage.py
+++ b/tests/linkage/test_linkage.py
@@ -664,7 +664,7 @@ def test_feature_match_log_odds_fuzzy():
             ),
             3,
         )
-        == 0.987
+        == 0.0
     )
 
 

--- a/tests/linkage/test_linkage.py
+++ b/tests/linkage/test_linkage.py
@@ -626,7 +626,7 @@ def test_feature_match_log_odds_fuzzy():
     assert "Mapping of columns to m/u log-odds must be provided" in str(e.value)
 
     ri = ["John", "Shepard", date(1980, 11, 7), "1234 Silversun Strip"]
-    rj = ["John", "Sheperd", datetime(2000, 6, 8), "asdfghjeki"]
+    rj = ["John", "Sheperd", datetime(1970, 6, 7), "asdfghjeki"]
     col_to_idx = {"first": 0, "last": 1, "birthdate": 2, "address": 3}
     log_odds = {"first": 4.0, "last": 6.5, "birthdate": 9.8, "address": 3.7}
 
@@ -654,7 +654,7 @@ def test_feature_match_log_odds_fuzzy():
             ),
             3,
         )
-        == 5.063
+        == 7.859
     )
 
     assert (


### PR DESCRIPTION
This PR makes a small improvement correction to the way we handle log odds computations. Previously, when we fuzzy matched, we just multiplied the string similarity by the log-odds weights for that field's score contribution. However, this allowed the edge case behavior that two records which are fairly dissimilar but have all fields present can, over the course of four or five fields, still accumulate a meaningfully positive log-odds score. This behavior isn't desirable because it makes our cutoff not something that's a true separation boundary. This PR gates the similarity score behind a fuzzy match threshold: only if the field comparison has an actually similar value does the weight get added.