### PR TITLE
Add standardize phone functions to standardization service

### DIFF
--- a/containers/standardization/app/utils.py
+++ b/containers/standardization/app/utils.py
@@ -1,6 +1,10 @@
+import copy
 import json
 import pathlib
 from typing import Literal, List, Union
+
+import phonenumbers
+import pycountry
 
 
 def read_json_from_assets(filename: str):
@@ -60,3 +64,195 @@ def standardize_name(
     if isinstance(raw_name, str):
         return outputs[0]
     return outputs
+
+
+def standardize_phone(
+    raw_phone: Union[str, List[str]], countries: List = [None, "US"]
+) -> Union[str, List[str]]:
+    """
+    Parses phone number(s) and generates the standardized ISO E.164 international format
+    for each given phone number as well as optional list of associated countries. If an
+    input phone number can't be parsed, that number returns an empty string. Parsing
+    uses the first successful strategy out of the following:
+
+    1. parses the phone number on its own
+    2. parses the phone number using the provided list of possible
+       associated countries
+    3. parses the phone number using the US as country
+
+    :param raw_phone: One or more raw phone number(s) to standardize.
+    :param countries: An optional list containing 2 letter ISO codes
+      associated with the phone numbers, signifying to which countries
+      the phone numbers might belong.
+    :return: Either a string or a list of strings, depending on the
+      input of raw_phone, holding the standardized phone number(s).
+    """
+
+    # Base cases: we always want to try the phone # on its own first;
+    # we also want to try the phone # with the US if all else fails
+    if None not in countries:
+        countries.insert(0, None)
+    if "US" not in countries:
+        countries.append("US")
+
+    phones_to_clean = raw_phone
+    if isinstance(raw_phone, str):
+        phones_to_clean = [raw_phone]
+    outputs = []
+
+    for phone in phones_to_clean:
+        standardized = ""
+        for country in countries:
+            # We were able to pull the phone # and corresponding country
+            try:
+                standardized = phonenumbers.parse(phone, country)
+                break
+
+            # This combo of given phone # and country isn't valid
+            except phonenumbers.phonenumberutil.NumberParseException:
+                continue
+
+        # If we got a match, format it according to ISO standards
+        if standardized != "" and phonenumbers.is_possible_number(standardized):
+            standardized = str(
+                phonenumbers.format_number(
+                    standardized, phonenumbers.PhoneNumberFormat.E164
+                )
+            )
+            outputs.append(standardized)
+        else:
+            outputs.append("")
+
+    if isinstance(raw_phone, str):
+        return outputs[0]
+    return outputs
+
+
+def standardize_country_code(
+    raw_country: str, code_type: Literal["alpha_2", "alpha_3", "numeric"] = "alpha_2"
+) -> str:
+    """
+    Identifies the country represented and generates the desired type of the ISO
+    3611 standardized country identifier for a given string representation of a country
+    (whether a full name such as "United States," or an abbreviation such as "US"
+    or "USA"). If the country identifier cannot be determined, returns None.
+
+    Example: If raw_country = "United States of America," then
+
+    * alpha_2 would be "US"
+    * alpha_3 would be "USA"
+    * numeric would be "840"
+
+    :param raw_country: The string representation of the country to be
+      put in ISO 3611 standardized form.
+    :param code_type: One of 'alpha_2', 'alpha_3', or 'numeric'; the
+      desired identifier type to generate.
+    :return: The standardized country identifier found in the resource's addresses.
+    """
+
+    # First, identify what country the input is referencing
+    standard = None
+    raw_country = raw_country.strip().upper()
+    if len(raw_country) == 2:
+        standard = pycountry.countries.get(alpha_2=raw_country)
+    elif len(raw_country) == 3:
+        standard = pycountry.countries.get(alpha_3=raw_country)
+        if standard is None:
+            standard = pycountry.countries.get(numeric=raw_country)
+    elif len(raw_country) >= 4:
+        standard = pycountry.countries.get(name=raw_country)
+        if standard is None:
+            standard = pycountry.countries.get(official_name=raw_country)
+
+    # Then, if we figured that out, convert it to desired form
+    if standard is not None:
+        if code_type == "alpha_2":
+            standard = standard.alpha_2
+        elif code_type == "alpha_3":
+            standard = standard.alpha_3
+        elif code_type == "numeric":
+            standard = standard.numeric
+
+    return standard
+
+
+def _extract_countries_from_resource(
+    resource: dict, code_type: Literal["alpha_2", "alpha_3", "numeric"] = "alpha_2"
+) -> List[str]:
+    """
+    Builds a list containing all of the countries, standardized by code_type, in the
+    addresses of a given FHIR resource as interpreted by the ISO 3611: standardized
+    country identifier. If the resource is not of a supported type, no
+    countries will be returned. Currently supported resource types are:
+
+    * Patient
+
+    :param resource: A FHIR resource or FHIR-formatted JSON dict.
+    :param code_type: A string equal to 'alpha_2', 'alpha_3', or 'numeric'
+      to specify which type of standard country identifier to generate.
+      Default: `alpha_2`
+    :return: A list of all the standardized countries found in the resource's
+      addresses.
+    """
+    countries = []
+    resource_type = resource.get("resourceType")
+    if resource_type == "Patient":
+        for address in resource.get("address"):
+            country = address.get("country")
+            if country:
+                countries.append(standardize_country_code(country, code_type))
+    return countries
+
+
+def _standardize_phones_in_resource(
+    resource: dict, overwrite=True
+) -> Union[dict, None]:
+    """
+    Standardizes all phone numbers in a FHIR-formatted Patient resource.
+
+    :param resource: A FHIR resource or FHIR-formatted JSON dict.
+    :param overwrite: If true, `data` is modified in-place;
+      if false, a copy of `data` modified and returned. Default: `True`.
+    :return: The resource with phone numbers appropriately standardized.
+    """
+    if not overwrite:
+        resource = copy.deepcopy(resource)
+
+    if resource.get("resourceType", "") == "Patient":
+        for telecom in resource.get("telecom", []):
+            if telecom.get("system") == "phone" and "value" in telecom:
+                countries = _extract_countries_from_resource(resource)
+                transformed_phone = standardize_phone(
+                    telecom.get("value", ""), countries
+                )
+                telecom["value"] = transformed_phone
+    return resource
+
+
+def standardize_phones_in_bundle(data: dict, overwrite=True) -> dict:
+    """
+    Standardizes all phone numbers in a given FHIR bundle or a FHIR resource.
+    Standardization is done according to the underlying `standardize_phone`
+    function in `phdi.harmonization`.
+
+    :param data: A FHIR bundle or FHIR-formatted JSON dict.
+    :param overwrite: If true, `data` is modified in-place;
+      if false, a copy of `data` modified and returned.  Default: `True`
+    :return: The bundle or resource with phones appropriately standardized.
+    """
+
+    if not overwrite:
+        data = copy.deepcopy(data)
+
+    # Allow users to pass in either a resource or a bundle
+    bundle = data
+    if "entry" not in data:
+        bundle = {"entry": [{"resource": data}]}
+
+    for entry in bundle.get("entry"):
+        resource = entry.get("resource", {})
+        resource = _standardize_phones_in_resource(resource, overwrite)
+
+    if "entry" not in data:
+        return bundle.get("entry", [{}])[0].get("resource", {})
+    return bundle

--- a/containers/standardization/assets/test_patient_bundle.json
+++ b/containers/standardization/assets/test_patient_bundle.json
@@ -1,0 +1,76 @@
+{
+  "resourceType": "Bundle",
+  "identifier": {
+    "value": "a very contrived FHIR bundle"
+  },
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Organization",
+        "id": "some-org-we-dont-care-about"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "some-uuid",
+        "identifier": [
+          {
+            "value": "123456",
+            "type": {
+              "coding": [
+                {
+                  "code": "MR",
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "display": "Medical record number"
+                }
+              ]
+            },
+            "system": "urn...no idea"
+          }
+        ],
+        "name": [
+          {
+            "family": "doe",
+            "given": [
+              "John ",
+              " Danger "
+            ],
+            "use": "official"
+          }
+        ],
+        "birthDate": "1983-02-01",
+        "gender": "female",
+        "address": [
+          {
+            "line": [
+              "123 Fake St",
+              "Unit #F"
+            ],
+            "BuildingNumber": "123",
+            "city": "Faketon",
+            "state": "NY",
+            "postalCode": "10001-0001",
+            "country": "USA",
+            "use": "home"
+          }
+        ],
+        "telecom": [
+          {
+            "use": "home",
+            "system": "phone",
+            "value": "123-456-7890"
+          },
+          {
+            "value": "johndanger@doe.net",
+            "system": "email"
+          }
+        ]
+      },
+      "request": {
+        "method": "GET",
+        "url": "testing for entry with no resource"
+      }
+    }
+  ]
+}

--- a/containers/standardization/tests/test_standardization.py
+++ b/containers/standardization/tests/test_standardization.py
@@ -1,7 +1,18 @@
+import copy
+import json
+import pathlib
+
 from fastapi.testclient import TestClient
 
 from app.main import app
-from app.utils import standardize_name
+from app.utils import (
+    standardize_name,
+    standardize_country_code,
+    standardize_phone,
+    standardize_phones_in_bundle,
+    _standardize_phones_in_resource,
+    _extract_countries_from_resource,
+)
 
 client = TestClient(app)
 
@@ -36,3 +47,124 @@ def test_standardize_name():
         "PAUL BUNYAN",
         "JRRTOLKIE87N 999",
     ]
+
+
+def test_standardize_country_code():
+    assert standardize_country_code("US") == "US"
+    assert standardize_country_code("USA") == "US"
+    assert standardize_country_code("United States of America") == "US"
+    assert standardize_country_code("United states ") == "US"
+    assert standardize_country_code("US", "alpha_3") == "USA"
+    assert standardize_country_code("USA", "numeric") == "840"
+
+    # Edge case testing: nonsense code and empty string
+    assert standardize_country_code("zzz") is None
+    assert standardize_country_code("") is None
+
+
+def test_standardize_phone():
+    # Working examples of "real" numbers
+    assert standardize_phone("555-654-9876") == "+15556549876"
+    assert standardize_phone("555 654 9876") == "+15556549876"
+    # Now supply country information
+    assert standardize_phone("123.234.6789", ["US"]) == "+11232346789"
+    assert standardize_phone("798.612.3456", ["GB"]) == "+447986123456"
+    # Now do it as a list
+    assert standardize_phone(["555-654-1234", "919876543210"], countries=["IN"]) == [
+        "+915556541234",
+        "+919876543210",
+    ]
+    # Make sure we catch edge cases and bad inputs
+    assert standardize_phone("") == ""
+    assert standardize_phone(" ") == ""
+    assert standardize_phone("gibberish") == ""
+    assert standardize_phone("1234567890987654321") == ""
+    assert standardize_phone("123") == ""
+
+
+def test_standardize_phones():
+    raw_bundle = json.load(
+        open(
+            pathlib.Path(__file__).parent.parent / "assets" / "test_patient_bundle.json"
+        )
+    )
+
+    # Case where we pass in a whole FHIR bundle
+    standardized_bundle = copy.deepcopy(raw_bundle.copy())
+    patient = standardized_bundle["entry"][1]["resource"]
+    patient["telecom"][0]["value"] = "+11234567890"
+    assert standardize_phones_in_bundle(raw_bundle) == standardized_bundle
+
+    # Case where we pass in a whole FHIR bundle and do not overwrite the data
+    standardized_bundle = copy.deepcopy(raw_bundle.copy())
+    patient = standardized_bundle["entry"][1]["resource"]
+    patient["telecom"][0]["value"] = "+11234567890"
+    assert (
+        standardize_phones_in_bundle(raw_bundle, overwrite=False) == standardized_bundle
+    )
+
+    # Case where we provide only a single resource
+    patient_resource = raw_bundle["entry"][1]["resource"]
+    standardized_patient = copy.deepcopy(patient_resource)
+    standardized_patient["telecom"][0]["value"] = "+11234567890"
+    assert standardize_phones_in_bundle(patient_resource) == standardized_patient
+
+    # Case where we provide only a single resource and do not overwrite the data
+    patient_resource = raw_bundle["entry"][1]["resource"]
+    standardized_patient = copy.deepcopy(patient_resource)
+    standardized_patient["telecom"][0]["value"] = "+11234567890"
+    assert (
+        standardize_phones_in_bundle(patient_resource, overwrite=False)
+        == standardized_patient
+    )
+
+    # Case where the input data has no country information in the address
+    patient_resource = raw_bundle["entry"][1]["resource"]
+    patient_resource.get("address")[0].pop("country")
+    assert patient_resource.get("address")[0].get("country") is None
+    standardized_patient = copy.deepcopy(patient_resource)
+    standardized_patient["telecom"][0]["value"] = "+11234567890"
+    assert standardize_phones_in_bundle(patient_resource) == standardized_patient
+
+    # Case where the input data has no country information in the address and we do not
+    # overwrite the data
+    patient_resource = raw_bundle["entry"][1]["resource"]
+    assert patient_resource.get("address")[0].get("country") is None
+    standardized_patient = copy.deepcopy(patient_resource)
+    standardized_patient["telecom"][0]["value"] = "+11234567890"
+    assert (
+        standardize_phones_in_bundle(patient_resource, overwrite=False)
+        == standardized_patient
+    )
+
+
+def test_standardize_phones_in_resource():
+    raw_bundle = json.load(
+        open(
+            pathlib.Path(__file__).parent.parent / "assets" / "test_patient_bundle.json"
+        )
+    )
+    patient_resource = raw_bundle["entry"][1]["resource"]
+    standardized_patient = copy.deepcopy(patient_resource)
+    standardized_patient["telecom"][0]["value"] = "+11234567890"
+    assert _standardize_phones_in_resource(patient_resource) == standardized_patient
+
+
+def test_extract_countries_from_resource():
+    raw_bundle = json.load(
+        open(
+            pathlib.Path(__file__).parent.parent / "assets" / "test_patient_bundle.json"
+        )
+    )
+    patient = raw_bundle["entry"][1].get("resource")
+    patient["address"].append(patient["address"][0])
+    patient["address"].append(patient["address"][0])
+    assert [country for country in _extract_countries_from_resource(patient)] == [
+        "US"
+    ] * 3
+    assert [
+        country for country in _extract_countries_from_resource(patient, "alpha_3")
+    ] == ["USA"] * 3
+    assert [
+        country for country in _extract_countries_from_resource(patient, "numeric")
+    ] == ["840"] * 3


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR copies all SDK functions and related tests for standardizing phone numbers from phdi into the standardization service. The functions should be added to standardization/app/utils.py and the tests should be added to standardization/tests. It also renames functions to more clearly delineate which ones relate to FHIR, e.g., `standardize_phones_in_bundle` and `standardize_phones_in_resource`.

## Related Issue
Fixes # [phdi-azure#368](https://app.zenhub.com/workspaces/skylight-dibbs-viper-6480ba23b5a07644e0e46d23/issues/gh/cdcgov/phdi-azure/368)

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
