### PR TITLE
[bug fix] fix eCR zip file requiring xml to be in a folder

### DIFF
--- a/containers/orchestration/app/utils.py
+++ b/containers/orchestration/app/utils.py
@@ -52,9 +52,7 @@ def unzip_ws(zipped_file) -> Dict:
 
 def unzip_http(zipped_file) -> Dict:
     my_zipfile = ZipFile(zipped_file.file)
-    file_to_open = [file for file in my_zipfile.namelist() if "CDA_eICR.xml" in file][
-        0
-    ]
+    file_to_open = [file for file in my_zipfile.namelist() if "CDA_eICR.xml" in file][0]
     f = my_zipfile.open(file_to_open)
     return f.read().decode("utf-8")
 

--- a/containers/orchestration/app/utils.py
+++ b/containers/orchestration/app/utils.py
@@ -44,7 +44,7 @@ def unzip_ws(zipped_file) -> Dict:
     my_zipfile = zipped_file
     if my_zipfile.namelist:
         file_to_open = [
-            file for file in my_zipfile.namelist() if "/CDA_eICR.xml" in file
+            file for file in my_zipfile.namelist() if "CDA_eICR.xml" in file
         ][0]
     f = my_zipfile.open(file_to_open)
     return f.read().decode("utf-8")
@@ -52,7 +52,7 @@ def unzip_ws(zipped_file) -> Dict:
 
 def unzip_http(zipped_file) -> Dict:
     my_zipfile = ZipFile(zipped_file.file)
-    file_to_open = [file for file in my_zipfile.namelist() if "/CDA_eICR.xml" in file][
+    file_to_open = [file for file in my_zipfile.namelist() if "CDA_eICR.xml" in file][
         0
     ]
     f = my_zipfile.open(file_to_open)


### PR DESCRIPTION
# PULL REQUEST

## Summary
Fix issue where the zip file has to contain a folder containing the files
current acceptable structure
```
.zip
|_folder
  |_ CDA_RR.xml
  |_ CDA_eICR.xml
```

this change will also accept the following structure
```
.zip
|_ CDA_RR.xml
|_ CDA_eICR.xml
```

## Related Issue
orchestration app crashes when uploaded zip file has the following structure
```
.zip
|_ CDA_RR.xml
|_ CDA_eICR.xml
```

## Additional Information
Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
