### PR TITLE
resolve the value of references in fhir converter

### DIFF
--- a/containers/fhir-converter/app/main.py
+++ b/containers/fhir-converter/app/main.py
@@ -5,6 +5,7 @@ from app.constants import FhirConverterInput
 from app.constants import sample_request
 from app.constants import sample_response
 from app.service import convert_to_fhir
+from app.service import resolve_references
 from fastapi import Body
 from fastapi import FastAPI
 from fastapi import HTTPException
@@ -65,6 +66,7 @@ async def convert(
     """
     fhir_converter_input = dict(input)
     fhir_converter_input.pop("rr_data")
+    input.input_data = resolve_references(input.input_data)
 
     # If RR is present, also need input data and conversion type eICR
     if input.rr_data is not None:

--- a/containers/fhir-converter/app/service.py
+++ b/containers/fhir-converter/app/service.py
@@ -2,6 +2,7 @@ import json
 import subprocess
 import uuid
 from pathlib import Path
+
 from lxml import etree
 
 from phdi.harmonization import standardize_hl7_datetimes
@@ -41,10 +42,10 @@ def add_data_source_to_bundle(bundle: dict, data_source: str) -> dict:
 
 def resolve_references(input_data: str):
     ecr = etree.fromstring(input_data)
-    ns = {'hl7': 'urn:hl7-org:v3'}
-    refs = ecr.xpath('//hl7:reference', namespaces=ns)
+    ns = {"hl7": "urn:hl7-org:v3"}
+    refs = ecr.xpath("//hl7:reference", namespaces=ns)
     for i in range(len(refs)):
-        ref_id = refs[i].attrib['value'][1:]
+        ref_id = refs[i].attrib["value"][1:]
         value = " ".join(ecr.xpath("//*[@ID='" + ref_id + "']/text()"))
         refs[i].text = value
 

--- a/containers/fhir-converter/app/service.py
+++ b/containers/fhir-converter/app/service.py
@@ -2,6 +2,7 @@ import json
 import subprocess
 import uuid
 from pathlib import Path
+from lxml import etree
 
 from phdi.harmonization import standardize_hl7_datetimes
 
@@ -36,6 +37,18 @@ def add_data_source_to_bundle(bundle: dict, data_source: str) -> dict:
             meta["source"] = [data_source]
 
     return bundle
+
+
+def resolve_references(input_data: str):
+    ecr = etree.fromstring(input_data)
+    ns = {'hl7': 'urn:hl7-org:v3'}
+    refs = ecr.xpath('//hl7:reference', namespaces=ns)
+    for i in range(len(refs)):
+        ref_id = refs[i].attrib['value'][1:]
+        value = " ".join(ecr.xpath("//*[@ID='" + ref_id + "']/text()"))
+        refs[i].text = value
+
+    return etree.tostring(ecr)
 
 
 def convert_to_fhir(

--- a/containers/fhir-converter/app/service.py
+++ b/containers/fhir-converter/app/service.py
@@ -41,7 +41,11 @@ def add_data_source_to_bundle(bundle: dict, data_source: str) -> dict:
 
 
 def resolve_references(input_data: str):
-    ecr = etree.fromstring(input_data)
+    try:
+        ecr = etree.fromstring(input_data.encode())
+    except etree.XMLSyntaxError:
+        return input_data
+
     ns = {"hl7": "urn:hl7-org:v3"}
     refs = ecr.xpath("//hl7:reference", namespaces=ns)
     for i in range(len(refs)):
@@ -49,7 +53,7 @@ def resolve_references(input_data: str):
         value = " ".join(ecr.xpath("//*[@ID='" + ref_id + "']/text()"))
         refs[i].text = value
 
-    return etree.tostring(ecr)
+    return etree.tostring(ecr).decode()
 
 
 def convert_to_fhir(

--- a/containers/fhir-converter/app/service.py
+++ b/containers/fhir-converter/app/service.py
@@ -48,10 +48,10 @@ def resolve_references(input_data: str):
 
     ns = {"hl7": "urn:hl7-org:v3"}
     refs = ecr.xpath("//hl7:reference", namespaces=ns)
-    for i in range(len(refs)):
-        ref_id = refs[i].attrib["value"][1:]
+    for ref in refs:
+        ref_id = ref.attrib["value"][1:]
         value = " ".join(ecr.xpath("//*[@ID='" + ref_id + "']/text()"))
-        refs[i].text = value
+        ref.text = value
 
     return etree.tostring(ecr).decode()
 

--- a/containers/fhir-converter/tests/integration/conftest.py
+++ b/containers/fhir-converter/tests/integration/conftest.py
@@ -9,7 +9,9 @@ def setup(request):
     print("Setting up tests...")
     compose_path = os.path.join(os.path.dirname(__file__), "./")
     compose_file_name = "docker-compose.yaml"
-    fhir_converter = DockerCompose(compose_path, compose_file_name=compose_file_name, build=True)
+    fhir_converter = DockerCompose(
+        compose_path, compose_file_name=compose_file_name, build=True
+    )
     converter_url = "http://0.0.0.0:8080"
 
     fhir_converter.start()

--- a/containers/fhir-converter/tests/integration/conftest.py
+++ b/containers/fhir-converter/tests/integration/conftest.py
@@ -9,7 +9,7 @@ def setup(request):
     print("Setting up tests...")
     compose_path = os.path.join(os.path.dirname(__file__), "./")
     compose_file_name = "docker-compose.yaml"
-    fhir_converter = DockerCompose(compose_path, compose_file_name=compose_file_name)
+    fhir_converter = DockerCompose(compose_path, compose_file_name=compose_file_name, build=True)
     converter_url = "http://0.0.0.0:8080"
 
     fhir_converter.start()

--- a/containers/fhir-converter/tests/test_FHIR-Converter.py
+++ b/containers/fhir-converter/tests/test_FHIR-Converter.py
@@ -359,6 +359,7 @@ def test_resolve_references_valid_input():
         == "Traveled to Singapore, Malaysia and Bali with my family."
     )
 
+
 def test_resolve_references_invalid_input():
     actual = resolve_references("VXU or HL7 MESSAGE")
     assert actual == "VXU or HL7 MESSAGE"

--- a/containers/fhir-converter/tests/test_FHIR-Converter.py
+++ b/containers/fhir-converter/tests/test_FHIR-Converter.py
@@ -197,7 +197,7 @@ invalid_rr_data_request = {
 
 invalid_rr_data_response = {
     "message": "Reportability Response (RR) data is only accepted for eCR "
-               "conversion requests."
+    "conversion requests."
 }
 
 
@@ -207,11 +207,11 @@ invalid_rr_data_response = {
 @mock.patch("app.service.Path")
 @mock.patch("app.main.resolve_references")
 def test_convert_valid_request(
-        patched_resolve_references,
-        patched_file_path,
-        patched_subprocess_run,
-        patched_open,
-        patched_json_load,
+    patched_resolve_references,
+    patched_file_path,
+    patched_subprocess_run,
+    patched_open,
+    patched_json_load,
 ):
     global valid_response
     patched_subprocess_run.return_value = mock.Mock(returncode=0)
@@ -239,12 +239,12 @@ def test_convert_valid_request(
 @mock.patch("app.main.add_rr_data_to_eicr")
 @mock.patch("app.main.resolve_references")
 def test_convert_valid_request_with_rr_data(
-        patched_resolve_references,
-        patched_add_rr_data_to_eicr,
-        patched_file_path,
-        patched_subprocess_run,
-        patched_open,
-        patched_json_load,
+    patched_resolve_references,
+    patched_add_rr_data_to_eicr,
+    patched_file_path,
+    patched_subprocess_run,
+    patched_open,
+    patched_json_load,
 ):
     patched_subprocess_run.return_value = mock.Mock(returncode=0)
     patched_json_load.return_value = valid_response
@@ -263,7 +263,11 @@ def test_convert_valid_request_with_rr_data(
 @mock.patch("app.service.Path")
 @mock.patch("app.main.resolve_references")
 def test_convert_conversion_failure(
-        patched_resolve_references,patched_file_path, patched_subprocess_run, patched_open, patched_json_load
+    patched_resolve_references,
+    patched_file_path,
+    patched_subprocess_run,
+    patched_open,
+    patched_json_load,
 ):
     patched_subprocess_run.return_value = mock.Mock(returncode=1)
     patched_json_load.return_value = valid_response
@@ -337,17 +341,20 @@ def test_add_data_source_to_bundle_missing_arg():
     assert expected_error_message in result_error_message
 
 
-bundle_with_references = "<ClinicalDocument xmlns=\"urn:hl7-org:v3\" xmlns:sdtc=\"urn:hl7-org:sdtc\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"><component><structuredBody><component><section><text><content styleCode=\"Bold\">Additional Data</content><table><tbody><tr><th>Assigned Birth Sex</th><td ID=\"birthsex\">Female</td></tr><tr><th>Gender Identity</th><td ID=\"gender-identity\">unknown</td></tr><tr><th>Sexual Orientation</th><td ID=\"sexual-orientation\">Do not know</td></tr></tbody></table><content styleCode=\"Bold\">Travel History</content><table><thead><tr><th>Date of Travel</th><th>Location</th></tr></thead><tbody><tr><td>January 18th, 2018 - February 18th, 2018</td><td ID=\"trvhx-1\">Traveled to Singapore, Malaysia and Bali with<br/>my family.</td></tr></tbody></table></text><entry><observation classCode=\"OBS\" moodCode=\"EVN\"><value code=\"F\" codeSystem=\"2.16.840.1.113883.5.1\" codeSystemName=\"AdministrativeGender\" displayName=\"Female\" xsi:type=\"CD\"><originalText><reference value=\"#birthsex\"/></originalText></value></observation></entry><entry><observation classCode=\"OBS\" moodCode=\"EVN\"><value nullFlavor=\"UNK\" xsi:type=\"CD\"><originalText><reference value=\"#gender-identity\"/></originalText></value></observation></entry><entry><observation classCode=\"OBS\" moodCode=\"EVN\"><value nullFlavor=\"UNK\" xsi:type=\"CD\"><originalText><reference value=\"#sexual-orientation\"/></originalText></value></observation></entry><entry><act classCode=\"ACT\" moodCode=\"EVN\"><text><reference value=\"#trvhx-1\"/></text></act></entry></section></component></structuredBody></component></ClinicalDocument>"
+bundle_with_references = '<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:sdtc="urn:hl7-org:sdtc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><component><structuredBody><component><section><text><content styleCode="Bold">Additional Data</content><table><tbody><tr><th>Assigned Birth Sex</th><td ID="birthsex">Female</td></tr><tr><th>Gender Identity</th><td ID="gender-identity">unknown</td></tr><tr><th>Sexual Orientation</th><td ID="sexual-orientation">Do not know</td></tr></tbody></table><content styleCode="Bold">Travel History</content><table><thead><tr><th>Date of Travel</th><th>Location</th></tr></thead><tbody><tr><td>January 18th, 2018 - February 18th, 2018</td><td ID="trvhx-1">Traveled to Singapore, Malaysia and Bali with<br/>my family.</td></tr></tbody></table></text><entry><observation classCode="OBS" moodCode="EVN"><value code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGender" displayName="Female" xsi:type="CD"><originalText><reference value="#birthsex"/></originalText></value></observation></entry><entry><observation classCode="OBS" moodCode="EVN"><value nullFlavor="UNK" xsi:type="CD"><originalText><reference value="#gender-identity"/></originalText></value></observation></entry><entry><observation classCode="OBS" moodCode="EVN"><value nullFlavor="UNK" xsi:type="CD"><originalText><reference value="#sexual-orientation"/></originalText></value></observation></entry><entry><act classCode="ACT" moodCode="EVN"><text><reference value="#trvhx-1"/></text></act></entry></section></component></structuredBody></component></ClinicalDocument>'
 
 
 def test_resolve_references():
     tree = etree.fromstring(resolve_references(bundle_with_references))
-    actual_refs = tree.xpath('//hl7:reference', namespaces={ "hl7" : 'urn:hl7-org:v3' })
-    assert actual_refs[0].attrib['value'] == "#birthsex"
+    actual_refs = tree.xpath("//hl7:reference", namespaces={"hl7": "urn:hl7-org:v3"})
+    assert actual_refs[0].attrib["value"] == "#birthsex"
     assert actual_refs[0].text == "Female"
-    assert actual_refs[1].attrib['value'] == "#gender-identity"
+    assert actual_refs[1].attrib["value"] == "#gender-identity"
     assert actual_refs[1].text == "unknown"
-    assert actual_refs[2].attrib['value'] == "#sexual-orientation"
+    assert actual_refs[2].attrib["value"] == "#sexual-orientation"
     assert actual_refs[2].text == "Do not know"
-    assert actual_refs[3].attrib['value'] == "#trvhx-1"
-    assert actual_refs[3].text == "Traveled to Singapore, Malaysia and Bali with my family."
+    assert actual_refs[3].attrib["value"] == "#trvhx-1"
+    assert (
+        actual_refs[3].text
+        == "Traveled to Singapore, Malaysia and Bali with my family."
+    )

--- a/containers/fhir-converter/tests/test_FHIR-Converter.py
+++ b/containers/fhir-converter/tests/test_FHIR-Converter.py
@@ -344,7 +344,7 @@ def test_add_data_source_to_bundle_missing_arg():
 bundle_with_references = '<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:sdtc="urn:hl7-org:sdtc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><component><structuredBody><component><section><text><content styleCode="Bold">Additional Data</content><table><tbody><tr><th>Assigned Birth Sex</th><td ID="birthsex">Female</td></tr><tr><th>Gender Identity</th><td ID="gender-identity">unknown</td></tr><tr><th>Sexual Orientation</th><td ID="sexual-orientation">Do not know</td></tr></tbody></table><content styleCode="Bold">Travel History</content><table><thead><tr><th>Date of Travel</th><th>Location</th></tr></thead><tbody><tr><td>January 18th, 2018 - February 18th, 2018</td><td ID="trvhx-1">Traveled to Singapore, Malaysia and Bali with<br/>my family.</td></tr></tbody></table></text><entry><observation classCode="OBS" moodCode="EVN"><value code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGender" displayName="Female" xsi:type="CD"><originalText><reference value="#birthsex"/></originalText></value></observation></entry><entry><observation classCode="OBS" moodCode="EVN"><value nullFlavor="UNK" xsi:type="CD"><originalText><reference value="#gender-identity"/></originalText></value></observation></entry><entry><observation classCode="OBS" moodCode="EVN"><value nullFlavor="UNK" xsi:type="CD"><originalText><reference value="#sexual-orientation"/></originalText></value></observation></entry><entry><act classCode="ACT" moodCode="EVN"><text><reference value="#trvhx-1"/></text></act></entry></section></component></structuredBody></component></ClinicalDocument>'
 
 
-def test_resolve_references():
+def test_resolve_references_valid_input():
     tree = etree.fromstring(resolve_references(bundle_with_references))
     actual_refs = tree.xpath("//hl7:reference", namespaces={"hl7": "urn:hl7-org:v3"})
     assert actual_refs[0].attrib["value"] == "#birthsex"
@@ -358,3 +358,7 @@ def test_resolve_references():
         actual_refs[3].text
         == "Traveled to Singapore, Malaysia and Bali with my family."
     )
+
+def test_resolve_references_invalid_input():
+    actual = resolve_references("VXU or HL7 MESSAGE")
+    assert actual == "VXU or HL7 MESSAGE"

--- a/containers/fhir-converter/tests/test_FHIR-Converter.py
+++ b/containers/fhir-converter/tests/test_FHIR-Converter.py
@@ -5,7 +5,9 @@ from unittest import mock
 import pytest
 from app.main import app
 from app.service import add_data_source_to_bundle
+from app.service import resolve_references
 from fastapi.testclient import TestClient
+from lxml import etree
 
 client = TestClient(app)
 
@@ -187,7 +189,7 @@ invalid_root_template_response = {
 }
 
 invalid_rr_data_request = {
-    "input_data": "VALID_INPUT_DATA",
+    "input_data": "<VALID_INPUT_DATA />",
     "input_type": "vxu",
     "root_template": "EICR",
     "rr_data": "RR",
@@ -195,7 +197,7 @@ invalid_rr_data_request = {
 
 invalid_rr_data_response = {
     "message": "Reportability Response (RR) data is only accepted for eCR "
-    "conversion requests."
+               "conversion requests."
 }
 
 
@@ -203,11 +205,13 @@ invalid_rr_data_response = {
 @mock.patch("app.service.open")
 @mock.patch("app.service.subprocess.run")
 @mock.patch("app.service.Path")
+@mock.patch("app.main.resolve_references")
 def test_convert_valid_request(
-    patched_file_path,
-    patched_subprocess_run,
-    patched_open,
-    patched_json_load,
+        patched_resolve_references,
+        patched_file_path,
+        patched_subprocess_run,
+        patched_open,
+        patched_json_load,
 ):
     global valid_response
     patched_subprocess_run.return_value = mock.Mock(returncode=0)
@@ -233,12 +237,14 @@ def test_convert_valid_request(
 @mock.patch("app.service.subprocess.run")
 @mock.patch("app.service.Path")
 @mock.patch("app.main.add_rr_data_to_eicr")
+@mock.patch("app.main.resolve_references")
 def test_convert_valid_request_with_rr_data(
-    patched_add_rr_data_to_eicr,
-    patched_file_path,
-    patched_subprocess_run,
-    patched_open,
-    patched_json_load,
+        patched_resolve_references,
+        patched_add_rr_data_to_eicr,
+        patched_file_path,
+        patched_subprocess_run,
+        patched_open,
+        patched_json_load,
 ):
     patched_subprocess_run.return_value = mock.Mock(returncode=0)
     patched_json_load.return_value = valid_response
@@ -255,8 +261,9 @@ def test_convert_valid_request_with_rr_data(
 @mock.patch("app.service.open")
 @mock.patch("app.service.subprocess.run")
 @mock.patch("app.service.Path")
+@mock.patch("app.main.resolve_references")
 def test_convert_conversion_failure(
-    patched_file_path, patched_subprocess_run, patched_open, patched_json_load
+        patched_resolve_references,patched_file_path, patched_subprocess_run, patched_open, patched_json_load
 ):
     patched_subprocess_run.return_value = mock.Mock(returncode=1)
     patched_json_load.return_value = valid_response
@@ -328,3 +335,19 @@ def test_add_data_source_to_bundle_missing_arg():
         add_data_source_to_bundle(valid_response, "")
     result_error_message = str(excinfo.value)
     assert expected_error_message in result_error_message
+
+
+bundle_with_references = "<ClinicalDocument xmlns=\"urn:hl7-org:v3\" xmlns:sdtc=\"urn:hl7-org:sdtc\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"><component><structuredBody><component><section><text><content styleCode=\"Bold\">Additional Data</content><table><tbody><tr><th>Assigned Birth Sex</th><td ID=\"birthsex\">Female</td></tr><tr><th>Gender Identity</th><td ID=\"gender-identity\">unknown</td></tr><tr><th>Sexual Orientation</th><td ID=\"sexual-orientation\">Do not know</td></tr></tbody></table><content styleCode=\"Bold\">Travel History</content><table><thead><tr><th>Date of Travel</th><th>Location</th></tr></thead><tbody><tr><td>January 18th, 2018 - February 18th, 2018</td><td ID=\"trvhx-1\">Traveled to Singapore, Malaysia and Bali with<br/>my family.</td></tr></tbody></table></text><entry><observation classCode=\"OBS\" moodCode=\"EVN\"><value code=\"F\" codeSystem=\"2.16.840.1.113883.5.1\" codeSystemName=\"AdministrativeGender\" displayName=\"Female\" xsi:type=\"CD\"><originalText><reference value=\"#birthsex\"/></originalText></value></observation></entry><entry><observation classCode=\"OBS\" moodCode=\"EVN\"><value nullFlavor=\"UNK\" xsi:type=\"CD\"><originalText><reference value=\"#gender-identity\"/></originalText></value></observation></entry><entry><observation classCode=\"OBS\" moodCode=\"EVN\"><value nullFlavor=\"UNK\" xsi:type=\"CD\"><originalText><reference value=\"#sexual-orientation\"/></originalText></value></observation></entry><entry><act classCode=\"ACT\" moodCode=\"EVN\"><text><reference value=\"#trvhx-1\"/></text></act></entry></section></component></structuredBody></component></ClinicalDocument>"
+
+
+def test_resolve_references():
+    tree = etree.fromstring(resolve_references(bundle_with_references))
+    actual_refs = tree.xpath('//hl7:reference', namespaces={ "hl7" : 'urn:hl7-org:v3' })
+    assert actual_refs[0].attrib['value'] == "#birthsex"
+    assert actual_refs[0].text == "Female"
+    assert actual_refs[1].attrib['value'] == "#gender-identity"
+    assert actual_refs[1].text == "unknown"
+    assert actual_refs[2].attrib['value'] == "#sexual-orientation"
+    assert actual_refs[2].text == "Do not know"
+    assert actual_refs[3].attrib['value'] == "#trvhx-1"
+    assert actual_refs[3].text == "Traveled to Singapore, Malaysia and Bali with my family."


### PR DESCRIPTION
# PULL REQUEST

## Summary
- In the eICR document, there are references that reference fields. These changes will set the text value of references to the matching ID's value.

Example:
There may be an observation for travel history that references `#trvhx-1`, but that data is located in a `table` outside of the entry
```XML
<entry>
    <act classCode="ACT" moodCode="EVN">
        <code code="420008001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Travel"/>
        <text>
            <reference value="#trvhx-1"/>
        </text>
        <effectiveTime>
            <low value="20180118"/>
            <high value="20180218"/>
        </effectiveTime>
    </act>
</entry>
```

```XML
<table>
    <thead>
        <tr>
            <th>Date of Travel</th>
            <th>Location</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>January 18th, 2018 - February 18th, 2018</td>
            <td ID="trvhx-1">Traveled to Singapore, Malaysia and Bali with<br/>my family.</td>
        </tr>
    </tbody>
</table>
```

Outcome:
```XML
<reference xmlns="urn:hl7-org:v3" xmlns:sdtc="urn:hl7-org:sdtc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" value="#trvhx-1">Traveled to Singapore, Malaysia and Bali with my family.</reference>
```

## Related Issue
Part of #1001

## Additional Information
- Using liquid templates, it is not possible as far as I am aware to fetch the value for that ID
- Set `build=True` for our integration test so the image rebuilds each time its run.

## Checklist

