### PR TITLE
Check to see if container is running & if image exists before building in local-dev.sh

### DIFF
--- a/containers/orchestration/local-dev.sh
+++ b/containers/orchestration/local-dev.sh
@@ -7,7 +7,7 @@ elif docker ps -a | grep -q "validation"; then
 else
     echo "validation Container does not exist, building and running..."
     # Build and run your Docker container here
-    docker build --no-cache -t validation ../validation/ls
+    docker build --no-cache -t validation ../validation/
     docker run -d -p 8081:8080 validation
 fi
 

--- a/containers/orchestration/local-dev.sh
+++ b/containers/orchestration/local-dev.sh
@@ -1,16 +1,22 @@
 # Validation
-if docker ps -a | grep -q "validation"; then
-    echo "validation Container exists, skipping build and run"
+if docker ps | grep -q "validation"; then
+    echo "Validation Container already running; skipping build and run"
+elif docker ps -a | grep -q "validation"; then
+    echo "Validation Container already built; running..."
+    docker run -d -p 8081:8080 validation
 else
     echo "validation Container does not exist, building and running..."
     # Build and run your Docker container here
-    docker build --no-cache -t validation ../validation/
+    docker build --no-cache -t validation ../validation/ls
     docker run -d -p 8081:8080 validation
 fi
 
 # FHIR Converter
-if docker ps -a | grep -q "fhir-converter"; then
-    echo "fhir-converter Container exists, skipping build and run"
+if docker ps | grep -q "fhir-converter"; then
+    echo "fhir-converter Container already running; skipping build and run"
+elif docker ps -a | grep -q "fhir-converter"; then
+    echo "fhir-converter Container already built; running..."
+    docker run -d -p 8082:8080 fhir-converter
 else
     echo "fhir-converter Container does not exist, building and running..."
     # Build and run your Docker container here
@@ -19,8 +25,12 @@ else
 fi
 
 
-if docker ps -a | grep -q "message-parser"; then
-    echo " message-parser Container exists, skipping build and run"
+# Message Parser
+if docker ps | grep -q "message-parser"; then
+    echo "message-parser Container already running; skipping build and run"
+elif docker ps -a | grep -q "message-parser"; then
+    echo "message-parser Container already built; running..."
+    docker run -d -p 8085:8080 message-parser
 else
     echo "message-parser Container does not exist, building and running..."
     # Build and run your Docker container here
@@ -29,8 +39,11 @@ else
 fi
 
 # Ingestion
-if docker ps -a | grep -q "ingestion"; then
-    echo " ingestion Container exists, skipping build and run"
+if docker ps | grep -q "ingestion"; then
+    echo "ingestion Container already running; skipping build and run"
+elif docker ps -a | grep -q "ingestion"; then
+    echo "ingestion Container already built; running..."
+    docker run -d -p 8083:8080 ingestion
 else
     echo "ingestion Container does not exist, building and running..."
     # Build and run your Docker container here


### PR DESCRIPTION
# PULL REQUEST

## Summary
Tweaks to the local-dev version of the orchestration service - will now check to see if the container is running, then if the image is built, and either just run the service or build/run as a result.

## Related Issue
No related issue; just something I kept hitting locally (I'd have images laying around so it wouldn't run the containers under the old version)

## Additional Information
Should hopefully be a non-breaking change, but lmk if there are issues! 

[//]: # (PR title: Remember to name your PR descriptively!)
