### PR TITLE
Improve Base Query Performance

### DIFF
--- a/phdi/linkage/__init__.py
+++ b/phdi/linkage/__init__.py
@@ -24,6 +24,7 @@ from phdi.linkage.link import (
     read_linkage_config,
     link_record_against_mpi,
     add_person_resource,
+    aggregate_given_names_for_linkage,
 )
 
 from phdi.linkage.core import BaseMPIConnectorClient
@@ -64,4 +65,5 @@ __all__ = [
     "convert_to_patient_fhir_resources",
     "DIBBsMPIConnectorClient",
     "datetime_to_str",
+    "aggregate_given_names_for_linkage",
 ]

--- a/phdi/linkage/mpi.py
+++ b/phdi/linkage/mpi.py
@@ -1,6 +1,5 @@
 from typing import List, Dict, Literal
-from sqlalchemy import Select, and_, func, literal_column, select, text
-from sqlalchemy.dialects.postgresql import aggregate_order_by
+from sqlalchemy import Select, and_, select, text
 from phdi.linkage.core import BaseMPIConnectorClient
 from phdi.linkage.utils import load_mpi_env_vars_os
 from phdi.linkage.dal import DataAccessLayer

--- a/phdi/linkage/mpi.py
+++ b/phdi/linkage/mpi.py
@@ -395,20 +395,6 @@ class DIBBsMPIConnectorClient(BaseMPIConnectorClient):
         :return: A single select statement queries all relevant
             blocking columns and tables from the MPI.
         """
-        given_name_subquery = (
-            select(
-                self.dal.GIVEN_NAME_TABLE.c.name_id.label("name_id"),
-                func.string_agg(
-                    self.dal.GIVEN_NAME_TABLE.c.given_name,
-                    aggregate_order_by(
-                        literal_column("' '"),
-                        self.dal.GIVEN_NAME_TABLE.c.given_name_index,
-                    ),
-                ).label("given_names"),
-            )
-            .group_by(self.dal.GIVEN_NAME_TABLE.c.name_id)
-            .subquery("gname_subq")
-        )
 
         id_sub_query = (
             select(
@@ -441,7 +427,9 @@ class DIBBsMPIConnectorClient(BaseMPIConnectorClient):
                 self.dal.PATIENT_TABLE.c.sex,
                 id_sub_query.c.mrn,
                 self.dal.NAME_TABLE.c.last_name,
-                given_name_subquery.c.given_names.label("first_name"),
+                self.dal.GIVEN_NAME_TABLE.c.given_name,
+                self.dal.GIVEN_NAME_TABLE.c.given_name_index,
+                self.dal.GIVEN_NAME_TABLE.c.name_id,
                 # TODO: keeping this here for the time
                 # when we decide to add phone numbers into
                 # the blocking data
@@ -457,7 +445,7 @@ class DIBBsMPIConnectorClient(BaseMPIConnectorClient):
                 id_sub_query,
             )
             .outerjoin(self.dal.NAME_TABLE)
-            .outerjoin(given_name_subquery)
+            .outerjoin(self.dal.GIVEN_NAME_TABLE)
             # TODO: keeping this here for the time
             # when we decide to add phone numbers into
             # the blocking data

--- a/tests/linkage/test_mpi.py
+++ b/tests/linkage/test_mpi.py
@@ -188,11 +188,11 @@ def test_get_base_query():
               identifier.patient_id AS patient_id
         FROM
           identifier
-        WHERE 
-          identifier.type_code = :type_code_1) AS ident_subq 
-          ON patient.patient_id = ident_subq.patient_id 
-          LEFT OUTER JOIN name ON patient.patient_id = name.patient_id 
-          LEFT OUTER JOIN given_name ON name.name_id = given_name.name_id 
+        WHERE
+          identifier.type_code = :type_code_1) AS ident_subq
+          ON patient.patient_id = ident_subq.patient_id
+          LEFT OUTER JOIN name ON patient.patient_id = name.patient_id
+          LEFT OUTER JOIN given_name ON name.name_id = given_name.name_id
           LEFT OUTER JOIN address ON patient.patient_id = address.patient_id
         """
     assert base_query is not None

--- a/tests/linkage/test_mpi.py
+++ b/tests/linkage/test_mpi.py
@@ -174,19 +174,23 @@ def test_block_data_failures():
 def test_get_base_query():
     MPI: DIBBsMPIConnectorClient = _init_db()
     base_query = MPI._get_base_query()
-    expected_query = """ 
-        SELECT 
-          patient.patient_id, patient.person_id, patient.dob AS birthdate, 
-          patient.sex, ident_subq.mrn, name.last_name, given_name.given_name, 
-          given_name.given_name_index, given_name.name_id, address.line_1 AS address, 
+    expected_query = """
+        SELECT
+          patient.patient_id, patient.person_id, patient.dob AS birthdate,
+          patient.sex, ident_subq.mrn, name.last_name, given_name.given_name,
+          given_name.given_name_index, given_name.name_id, address.line_1 AS address,
           address.zip_code AS zip, address.city, address.state
-        FROM 
-          patient 
-          LEFT OUTER JOIN (SELECT identifier.patient_identifier AS mrn, identifier.patient_id AS patient_id
-        FROM 
+        FROM
+          patient
+          LEFT OUTER JOIN (
+            SELECT
+              identifier.patient_identifier AS mrn,
+              identifier.patient_id AS patient_id
+        FROM
           identifier
         WHERE 
-          identifier.type_code = :type_code_1) AS ident_subq ON patient.patient_id = ident_subq.patient_id 
+          identifier.type_code = :type_code_1) AS ident_subq 
+          ON patient.patient_id = ident_subq.patient_id 
           LEFT OUTER JOIN name ON patient.patient_id = name.patient_id 
           LEFT OUTER JOIN given_name ON name.name_id = given_name.name_id 
           LEFT OUTER JOIN address ON patient.patient_id = address.patient_id

--- a/tests/linkage/test_mpi.py
+++ b/tests/linkage/test_mpi.py
@@ -115,7 +115,7 @@ def test_get_blocked_data():
     assert blocked_data[0][1] == "person_id"
     assert blocked_data[1][2].strftime("%Y-%m-%d") == "1977-11-11"
     assert blocked_data[0][2] == "birthdate"
-    assert len(blocked_data[0]) == 11
+    assert len(blocked_data[0]) == 13
 
 
 def test_block_data_failures():
@@ -168,30 +168,29 @@ def test_block_data_failures():
     assert blocked_data[0][1] == "person_id"
     assert blocked_data[1][2].strftime("%Y-%m-%d") == "1977-11-11"
     assert blocked_data[0][2] == "birthdate"
-    assert len(blocked_data[0]) == 11
+    assert len(blocked_data[0]) == 13
 
 
 def test_get_base_query():
     MPI: DIBBsMPIConnectorClient = _init_db()
     base_query = MPI._get_base_query()
-    expected_query = (
-        "SELECT patient.patient_id, patient.person_id, patient.dob AS"
-        + " birthdate, patient.sex, ident_subq.mrn, name.last_name, "
-        + "gname_subq.given_names AS first_name, address.line_1 AS "
-        + "address, address.zip_code AS zip, address.city, address.state"
-        + "FROM patient LEFT OUTER JOIN (SELECT identifier.patient_identifier AS mrn,"
-        + " identifier.patient_id AS patient_id"
-        + "FROM identifier"
-        + "WHERE identifier.type_code = :type_code_1) AS ident_subq ON "
-        + "patient.patient_id"
-        + " = ident_subq.patient_id LEFT OUTER JOIN name ON patient.patient_id = "
-        + "name.patient_id LEFT OUTER JOIN (SELECT given_name.name_id AS name_id, "
-        + "string_agg(given_name.given_name, ' ' ORDER BY given_name.given_name_index)"
-        + " AS given_names"
-        + " FROM given_name GROUP BY given_name.name_id) AS gname_subq ON name.name_id "
-        + "= gname_subq.name_id LEFT OUTER JOIN address ON patient.patient_id = "
-        + "address.patient_id"
-    )
+    expected_query = """ 
+        SELECT 
+          patient.patient_id, patient.person_id, patient.dob AS birthdate, 
+          patient.sex, ident_subq.mrn, name.last_name, given_name.given_name, 
+          given_name.given_name_index, given_name.name_id, address.line_1 AS address, 
+          address.zip_code AS zip, address.city, address.state
+        FROM 
+          patient 
+          LEFT OUTER JOIN (SELECT identifier.patient_identifier AS mrn, identifier.patient_id AS patient_id
+        FROM 
+          identifier
+        WHERE 
+          identifier.type_code = :type_code_1) AS ident_subq ON patient.patient_id = ident_subq.patient_id 
+          LEFT OUTER JOIN name ON patient.patient_id = name.patient_id 
+          LEFT OUTER JOIN given_name ON name.name_id = given_name.name_id 
+          LEFT OUTER JOIN address ON patient.patient_id = address.patient_id
+        """
     assert base_query is not None
     assert isinstance(base_query, Select)
     _clean_up(MPI.dal)
@@ -461,14 +460,14 @@ def test_block_data_with_transform():
     _clean_up(MPI.dal)
 
     # ensure blocked data has two rows, headers and data
-    assert len(blocked_data) == 2
+    assert len(blocked_data) == 3
     assert blocked_data[1][1] is None
     assert blocked_data[1][0] == pks_pt[0]
     assert blocked_data[1][0] != pks_pt2[0]
     assert blocked_data[1][2] == datetime.date(1983, 2, 1)
     assert blocked_data[1][3] == "male"
-    assert blocked_data[1][7] == add1[0].get("line_1")
-    assert blocked_data[1][8] == add1[0].get("zip_code")
+    assert blocked_data[2][9] == add1[0].get("line_1")
+    assert blocked_data[2][10] == add1[0].get("zip_code")
 
 
 def test_generate_dict_record_from_results():


### PR DESCRIPTION
# PULL REQUEST

## Summary
Remove the aggregate in the subquery for `_get_base_query` to improve performance; at the same time modify record linkage to accept this new data structure. Fix tests based on these updates.

## Related Issue
Fixes #362 #363 
