### PR TITLE
Update Message Parser to return data types other than strings

### DIFF
--- a/containers/message-parser/tests/test_parse_message_endpoint.py
+++ b/containers/message-parser/tests/test_parse_message_endpoint.py
@@ -98,8 +98,8 @@ expected_successful_response_floats = {
     "parsed_values": {
         "first_name": "John ",
         "last_name": "doe",
-        "latitude": "34.58002",
-        "longitude": "-118.08925",
+        "latitude": 34.58002,
+        "longitude": -118.08925,
         "active_problems": [],
     },
 }
@@ -123,7 +123,7 @@ expected_successful_response_floats_with_meta_data = {
             "resource_type": "Patient",
         },
         "latitude": {
-            "value": "34.58002",
+            "value": 34.58002,
             "fhir_path": "Bundle.entry.resource.where(resourceType = 'Patient').address"
             + ".extension"
             + ".where(url='http://hl7.org/fhir/StructureDefinition/geolocation')"
@@ -132,7 +132,7 @@ expected_successful_response_floats_with_meta_data = {
             "resource_type": "Patient",
         },
         "longitude": {
-            "value": "-118.08925",
+            "value": -118.08925,
             "fhir_path": "Bundle.entry.resource.where(resourceType = 'Patient').address"
             + ".extension"
             + ".where(url='http://hl7.org/fhir/StructureDefinition/geolocation')"


### PR DESCRIPTION
# PULL REQUEST

## Summary
Updates the message parser to be able to return data types other than strings. Currently just converts all data to strings. This refactors out a helper function that returns data without transformation for values of length 1, otherwise joins them in a comma separated string.

## Related Issue
Fixes https://app.zenhub.com/workspaces/skylight-dibbs-viper-6480ba23b5a07644e0e46d23/issues/gh/cdcgov/phdi-azure/306

