### PR TITLE
Adding harmonization datetime function to fhir-converter container

### DIFF
--- a/containers/fhir-converter/Dockerfile
+++ b/containers/fhir-converter/Dockerfile
@@ -4,10 +4,10 @@ FROM mcr.microsoft.com/dotnet/sdk:3.1 as build
 RUN git clone https://github.com/microsoft/FHIR-Converter.git --branch v5.0.4 --single-branch /build/FHIR-Converter
 WORKDIR /build/FHIR-Converter
 RUN echo test > src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/TestData/DecompressedFiles/VXU_V04.liquid
-RUN rm src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/TestData/DecompressedFiles/.wh.VXU_V04.liquid
+RUN if [ -f src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/TestData/DecompressedFiles/.wh.VXU_V04.liquid ]; then rm src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/TestData/DecompressedFiles/.wh.VXU_V04.liquid; fi
 RUN mkdir bin && \
-    wget https://github.com/deislabs/oras/releases/download/v0.12.0/oras_0.12.0_windows_amd64.tar.gz -O ./bin/oras.tar.gz && \
-    tar -xvf ./bin/oras.tar.gz -C ./bin
+  wget https://github.com/deislabs/oras/releases/download/v0.12.0/oras_0.12.0_windows_amd64.tar.gz -O ./bin/oras.tar.gz && \
+  tar -xvf ./bin/oras.tar.gz -C ./bin
 
 # Build Microsoft FHIR Converter
 RUN dotnet build -c Release -o output

--- a/containers/fhir-converter/app/service.py
+++ b/containers/fhir-converter/app/service.py
@@ -3,6 +3,8 @@ import subprocess
 import json
 import uuid
 
+from phdi.harmonization import standardize_hl7_datetimes
+
 
 def add_data_source_to_bundle(bundle: dict, data_source: str) -> dict:
     """
@@ -66,6 +68,7 @@ def convert_to_fhir(
     )
     if input_type == "elr" or input_type == "vxu":
         template_directory_path = "/build/FHIR-Converter/data/Templates/Hl7v2"
+        input_data = standardize_hl7_datetimes(input_data)
     elif input_type == "ecr":
         template_directory_path = "/build/FHIR-Converter/data/Templates/eCR"
     else:


### PR DESCRIPTION
# PULL REQUEST

## Summary
Ensure that the harmonization datetime function is being called in the `fhir-converter` container. This is specifically designed for HL7v2 message types. Since we're setting templates to HL7v2 for all requests using `input_type` equal to either `"elr"` or `"vxu"`, we're going to also run the datetime function from harmonization to clean up dates for message segments that dates are supposed to be located. I also added logic in the Dockerfile to safely remove a file so that the container is able to build on Linux.

## Related Issue
Fixes #928

## Additional Information
Tested locally with ELRs structured similarly to those failing for LAC

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
