### PR TITLE
Fhir to phdc

### DIFF
--- a/containers/message-parser/app/default_schemas/test_reference_schema.json
+++ b/containers/message-parser/app/default_schemas/test_reference_schema.json
@@ -2,10 +2,7 @@
   "first_name": {
     "fhir_path": "Bundle.entry.resource.where(resourceType = 'Patient').name.first().given.first()",
     "data_type": "string",
-    "nullable": true,
-    "metadata": {
-      "category": "name"
-    }
+    "nullable": true
   },
   "last_name": {
     "fhir_path": "Bundle.entry.resource.where(resourceType = 'Patient').name.first().family",

--- a/containers/message-parser/app/main.py
+++ b/containers/message-parser/app/main.py
@@ -376,16 +376,7 @@ async def fhir_to_phdc_endpoint(
                     # Reference case: information is contained on another
                     # resource that we have to look up
                     else:
-                        reference_path = secondary_parser
-                        reference_lookup = (
-                            parsing_schema.get(field)
-                            .get("secondary_schema")
-                            .get(secondary_field)
-                            .get("reference_lookup")
-                        )
-                        reference_lookup = fhirpathpy.compile(reference_lookup)
-
-                        if len(reference_lookup(initial_value)) == 0:
+                        if len(secondary_parser(initial_value)) == 0:
                             response.status_code = status.HTTP_400_BAD_REQUEST
                             return {
                                 "message": "Provided `reference_lookup` location does "
@@ -394,7 +385,7 @@ async def fhir_to_phdc_endpoint(
                             }
                         else:
                             reference_lookup = ",".join(
-                                map(str, reference_lookup(initial_value))
+                                map(str, secondary_parser(initial_value))
                             )
 
                             # FHIR references are prefixed with resource type
@@ -403,6 +394,12 @@ async def fhir_to_phdc_endpoint(
                             # Now, if we found the ID being referenced, we can search
                             # the original bundle for the resource being referenced
                             # by building a concatenated reference path
+                            reference_path = (
+                                parsing_schema.get(field)
+                                .get("secondary_schema")
+                                .get(secondary_field)
+                                .get("fhir_path")
+                            )
                             reference_path = reference_path.replace(
                                 DIBBS_REFERENCE_SIGNIFIER, reference_lookup
                             )

--- a/containers/message-parser/app/utils.py
+++ b/containers/message-parser/app/utils.py
@@ -92,14 +92,19 @@ def get_parsers(extraction_schema: frozendict) -> frozendict:
             for secondary_field, secondary_field_definition in field_definition[
                 "secondary_schema"
             ].items():
+                # Base case: secondary field is located on this resource
                 if not secondary_field_definition["fhir_path"].startswith("Bundle"):
                     secondary_parsers[secondary_field] = fhirpathpy.compile(
                         secondary_field_definition["fhir_path"]
                     )
+
+                # Reference case: secondary field is located on a different resource,
+                # so we can't compile the fhir_path proper; instead, compile the
+                # reference for quick access later
                 else:
-                    secondary_parsers[secondary_field] = secondary_field_definition[
-                        "fhir_path"
-                    ]
+                    secondary_parsers[secondary_field] = fhirpathpy.compile(
+                        secondary_field_definition["reference_lookup"]
+                    )
             parser["secondary_parsers"] = secondary_parsers
         parsers[field] = parser
     return frozendict(parsers)

--- a/containers/message-parser/app/utils.py
+++ b/containers/message-parser/app/utils.py
@@ -96,6 +96,10 @@ def get_parsers(extraction_schema: frozendict) -> frozendict:
                     secondary_parsers[secondary_field] = fhirpathpy.compile(
                         secondary_field_definition["fhir_path"]
                     )
+                else:
+                    secondary_parsers[secondary_field] = secondary_field_definition[
+                        "fhir_path"
+                    ]
             parser["secondary_parsers"] = secondary_parsers
         parsers[field] = parser
     return frozendict(parsers)

--- a/containers/message-parser/assets/sample_fhir_to_phdc_requests.json
+++ b/containers/message-parser/assets/sample_fhir_to_phdc_requests.json
@@ -1,0 +1,172 @@
+{
+  "simple_reference_schema": {
+    "summary": "Simple Custom Reference Extraction Schema",
+    "description": "This is a simple schema showing how FHIR-bundled resources can reference each other during extraction.",
+    "value": {
+      "parsing_schema": {
+        "first_name": {
+          "fhir_path": "Bundle.entry.resource.where(resourceType = 'Patient').name.first().given.first()",
+          "data_type": "string",
+          "nullable": true,
+          "metadata": {
+            "category": "name"
+          }
+        },
+        "last_name": {
+          "fhir_path": "Bundle.entry.resource.where(resourceType = 'Patient').name.first().family",
+          "data_type": "string",
+          "nullable": true
+        },
+        "labs": {
+          "fhir_path": "Bundle.entry.resource.where(resourceType='Observation').where(category.coding.code='laboratory')",
+          "data_type": "array",
+          "nullable": true,
+          "secondary_schema": {
+            "test_type": {
+              "fhir_path": "Observation.code.coding.display",
+              "data_type": "string",
+              "nullable": true
+            },
+            "test_result_code_display": {
+              "fhir_path": "Observation.valueCodeableConcept.coding.display",
+              "data_type": "string",
+              "nullable": true
+            },
+            "ordering_provider": {
+              "fhir_path": "Bundle.entry.resource.where(resourceType='Organization').where(id='#REF#').name",
+              "reference_lookup": "Observation.performer.first().reference",
+              "data_type": "string",
+              "nullable": true
+            },
+            "requesting_organization_contact_person": {
+              "fhir_path": "Bundle.entry.resource.where(resourceType='Organization').where(id='#REF#').contact.name.text",
+              "reference_lookup": "Observation.performer.first().reference",
+              "data_type": "string",
+              "nullable": true
+            }
+          }
+        }
+      },
+      "bundle": {
+        "resourceType": "Bundle",
+        "identifier": {
+          "value": "a very contrived FHIR bundle"
+        },
+        "entry": [
+          {
+            "resource": {
+              "resourceType": "Organization",
+              "id": "idu2-jd81-lqpp-172j-nx82",
+              "active": true,
+              "name": "Western Pennsylvania Medical General",
+              "alias": [
+                "WPMG",
+                "Penn Gen"
+              ],
+              "contact": {
+                "name": {
+                  "text": "Dr. Totally Real Doctor, M.D."
+                }
+              }
+            }
+          },
+          {
+            "resource": {
+              "resourceType": "Patient",
+              "id": "some-uuid",
+              "identifier": [
+                {
+                  "value": "123456",
+                  "type": {
+                    "coding": [
+                      {
+                        "code": "MR",
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                        "display": "Medical record number"
+                      }
+                    ]
+                  },
+                  "system": "urn...no idea"
+                }
+              ],
+              "name": [
+                {
+                  "family": "doe",
+                  "given": [
+                    "John ",
+                    " Danger "
+                  ],
+                  "use": "official"
+                }
+              ],
+              "birthDate": "1983-02-01",
+              "gender": "female",
+              "address": [
+                {
+                  "line": [
+                    "123 Fake St",
+                    "Unit #F"
+                  ],
+                  "BuildingNumber": "123",
+                  "city": "Faketon",
+                  "state": "NY",
+                  "postalCode": "10001-0001",
+                  "country": "USA",
+                  "use": "home"
+                }
+              ],
+              "telecom": [
+                {
+                  "use": "home",
+                  "system": "phone",
+                  "value": "123-456-7890"
+                },
+                {
+                  "value": "johndanger@doe.net",
+                  "system": "email"
+                }
+              ]
+            },
+            "request": {
+              "method": "GET",
+              "url": "testing for entry with no resource"
+            }
+          },
+          {
+            "resource": {
+              "resourceType": "Observation",
+              "id": "obs1",
+              "category": {
+                "coding": {
+                  "code": "laboratory",
+                  "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                  "display": "Laboratory"
+                }
+              },
+              "code": {
+                "coding": {
+                  "system": "http://acmelabs.org",
+                  "code": "104177",
+                  "display": "Blood culture"
+                }
+              },
+              "valueCodeableConcept": {
+                "coding": {
+                  "system": "http://snomed.info/sct",
+                  "code": "3092008",
+                  "display": "Staphylococcus aureus"
+                }
+              },
+              "performer": [
+                {
+                  "reference": "Organization/idu2-jd81-lqpp-172j-nx82",
+                  "display": "Western Pennsylvania General"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/containers/message-parser/assets/sample_fhir_to_phdc_response.json
+++ b/containers/message-parser/assets/sample_fhir_to_phdc_response.json
@@ -1,0 +1,27 @@
+{
+  "description": "Success",
+  "content": {
+    "application/json": {
+      "examples": {
+        "simple_reference_schema": {
+          "summary": "Simple response for the custom reference schema",
+          "value": {
+            "message": "FHIR extraction succeeded!",
+            "parsed_values": {
+              "first_name": "JOHN",
+              "last_name": "DOE",
+              "labs": [
+                {
+                  "test_type": "Blood culture",
+                  "test_result_code_display": "Staphylococcus aureus",
+                  "ordering_provider": "Western Pennsylvania Medical General",
+                  "requesting_organization_contact_person": "Dr. Totally Real Doctor, M.D."
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/containers/message-parser/tests/test_fhir_to_phdc_endpoint.py
+++ b/containers/message-parser/tests/test_fhir_to_phdc_endpoint.py
@@ -1,0 +1,139 @@
+import json
+from copy import deepcopy
+from pathlib import Path
+
+from app.main import app
+from fastapi.testclient import TestClient
+
+
+client = TestClient(app)
+
+fhir_bundle_path = (
+    Path(__file__).parent.parent.parent.parent
+    / "tests"
+    / "assets"
+    / "general"
+    / "patient_bundle_w_labs.json"
+)
+
+with open(fhir_bundle_path, "r") as file:
+    fhir_bundle = json.load(file)
+
+test_schema_path = (
+    Path(__file__).parent.parent
+    / "app"
+    / "default_schemas"
+    / "test_reference_schema.json"
+)
+
+with open(test_schema_path, "r") as file:
+    test_schema = json.load(file)
+
+expected_successful_response = {
+    "message": "Parsing succeeded!",
+    "parsed_values": {
+        "first_name": "John ",
+        "last_name": "doe",
+        "labs": [
+            {
+                "test_type": "Blood culture",
+                "test_result_code_display": "Staphylococcus aureus",
+                "ordering_provider": "Western Pennsylvania Medical General",
+                "requesting_organization_contact_person": "Dr. Totally Real Doctor, M.D.",  # noqa
+            }
+        ],
+    },
+}
+
+
+def test_parse_message_success_internal_schema():
+    test_request = {
+        "parsing_schema_name": "test_reference_schema.json",
+        "message": fhir_bundle,
+    }
+
+    actual_response = client.post("/fhir_to_phdc", json=test_request)
+    assert actual_response.status_code == 200
+    assert actual_response.json() == expected_successful_response
+
+
+def test_parse_message_success_external_schema():
+    request = {
+        "parsing_schema": test_schema,
+        "message": fhir_bundle,
+    }
+
+    actual_response = client.post("/fhir_to_phdc", json=request)
+    assert actual_response.status_code == 200
+    assert actual_response.json() == expected_successful_response
+
+
+def test_parse_message_internal_and_external_schema():
+    request = {
+        "parsing_schema": test_schema,
+        "parsing_schema_name": "test_reference_schema.json",
+        "message": {},
+    }
+
+    actual_response = client.post("/fhir_to_phdc", json=request)
+    assert actual_response.status_code == 422
+    assert (
+        actual_response.json()["detail"][0]["msg"]
+        == "Values for both 'parsing_schema' and 'parsing_schema_name' have been "
+        "provided. Only one of these values is permited."
+    )
+
+
+def test_parse_message_neither_internal_nor_external_schema():
+    request = {
+        "message_format": "fhir",
+        "message": {},
+    }
+
+    actual_response = client.post("/fhir_to_phdc", json=request)
+    assert actual_response.status_code == 422
+    assert (
+        actual_response.json()["detail"][0]["msg"]
+        == "Values for 'parsing_schema' and 'parsing_schema_name' have not been "
+        "provided. One, but not both, of these values is required."
+    )
+
+
+def test_schema_without_reference_lookup():
+    no_lookup_schema = deepcopy(test_schema)
+    del no_lookup_schema["labs"]["secondary_schema"]["ordering_provider"][
+        "reference_lookup"
+    ]
+    request = {
+        "message": {},
+        "parsing_schema": no_lookup_schema,
+    }
+
+    actual_response = client.post("/fhir_to_phdc", json=request)
+    assert actual_response.status_code == 422
+    assert (
+        actual_response.json()["detail"][0]["msg"]
+        == "Secondary fields in the parsing schema that reference other "
+        "resources must include a `reference_lookup` field that identifies "
+        "where the reference ID can be found."
+    )
+
+
+def test_schema_without_identifier_path():
+    no_bundle_schema = deepcopy(test_schema)
+    no_bundle_schema["labs"]["secondary_schema"]["ordering_provider"][
+        "fhir_path"
+    ] = "Observation.provider"
+    request = {
+        "message": {},
+        "parsing_schema": no_bundle_schema,
+    }
+
+    actual_response = client.post("/fhir_to_phdc", json=request)
+    assert actual_response.status_code == 422
+    assert (
+        actual_response.json()["detail"][0]["msg"]
+        == "Secondary fields in the parsing schema that provide `reference_lookup` "
+        "locations must have a `fhir_path` that begins with `Bundle` and identifies "
+        "the type of resource being referenced."
+    )

--- a/containers/message-parser/tests/test_parse_message_endpoint.py
+++ b/containers/message-parser/tests/test_parse_message_endpoint.py
@@ -1,5 +1,4 @@
 import json
-from copy import deepcopy
 from pathlib import Path
 from unittest import mock
 
@@ -356,46 +355,4 @@ def test_parse_message_neither_internal_nor_external_schema():
         actual_response.json()["detail"][0]["msg"]
         == "Values for 'parsing_schema' and 'parsing_schema_name' have not been "
         "provided. One, but not both, of these values is required."
-    )
-
-
-def test_schema_without_reference_lookup():
-    no_lookup_schema = deepcopy(test_reference_schema)
-    del no_lookup_schema["labs"]["secondary_schema"]["ordering_provider"][
-        "reference_lookup"
-    ]
-    request = {
-        "message_format": "fhir",
-        "message": "some-hl7v2-elr-message",
-        "parsing_schema": no_lookup_schema,
-    }
-
-    actual_response = client.post("/parse_message", json=request)
-    assert actual_response.status_code == 422
-    assert (
-        actual_response.json()["detail"][0]["msg"]
-        == "Secondary fields in the parsing schema that reference other resources must "
-        "include a `reference_lookup` field that identifies where the reference ID can "
-        "be found."
-    )
-
-
-def test_schema_without_identifier_path():
-    no_bundle_schema = deepcopy(test_reference_schema)
-    no_bundle_schema["labs"]["secondary_schema"]["ordering_provider"][
-        "fhir_path"
-    ] = "Observation.provider"
-    request = {
-        "message_format": "fhir",
-        "message": "some-hl7v2-elr-message",
-        "parsing_schema": no_bundle_schema,
-    }
-
-    actual_response = client.post("/parse_message", json=request)
-    assert actual_response.status_code == 422
-    assert (
-        actual_response.json()["detail"][0]["msg"]
-        == "Secondary fields in the parsing schema that provide `reference_lookup` "
-        "locations must have a `fhir_path` that begins with `Bundle` and identifies "
-        "the type of resource being referenced."
     )


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR fully  implements the `fhir-to-phdc` endpoint, separating that functionality from the message parser. We can now fully handle extracting reference IDs from resources sent to the service, and then can use those IDs to search for other resources in the bundle that contain information referenced in the schema. Also includes validators, unit tests, and examples.

## Related Issue
Fixes #1023 

## Additional Information
This PR will need to go through some changes after we get a review on the PR for 1022, since that's where the schema support logic is. Once that PR is cleaned and ready, this one can be finalized, though most of the logic and checks implemented here will still hold.