### PR TITLE
Adding DOB standardization functions and tests to Standardization container

### DIFF
--- a/containers/standardization/app/utils.py
+++ b/containers/standardization/app/utils.py
@@ -1,10 +1,100 @@
+import copy
 import json
 import pathlib
-from typing import Literal, List, Union
+from datetime import datetime
+from typing import Dict, Callable, Literal, List, Optional, Union
+
+from detect_delimiter import detect
+from fhirpathpy import evaluate as fhirpath_evaluate
+
+
+FHIR_DATE_FORMAT = "%Y-%m-%d"
+FHIR_DATE_DELIM = "-"
 
 
 def read_json_from_assets(filename: str):
     return json.load(open((pathlib.Path(__file__).parent.parent / "assets" / filename)))
+
+
+def is_fhir_bundle(bundle) -> bool:
+    """
+    Check if the given data is a valid FHIR bundle.
+
+    :param bundle: The data to check.
+    :return: True if it's a FHIR bundle, False otherwise.
+    """
+    if not isinstance(bundle, dict):
+        return False
+
+    if bundle.get("resourceType") != "Bundle":
+        return False
+
+    entries = bundle.get("entry", [])
+    if not isinstance(entries, list) or not all(
+        "resource" in entry for entry in entries
+    ):
+        return False
+
+    return True
+
+
+def is_patient_resource(resource) -> bool:
+    """
+    Check if the given data is a valid FHIR patient resource.
+
+    :param resource: The data to check.
+    :return: True if it's a Patient resource, False otherwise.
+    """
+    return isinstance(resource, dict) and resource.get("resourceType") == "Patient"
+
+
+def apply_function_to_fhirpath(bundle: Dict, fhirpath: str, function: Callable) -> Dict:
+    """
+    Applies a given function to elements in a FHIR bundle identified by a FHIRPath expression.
+
+    :param bundle: A FHIR bundle.
+    :param fhirpath: A FHIRPath expression to select elements in the resource.
+    :param function: A function to be applied to each selected element.
+    :return: The modified resource or bundle.
+    """
+    if not is_fhir_bundle(bundle):
+        raise ValueError("The provided :param bundle is not a valid FHIR bundle.")
+
+    elements = fhirpath_evaluate(bundle, fhirpath)
+
+    for element in elements:
+        # apply the function to each element
+        function(element)
+
+    return bundle
+
+
+# TODO: function not working as expected; find out it's within scope to
+# refactor this and replace the dependancy on detect_delimiter.detect
+# since it hasn't been updated since 2018
+def detect_delimiter(text: str) -> Optional[str]:
+    """
+    Detects the delimiter used in text formats such as CSV and its variants.
+
+    This is a simplified version of the detect_delimiter.detect function that
+    checks for common delimiters and returns the one that evenly splits the text
+    into fields across multiple lines. If no delimiter is found, it returns None.
+    """
+    candidates = list(",;:|/\t")
+    lines = text.splitlines()
+    likely_candidates = []
+
+    for c in candidates:
+        fields_for_candidate = [len(line.split(c)) for line in lines]
+
+        # check if all lines have the same number of fields when split by the candidate
+        if fields_for_candidate and all(
+            n == fields_for_candidate[0] for n in fields_for_candidate
+        ):
+            likely_candidates.append(c)
+
+    # return the first likely candidate if found, else None
+    return likely_candidates[0] if likely_candidates else None
 
 
 def standardize_name(
@@ -60,3 +150,139 @@ def standardize_name(
     if isinstance(raw_name, str):
         return outputs[0]
     return outputs
+
+
+def _validate_date(year: str, month: str, day: str, future: bool = False) -> bool:
+    """
+    Validates that a date supplied, split out by the different date components
+        is a valid date (ie. not 02-30-2000 or 12-32-2000). This function can
+        also verify that the date supplied is not greater than now
+
+    :param raw_date: One date in string format to standardize.
+    :param existing_format: A python DateTime format used to parse the date
+        supplied.  Default: `%Y-%m-%d` (YYYY-MM-DD).
+    :param new_format: A python DateTime format used to convert the date
+        supplied into.  Default: `%Y-%m-%d` (YYYY-MM-DD).
+    :return: A date as a string in the format supplied by new_format.
+    """
+    is_valid_date = True
+    try:
+        valid_date = datetime(int(year), int(month), int(day))
+        if future and valid_date > datetime.now():
+            is_valid_date = False
+    except ValueError:
+        is_valid_date = False
+
+    return is_valid_date
+
+
+def _standardize_date(
+    raw_date: str, date_format: str = FHIR_DATE_FORMAT, future: bool = False
+) -> str:
+    """
+    Validates a date string is a proper date and then standardizes the
+    date string into the FHIR Date Standard (YYYY-MM-DD)
+
+    :param raw_date: A date string to standardize.
+    :param date_format: A python Date format used to parse and order
+        the date components from the date string.
+        Default: `%Y-%m-%d` (YYYY-MM-DD).
+    :param future: A boolean that if True will verify that the date
+        supplied is not in the future.
+        Default: False
+    :return: A date as a string in the FHIR Date Format.
+    """
+    # delim = detect_delimiter(raw_date)
+    # format_delim = detect_delimiter(date_format.replace("%", ""))
+    delim = detect(raw_date)
+    format_delim = detect(date_format.replace("%", ""))
+
+    # parse out the different date components (year, month, day)
+    date_values = raw_date.split(delim)
+    format_values = date_format.replace("%", "").lower().split(format_delim)
+    date_dict = {}
+
+    # loop through date values and the format values
+    #   and create a date dictionary where the format is the key
+    #   and the date values are the value ordering the date component values
+    #   using the date format supplied
+    for format_value, date_value in zip(format_values, date_values):
+        date_dict[format_value[0]] = date_value
+
+    # check that all the necessary date components are present within the date_dict
+    if not all(key in date_dict for key in ["y", "m", "d"]):
+        raise ValueError(
+            f"Invalid date format or missing components in date: {raw_date}"
+        )
+
+    # verify that the date components in the date dictionary create a valid
+    # date and based upon the future param that the date is not in the future
+    if not _validate_date(date_dict["y"], date_dict["m"], date_dict["d"], future):
+        raise ValueError(f"Invalid date format supplied: {raw_date}")
+
+    return (
+        date_dict["y"]
+        + FHIR_DATE_DELIM
+        + date_dict["m"]
+        + FHIR_DATE_DELIM
+        + date_dict["d"]
+    )
+
+
+def standardize_dob(raw_dob: str, existing_format: str = FHIR_DATE_FORMAT) -> str:
+    """
+    Validates and standardizes a date of birth string into YYYY-MM-DD format.
+
+    :param raw_dob: One date of birth (dob) to standardize.
+    :param existing_format: A python DateTime format used to parse the date of
+        birth within the Patient resource.  Default: `%Y-%m-%d` (YYYY-MM-DD).
+    :return: Date of birth as a string in YYYY-MM-DD format
+        or None if date of birth is invalid.
+    """
+
+    #  Need to make sure dob is not None or null ("")
+    #  or detect() will end up in an infinite loop
+    if raw_dob is None or len(raw_dob) == 0:
+        raise ValueError("Date of Birth must be supplied!")
+
+    standardized_dob = _standardize_date(
+        raw_date=raw_dob, date_format=existing_format, future=True
+    )
+
+    return standardized_dob
+
+
+def standardize_dob_fhir(
+    data: Dict, date_format: str = "%Y-%m-%d", overwrite: bool = True
+) -> Dict:
+    """
+    Standardizes all birth dates in a given FHIR bundle or a FHIR patient resource.
+    Standardization is done according to the 'standardize_dob' function.
+    The final birthDate will follow the FHIR STu3/R4 format of YYYY-MM-DD.
+
+    :param data: A FHIR bundle or FHIR patient resource.
+    :param date_format: A python DateTime format used to parse the birthDate.
+                        Default: '%Y-%m-%d' (YYYY-MM-DD).
+    :param overwrite: If true, `data` is modified in-place;
+                      if false, a copy of `data` is modified and returned.
+                      Default: True.
+    :return: The modified bundle or patient resource.
+    """
+
+    if not overwrite:
+        data = copy.deepcopy(data)
+
+    if is_fhir_bundle(data):
+        fhirpath = "Bundle.entry.resource.where(resourceType='Patient').birthDate"
+    elif is_patient_resource(data):
+        fhirpath = "Patient.birthDate"
+    else:
+        raise ValueError(
+            "The provided data is neither a valid FHIR Bundle nor a Patient resource."
+        )
+
+    def standardize_dob_in_element(element):
+        if "value" in element:
+            element["value"] = standardize_dob(element["value"], date_format)
+
+    return apply_function_to_fhirpath(data, fhirpath, standardize_dob_in_element)

--- a/containers/standardization/app/utils.py
+++ b/containers/standardization/app/utils.py
@@ -2,7 +2,7 @@ import copy
 import json
 import pathlib
 from datetime import datetime
-from typing import Dict, Callable, Literal, List, Optional, Union
+from typing import Dict, Callable, Literal, List, Union
 
 from detect_delimiter import detect
 from fhirpathpy import evaluate as fhirpath_evaluate
@@ -68,34 +68,6 @@ def apply_function_to_fhirpath(bundle: Dict, fhirpath: str, function: Callable) 
         function(element)
 
     return bundle
-
-
-# TODO: function not working as expected; find out it's within scope to
-# refactor this and replace the dependancy on detect_delimiter.detect
-# since it hasn't been updated since 2018
-def detect_delimiter(text: str) -> Optional[str]:
-    """
-    Detects the delimiter used in text formats such as CSV and its variants.
-
-    This is a simplified version of the detect_delimiter.detect function that
-    checks for common delimiters and returns the one that evenly splits the text
-    into fields across multiple lines. If no delimiter is found, it returns None.
-    """
-    candidates = list(",;:|/\t")
-    lines = text.splitlines()
-    likely_candidates = []
-
-    for c in candidates:
-        fields_for_candidate = [len(line.split(c)) for line in lines]
-
-        # check if all lines have the same number of fields when split by the candidate
-        if fields_for_candidate and all(
-            n == fields_for_candidate[0] for n in fields_for_candidate
-        ):
-            likely_candidates.append(c)
-
-    # return the first likely candidate if found, else None
-    return likely_candidates[0] if likely_candidates else None
 
 
 def standardize_name(
@@ -193,8 +165,6 @@ def _standardize_date(
         Default: False
     :return: A date as a string in the FHIR Date Format.
     """
-    # delim = detect_delimiter(raw_date)
-    # format_delim = detect_delimiter(date_format.replace("%", ""))
     delim = detect(raw_date)
     format_delim = detect(date_format.replace("%", ""))
 
@@ -240,7 +210,6 @@ def standardize_dob(raw_dob: str, existing_format: str = FHIR_DATE_FORMAT) -> st
     :return: Date of birth as a string in YYYY-MM-DD format
         or None if date of birth is invalid.
     """
-
     #  Need to make sure dob is not None or null ("")
     #  or detect() will end up in an infinite loop
     if raw_dob is None or len(raw_dob) == 0:
@@ -269,7 +238,6 @@ def standardize_dob_fhir(
                       Default: True.
     :return: The modified bundle or patient resource.
     """
-
     if not overwrite:
         data = copy.deepcopy(data)
 

--- a/containers/standardization/app/utils.py
+++ b/containers/standardization/app/utils.py
@@ -165,6 +165,9 @@ def _standardize_date(
         Default: False
     :return: A date as a string in the FHIR Date Format.
     """
+    # TODO: detect function from detect-delimiter hasn't been updated
+    # since 2018; might be worth replacing with a more robust library
+    # or writing our own detection function
     delim = detect(raw_date)
     format_delim = detect(date_format.replace("%", ""))
 

--- a/containers/standardization/app/utils.py
+++ b/containers/standardization/app/utils.py
@@ -50,7 +50,8 @@ def is_patient_resource(resource) -> bool:
 
 def apply_function_to_fhirpath(bundle: Dict, fhirpath: str, function: Callable) -> Dict:
     """
-    Applies a given function to elements in a FHIR bundle identified by a FHIRPath expression.
+    Applies a given function to elements in a FHIR bundle identified by a FHIRPath
+    expression.
 
     :param bundle: A FHIR bundle.
     :param fhirpath: A FHIRPath expression to select elements in the resource.

--- a/containers/standardization/tests/test_standardization.py
+++ b/containers/standardization/tests/test_standardization.py
@@ -1,9 +1,22 @@
+import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
-from app.utils import standardize_name
+from app.utils import (
+    read_json_from_assets,
+    standardize_name,
+    standardize_dob,
+    standardize_dob_fhir,
+    _standardize_date,
+    _validate_date,
+)
 
 client = TestClient(app)
+
+
+@pytest.fixture
+def single_patient_bundle():
+    return read_json_from_assets("single_patient_bundle.json")
 
 
 def test_health_check():
@@ -36,3 +49,51 @@ def test_standardize_name():
         "PAUL BUNYAN",
         "JRRTOLKIE87N 999",
     ]
+
+
+@pytest.mark.parametrize(
+    "input_date, format_string, future, expected",
+    [
+        ("1977-11-21", None, False, "1977-11-21"),
+        ("1980-01-31", None, False, "1980-01-31"),
+        ("1977/11/21", "%Y/%m/%d", False, "1977-11-21"),
+        ("1980/01/31", "%Y/%m/%d", False, "1980-01-31"),
+        ("01/1980/31", "%m/%Y/%d", False, "1980-01-31"),
+        ("11-1977-21", "%m-%Y-%d", False, "1977-11-21"),
+    ],
+)
+def test_standardize_date(input_date, format_string, future, expected):
+    if format_string:
+        assert _standardize_date(input_date, format_string, future) == expected
+    else:
+        assert _standardize_date(input_date, future=future) == expected
+
+
+def test_standardize_date_invalid():
+    with pytest.raises(ValueError) as e:
+        _standardize_date("blah")
+    assert "Invalid date format or missing components in date: blah" in str(e.value)
+
+
+def test_standardize_date_format_mismatch():
+    with pytest.raises(ValueError) as e:
+        _standardize_date("abc-def-ghi", "%Y-%m-%d")
+    assert "Invalid date format supplied:" in str(e.value)
+
+    with pytest.raises(ValueError) as e:
+        _standardize_date("1980-01-31", "%H:%M:%S")
+    assert "Invalid date format or missing components in date:" in str(e.value)
+
+
+@pytest.mark.parametrize(
+    "year, month, day, allow_future, expected",
+    [
+        ("1980", "10", "15", False, True),
+        ("3030", "10", "15", False, True),
+        ("3030", "10", "15", True, False),
+        ("2005", "15", "10", False, False),
+        ("2005", "02", "30", False, False),
+    ],
+)
+def test_validate_date(year, month, day, allow_future, expected):
+    assert _validate_date(year, month, day, allow_future) == expected

--- a/containers/standardization/tests/test_standardization.py
+++ b/containers/standardization/tests/test_standardization.py
@@ -5,8 +5,6 @@ from app.main import app
 from app.utils import (
     read_json_from_assets,
     standardize_name,
-    standardize_dob,
-    standardize_dob_fhir,
     _standardize_date,
     _validate_date,
 )


### PR DESCRIPTION
# PULL REQUEST

## Summary
Adding the date standardization functions to the Standardization container. Given that we're moving away from the SDK and adding functions to the `utils.py` script within the application files there may need to be some changes to ensure the atomic versions of SDK functions and their FHIR counterparts can be leveraged in a modular way. This PR proposes a wrapper to apply a function to a bundle using a FHIRPath.

## Related Issue
Fixes https://github.com/CDCgov/phdi-azure/issues/369

## Checklist

- [x] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
