### PR TITLE
Add `_build_addr` method to PHDCBuilder

### DIFF
--- a/containers/message-parser/app/phdc/phdc.py
+++ b/containers/message-parser/app/phdc/phdc.py
@@ -46,13 +46,13 @@ class PHDCBuilder:
         Builds an `addr` XML element for address data. There are two types of address
          uses: 'H' for home address and 'WP' for workplace address.
 
-        :param use: Type of address, defaults to None., defaults to None
-        :param line: Street address, defaults to None
-        :param city: City, defaults to None
-        :param state: State, defaults to None
-        :param zip: Zip code, defaults to None
-        :param county: County, defaults to None
-        :param country: Country, defaults to None
+        :param use: Type of address, defaults to None.
+        :param line: Street address, defaults to None.
+        :param city: City, defaults to None.
+        :param state: State, defaults to None.
+        :param zip: Zip code, defaults to None.
+        :param county: County, defaults to None.
+        :param country: Country, defaults to None.
         :return: XML element of address data.
         """
         address_elements = locals()

--- a/containers/message-parser/app/phdc/phdc.py
+++ b/containers/message-parser/app/phdc/phdc.py
@@ -33,5 +33,45 @@ class PHDCBuilder:
 
         return telecom_data
 
+    def _build_addr(
+        use: Literal["H", "WP"] = None,
+        line: str = None,
+        city: str = None,
+        state: str = None,
+        zip: str = None,
+        county: str = None,
+        country: str = None,
+    ):
+        """
+        Builds an `addr` XML element for address data. There are two types of address
+         uses: 'H' for home address and 'WP' for workplace address.
+
+        :param use: _description_, defaults to None
+        :param line: _description_, defaults to None
+        :param city: _description_, defaults to None
+        :param state: _description_, defaults to None
+        :param zip: _description_, defaults to None
+        :param county: _description_, defaults to None
+        :param country: _description_, defaults to None
+        :return: XML element of address data.
+        """
+        address_elements = locals()
+
+        address_data = ET.Element("addr")
+        if use is not None:
+            address_data.set("use", use)
+
+        for element, value in address_elements.items():
+            if element != "use" and value is not None:
+                if element == "line":
+                    element = "streetAddressLine"
+                elif element == "zip":
+                    element = "postalCode"
+                e = ET.Element(element)
+                e.text = value
+                address_data.append(e)
+
+        return address_data
+
     def build(self):
         return PHDC(self)

--- a/containers/message-parser/app/phdc/phdc.py
+++ b/containers/message-parser/app/phdc/phdc.py
@@ -46,13 +46,13 @@ class PHDCBuilder:
         Builds an `addr` XML element for address data. There are two types of address
          uses: 'H' for home address and 'WP' for workplace address.
 
-        :param use: _description_, defaults to None
-        :param line: _description_, defaults to None
-        :param city: _description_, defaults to None
-        :param state: _description_, defaults to None
-        :param zip: _description_, defaults to None
-        :param county: _description_, defaults to None
-        :param country: _description_, defaults to None
+        :param use: Type of address, defaults to None., defaults to None
+        :param line: Street address, defaults to None
+        :param city: City, defaults to None
+        :param state: State, defaults to None
+        :param zip: Zip code, defaults to None
+        :param county: County, defaults to None
+        :param country: Country, defaults to None
         :return: XML element of address data.
         """
         address_elements = locals()

--- a/containers/message-parser/tests/test_phdc.py
+++ b/containers/message-parser/tests/test_phdc.py
@@ -28,3 +28,57 @@ from lxml import etree as ET
 def test_build_telecom(build_telecom_test_data, expected_result):
     xml_telecom_data = PHDCBuilder._build_telecom(**build_telecom_test_data)
     assert ET.tostring(xml_telecom_data).decode() == expected_result
+
+
+@pytest.mark.parametrize(
+    "build_addr_test_data, expected_result",
+    [
+        # Success with all values present
+        (
+            {
+                "use": "H",
+                "line": "123 Main Street",
+                "city": "Brooklyn",
+                "state": "New York",
+                "zip": "11205",
+                "county": "Kings",
+                "country": "USA",
+            },
+            (
+                '<addr use="H"><streetAddressLine>123 Main Street</streetAddressLine>'
+                + "<city>Brooklyn</city><state>New York</state>"
+                + "<postalCode>11205</postalCode><county>Kings</county>"
+                + "<country>USA</country></addr>"
+            ),
+        ),
+        # Success with some values missing
+        (
+            {
+                "use": "H",
+                "line": "123 Main Street",
+                "city": "Brooklyn",
+                "state": "New York",
+            },
+            (
+                '<addr use="H"><streetAddressLine>123 Main Street</streetAddressLine>'
+                + "<city>Brooklyn</city><state>New York</state></addr>"
+            ),
+        ),
+        # Success with some values as None
+        (
+            {
+                "use": "H",
+                "line": "123 Main Street",
+                "city": "Brooklyn",
+                "state": None,
+            },
+            (
+                '<addr use="H"><streetAddressLine>123 Main Street</streetAddressLine>'
+                + "<city>Brooklyn</city></addr>"
+            ),
+        ),
+    ],
+)
+def test_build_addr(build_addr_test_data, expected_result):
+    xml_addr_data = PHDCBuilder._build_addr(**build_addr_test_data)
+    assert ET.tostring(xml_addr_data).decode() == expected_result


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR adds an internal method for building out the address section of a PHDC. 

## Related Issue
Fixes #1052 

## Additional Information
- This PR assumes a single address as the input with a single `line`. PHDC does allow for mutiple `lines` in an address or for the address to be condensed on a single line.

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
