### PR TITLE
Add `PHDCDirector` class handle build patterns for PHDCBuilder

### DIFF
--- a/containers/message-parser/app/phdc/phdc.py
+++ b/containers/message-parser/app/phdc/phdc.py
@@ -1,20 +1,23 @@
+from __future__ import annotations
+
 from typing import Literal
+from typing import Optional
 
 from lxml import etree as ET
 
 
 class PHDC:
-    def __init__(self, builder):
+    def __init__(self, builder: PHDCBuilder) -> None:
         self.header = builder.header
 
 
 class PHDCBuilder:
-    def __init__(self):
+    def __init__(self) -> None:
         self.header = None
 
     def _build_telecom(
         phone: str,
-        use: Literal["HP", "WP", "MC"] = None,
+        use: Optional[Literal["HP", "WP", "MC"]] = None,
     ):
         """
         Builds a `telecom` XML element for phone data including phone number (as
@@ -33,5 +36,23 @@ class PHDCBuilder:
 
         return telecom_data
 
-    def build(self):
+    def build(self) -> PHDC:
         return PHDC(self)
+
+
+class PHDCDirector:
+    def __init__(self, builder: PHDCBuilder) -> None:
+        self.builder = builder
+
+    def build_case_report(
+        self, phone: str, use: Optional[Literal["HP", "WP", "MC"]] = None
+    ) -> PHDC:
+        self.builder._build_telecom(phone, use)
+        return self.builder.build()
+
+    # TODO: find out if source data we will use requires building separate lab reports
+    def build_lab_report(
+        self, phone: str, use: Optional[Literal["HP", "WP", "MC"]] = None
+    ) -> PHDC:
+        self.builder._build_telecom(phone, use)
+        return self.builder.build()

--- a/containers/message-parser/app/phdc/phdc.py
+++ b/containers/message-parser/app/phdc/phdc.py
@@ -10,12 +10,16 @@ class PHDC:
     def __init__(self, builder: PHDCBuilder) -> None:
         self.header = builder.header
 
+    def to_xml_string(self):
+        return ET.tostring(self.header) if self.header is not None else ""
+
 
 class PHDCBuilder:
     def __init__(self) -> None:
         self.header = None
 
     def _build_telecom(
+        self,
         phone: str,
         use: Optional[Literal["HP", "WP", "MC"]] = None,
     ):
@@ -37,6 +41,7 @@ class PHDCBuilder:
         return telecom_data
 
     def _build_addr(
+        self,
         use: Optional[Literal["H", "WP"]] = None,
         line: str = None,
         city: str = None,
@@ -65,7 +70,7 @@ class PHDCBuilder:
             address_data.set("use", use)
 
         for element, value in address_elements.items():
-            if element != "use" and value is not None:
+            if element not in ["use", "self"] and value is not None:
                 if element == "line":
                     element = "streetAddressLine"
                 elif element == "zip":
@@ -76,7 +81,7 @@ class PHDCBuilder:
 
         return address_data
 
-    def build(self):
+    def build(self, **kwargs) -> PHDC:
         return PHDC(self)
 
 
@@ -96,9 +101,9 @@ class PHDCDirector:
         :param addr_data: Dictionary of address data.
         :return: PHDC object.
         """
-        self.builder._build_telecom(**telecom_data)
-        self.builder._build_addr(**addr_data)
-        return self.builder.build()
+        telecom_element = self.builder._build_telecom(**telecom_data)
+        addr_element = self.builder._build_addr(**addr_data)
+        return self.builder.build(telecom=telecom_element, addr=addr_element)
 
     # TODO: find out if source data we will use requires building separate lab reports
     def build_lab_report(self, telecom_data: dict, addr_data: dict) -> PHDC:
@@ -113,6 +118,6 @@ class PHDCDirector:
         :param addr_data: Dictionary of address data.
         :return: PHDC object.
         """
-        self.builder._build_telecom(**telecom_data)
-        self.builder._build_addr(**addr_data)
-        return self.builder.build()
+        telecom_element = self.builder._build_telecom(**telecom_data)
+        addr_element = self.builder._build_addr(**addr_data)
+        return self.builder.build(telecom=telecom_element, addr=addr_element)

--- a/containers/message-parser/app/phdc/phdc.py
+++ b/containers/message-parser/app/phdc/phdc.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import Literal
-from typing import Optional
 
 from lxml import etree as ET
 
@@ -21,7 +20,7 @@ class PHDCBuilder:
     def _build_telecom(
         self,
         phone: str,
-        use: Optional[Literal["HP", "WP", "MC"]] = None,
+        use: Literal["HP", "WP", "MC"] = None,
     ):
         """
         Builds a `telecom` XML element for phone data including phone number (as
@@ -42,7 +41,7 @@ class PHDCBuilder:
 
     def _build_addr(
         self,
-        use: Optional[Literal["H", "WP"]] = None,
+        use: Literal["H", "WP"] = None,
         line: str = None,
         city: str = None,
         state: str = None,
@@ -106,18 +105,3 @@ class PHDCDirector:
         return self.builder.build(telecom=telecom_element, addr=addr_element)
 
     # TODO: find out if source data we will use requires building separate lab reports
-    def build_lab_report(self, telecom_data: dict, addr_data: dict) -> PHDC:
-        """
-        Builds a lab report PHDC object.
-
-        Arguments are dictionaries passed to PHDCBuilder's methods and should include
-        the arguments required by those methods. See PHDCBuilder's methods for more
-        info.
-
-        :param telecom_data: Dictionary of telecom data.
-        :param addr_data: Dictionary of address data.
-        :return: PHDC object.
-        """
-        telecom_element = self.builder._build_telecom(**telecom_data)
-        addr_element = self.builder._build_addr(**addr_data)
-        return self.builder.build(telecom=telecom_element, addr=addr_element)

--- a/containers/message-parser/app/phdc/phdc.py
+++ b/containers/message-parser/app/phdc/phdc.py
@@ -84,15 +84,35 @@ class PHDCDirector:
     def __init__(self, builder: PHDCBuilder) -> None:
         self.builder = builder
 
-    def build_case_report(
-        self, phone: str, use: Optional[Literal["HP", "WP", "MC"]] = None
-    ) -> PHDC:
-        self.builder._build_telecom(phone, use)
+    def build_case_report(self, telecom_data: dict, addr_data: dict) -> PHDC:
+        """
+        Builds a case report PHDC object.
+
+        Arguments are dictionaries passed to PHDCBuilder's methods and should include
+        the arguments required by those methods. See PHDCBuilder's methods for more
+        info.
+
+        :param telecom_data: Dictionary of telecom data.
+        :param addr_data: Dictionary of address data.
+        :return: PHDC object.
+        """
+        self.builder._build_telecom(**telecom_data)
+        self.builder._build_addr(**addr_data)
         return self.builder.build()
 
     # TODO: find out if source data we will use requires building separate lab reports
-    def build_lab_report(
-        self, phone: str, use: Optional[Literal["HP", "WP", "MC"]] = None
-    ) -> PHDC:
-        self.builder._build_telecom(phone, use)
+    def build_lab_report(self, telecom_data: dict, addr_data: dict) -> PHDC:
+        """
+        Builds a lab report PHDC object.
+
+        Arguments are dictionaries passed to PHDCBuilder's methods and should include
+        the arguments required by those methods. See PHDCBuilder's methods for more
+        info.
+
+        :param telecom_data: Dictionary of telecom data.
+        :param addr_data: Dictionary of address data.
+        :return: PHDC object.
+        """
+        self.builder._build_telecom(**telecom_data)
+        self.builder._build_addr(**addr_data)
         return self.builder.build()

--- a/containers/message-parser/tests/test_phdc.py
+++ b/containers/message-parser/tests/test_phdc.py
@@ -115,8 +115,3 @@ def director_data():
 def test_director_build_case_report(director, director_data):
     case_report = director.build_case_report(**director_data)
     assert isinstance(case_report, PHDC)
-
-
-def test_director_build_lab_report(director, director_data):
-    lab_report = director.build_lab_report(**director_data)
-    assert isinstance(lab_report, PHDC)

--- a/containers/message-parser/tests/test_phdc.py
+++ b/containers/message-parser/tests/test_phdc.py
@@ -1,6 +1,18 @@
 import pytest
+from app.phdc.phdc import PHDC
 from app.phdc.phdc import PHDCBuilder
+from app.phdc.phdc import PHDCDirector
 from lxml import etree as ET
+
+
+@pytest.fixture
+def builder():
+    return PHDCBuilder()
+
+
+@pytest.fixture
+def director(builder):
+    return PHDCDirector(builder)
 
 
 @pytest.mark.parametrize(
@@ -25,8 +37,8 @@ from lxml import etree as ET
         ),
     ],
 )
-def test_build_telecom(build_telecom_test_data, expected_result):
-    xml_telecom_data = PHDCBuilder._build_telecom(**build_telecom_test_data)
+def test_build_telecom(builder, build_telecom_test_data, expected_result):
+    xml_telecom_data = builder._build_telecom(**build_telecom_test_data)
     assert ET.tostring(xml_telecom_data).decode() == expected_result
 
 
@@ -79,6 +91,32 @@ def test_build_telecom(build_telecom_test_data, expected_result):
         ),
     ],
 )
-def test_build_addr(build_addr_test_data, expected_result):
-    xml_addr_data = PHDCBuilder._build_addr(**build_addr_test_data)
+def test_build_addr(builder, build_addr_test_data, expected_result):
+    xml_addr_data = builder._build_addr(**build_addr_test_data)
     assert ET.tostring(xml_addr_data).decode() == expected_result
+
+
+@pytest.fixture
+def director_data():
+    return {
+        "telecom_data": {"phone": "+1-800-555-1234", "use": "WP"},
+        "addr_data": {
+            "use": "H",
+            "line": "123 Main Street",
+            "city": "Brooklyn",
+            "state": "New York",
+            "zip": "11205",
+            "county": "Kings",
+            "country": "USA",
+        },
+    }
+
+
+def test_director_build_case_report(director, director_data):
+    case_report = director.build_case_report(**director_data)
+    assert isinstance(case_report, PHDC)
+
+
+def test_director_build_lab_report(director, director_data):
+    lab_report = director.build_lab_report(**director_data)
+    assert isinstance(lab_report, PHDC)


### PR DESCRIPTION
# PULL REQUEST

## Summary
Add `PHDCDirector` to handle the build patterns for `PHDCBuilder`. There are two basic methods for `PHDCDirector`:

1. `build_case_report` for case report data
2. `build_lab_report` for lab report data

At present we know that the source data we're ingesting will likely be case report data, however, we still do not know if these data will require separate lab reports at this time. This method is stubbed out for now to make the director extensible but the idea is that the focus would be on the case report method until we learn more. I'm definitely interested in feedback from others if this makes sense to them or not.

## Related Issue
Fixes #1066 


## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
