### PR TITLE
Update download_object() method to return bytes if encoding is set to None

### DIFF
--- a/phdi/cloud/azure.py
+++ b/phdi/cloud/azure.py
@@ -6,7 +6,7 @@ from azure.keyvault.secrets import SecretClient
 from azure.identity import DefaultAzureCredential
 from azure.storage.blob import ContainerClient, BlobServiceClient
 from datetime import datetime, timezone
-from typing import List, Union
+from typing import List, Union, Literal
 
 
 class AzureCredentialManager(BaseCredentialManager):
@@ -138,25 +138,29 @@ class AzureCloudContainerConnection(BaseCloudStorageConnection):
         return ContainerClient.from_container_url(container_url, credential=creds)
 
     def download_object(
-        self, container_name: str, filename: str, encoding: str = "UTF-8"
+        self,
+        container_name: str,
+        filename: str,
+        encoding: Literal[None, str] = "UTF-8",
     ) -> str:
         """
-        Downloads a character blob from storage and returns it as a string.
+        Downloads a blob from storage and returns it as a string or bytes.
 
         :param container_name: The name of the container containing object to download.
         :param filename: The location of the file within Azure blob storage.
-        :param encoding: The encoding applied to the downloaded content. Default: UTF-8
+        :param encoding: The encoding applied to the downloaded content. If set to None 
+            then the blob contents will be returned as bytes. Default: UTF-8
         :return: A character blob as a string from the given container and filename.
         """
         container_location = f"{self.storage_account_url}/{container_name}"
         container_client = self._get_container_client(container_location)
         blob_client = container_client.get_blob_client(filename)
 
-        downloader = blob_client.download_blob()
+        downloader = blob_client.download_blob(encoding=encoding)
 
-        downloaded_text = downloader.content_as_text(encoding=encoding)
+        blob_contents = downloader.readall()
 
-        return downloaded_text
+        return blob_contents
 
     def upload_object(
         self,

--- a/phdi/cloud/azure.py
+++ b/phdi/cloud/azure.py
@@ -148,7 +148,7 @@ class AzureCloudContainerConnection(BaseCloudStorageConnection):
 
         :param container_name: The name of the container containing object to download.
         :param filename: The location of the file within Azure blob storage.
-        :param encoding: The encoding applied to the downloaded content. If set to None 
+        :param encoding: The encoding applied to the downloaded content. If set to None
             then the blob contents will be returned as bytes. Default: UTF-8
         :return: A character blob as a string from the given container and filename.
         """

--- a/phdi/cloud/azure.py
+++ b/phdi/cloud/azure.py
@@ -142,7 +142,7 @@ class AzureCloudContainerConnection(BaseCloudStorageConnection):
         container_name: str,
         filename: str,
         encoding: Literal[None, str] = "UTF-8",
-    ) -> str:
+    ) -> Literal[str, bytes]:
         """
         Downloads a blob from storage and returns it as a string or bytes.
 


### PR DESCRIPTION

# PULL REQUEST

## Summary
This PR allows `AzureCloudContainerConnection.download_object()` to return blob contents as either a string when encoding is specified, or bytes when the encoding is not specified. Backwards compatibility is preserved by maintaining `UTF-8` as the default value for encoding. 

This change is necessary now in order for us to work with ZIP files in blob storage since these files cannot be directly decoded. 

Additionally we migrate to using the `readall()` method on the Azure blob client because `download_as_text` and `download_as_bytes` have been deprecated.   


## Checklist

- [x] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
