### PR TITLE
Update given name conversion to list of strings

### DIFF
--- a/phdi/linkage/seed.py
+++ b/phdi/linkage/seed.py
@@ -12,12 +12,11 @@ def extract_given_name(data: Dict):
 
     for name in [first_name, middle_name]:
         if name is not None:
-            given_names.append(" ".join(n for n in name.split()))
+            for n in name.split():
+                given_names.append(n)
 
-    given_name = " ".join(name for name in given_names)
-
-    if given_name != "":
-        return given_name
+    if len(given_names) > 0:
+        return given_names
     else:
         return None
 
@@ -36,12 +35,13 @@ def adjust_birthdate(data: Dict):
 def convert_to_patient_fhir_resources(data: Dict) -> Tuple:
     """
     Converts and returns a row of patient data into patient resource in a FHIR-formatted
-    patient resouce with a newly generated patient id as well as the `iris_id`.
+    patient resouce with a newly generated patient id as well as the
+    `external_person_id`.
 
     :param data: Dictionary of patient data that optionionally includes the following
       fields: mrn, ssn, first_name, middle_name, last_name, home_phone, cell-phone, sex,
       birthdate, address, city, state, zip.
-    :return: Tuple of the `iris_id` and FHIR-formatted patient resource.
+    :return: Tuple of the `external_person_id` and FHIR-formatted patient resource.
     """
 
     patient_id = str(uuid.uuid4())
@@ -119,5 +119,5 @@ def convert_to_patient_fhir_resources(data: Dict) -> Tuple:
         ],
     }
 
-    iris_id = data.get("person_id", None)
-    return (iris_id, fhir_bundle)
+    external_person_id = data.get("person_id", None)
+    return (external_person_id, fhir_bundle)

--- a/tests/linkage/test_seed.py
+++ b/tests/linkage/test_seed.py
@@ -56,12 +56,12 @@ def test_extract_given_name():
     # test all non-null values are included
     data = {"first_name": "John", "middle_name": "Jacob Jingleheimer"}
     given_name = extract_given_name(data)
-    assert given_name == "John Jacob Jingleheimer"
+    assert given_name == ["John", "Jacob", "Jingleheimer"]
 
     # test null values are excluded
     data = {"first_name": "John", "middle_name": None}
     given_name = extract_given_name(data)
-    assert given_name == "John"
+    assert given_name == ["John"]
 
     # test full null values return null
     data = {"first_name": None, "middle_name": None}


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR updates the `extract_given_name` function to extract given names in a FHIR-compatible manner, i.e., given names are returned as lists of strings `['John', 'Jacob']` not strings `'John Jacob'`. 

## Related Issue
Fixes #

## Additional Information
Anything else the review team should know?

## Checklist

- [x] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
