### PR TITLE
Add integration tests

### DIFF
--- a/containers/message-parser/app/main.py
+++ b/containers/message-parser/app/main.py
@@ -141,6 +141,16 @@ def extract_and_apply_parsers(parsing_schema, message, response):
     return parsed_values
 
 
+@app.get("/")
+async def health_check():
+    """
+    Check service status. If an HTTP 200 status code is returned along with
+    '{"status": "OK"}' then the FHIR conversion service is available and running
+    properly.
+    """
+    return {"status": "OK"}
+
+
 @app.post("/parse_message", status_code=200, responses=parse_message_response_examples)
 async def parse_message_endpoint(
     input: Annotated[ParseMessageInput, Body(examples=parse_message_request_examples)],

--- a/containers/message-parser/requirements.txt
+++ b/containers/message-parser/requirements.txt
@@ -6,3 +6,4 @@ uvicorn
 httpx
 pytest
 frozendict
+testcontainers[compose]==3.7.1

--- a/containers/message-parser/tests/integration/conftest.py
+++ b/containers/message-parser/tests/integration/conftest.py
@@ -1,0 +1,27 @@
+import os
+
+import pytest
+from testcontainers.compose import DockerCompose
+
+
+@pytest.fixture(scope="session")
+def setup(request):
+    print("Setting up tests...")
+    compose_path = os.path.join(os.path.dirname(__file__), "./")
+    compose_file_name = "docker-compose.yaml"
+    message_parser = DockerCompose(
+        compose_path, compose_file_name=compose_file_name, build=True
+    )
+    parser_url = "http://0.0.0.0:8080"
+
+    message_parser.start()
+    message_parser.wait_for(parser_url)
+    print("Message Parser ready to test!")
+
+    def teardown():
+        print("Service logs...\n")
+        print(message_parser.get_logs())
+        print("Tests finished! Tearing down.")
+        message_parser.stop()
+
+    request.addfinalizer(teardown)

--- a/containers/message-parser/tests/integration/docker-compose.yaml
+++ b/containers/message-parser/tests/integration/docker-compose.yaml
@@ -1,0 +1,8 @@
+version: "3.3"
+
+services:
+  message-parser-service:
+    build:
+      context: ../..
+    ports:
+      - "8080:8080"

--- a/containers/message-parser/tests/integration/test_message_parser.py
+++ b/containers/message-parser/tests/integration/test_message_parser.py
@@ -1,0 +1,82 @@
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+PARSER_URL = "http://0.0.0.0:8080"
+PARSE_MESSAGE = PARSER_URL + "/parse_message"
+FHIR_TO_PHDC = PARSER_URL + "/fhir_to_phdc"
+
+
+@pytest.mark.integration
+def test_health_check(setup):
+    health_check_response = httpx.get(PARSER_URL)
+    assert health_check_response.status_code == 200
+
+
+reference_bundle_path = (
+    Path(__file__).parent.parent.parent.parent.parent
+    / "tests"
+    / "assets"
+    / "general"
+    / "patient_bundle_w_labs.json"
+)
+
+with open(reference_bundle_path, "r") as file:
+    reference_bundle = json.load(file)
+
+test_reference_schema_path = (
+    Path(__file__).parent.parent.parent
+    / "app"
+    / "default_schemas"
+    / "test_reference_schema.json"
+)
+
+with open(test_reference_schema_path, "r") as file:
+    test_reference_schema = json.load(file)
+
+
+@pytest.mark.integration
+def test_parse_message(setup):
+    expected_reference_response = {
+        "message": "Parsing succeeded!",
+        "parsed_values": {
+            "first_name": "John ",
+            "last_name": "doe",
+            "labs": [
+                {
+                    "test_type": "Blood culture",
+                    "test_result_code_display": "Staphylococcus aureus",
+                    "ordering_provider": "Western Pennsylvania Medical General",
+                    "requesting_organization_contact_person": "Dr. Totally Real Doctor, M.D.",  # noqa
+                }
+            ],
+        },
+    }
+
+    request = {
+        "message_format": "fhir",
+        "parsing_schema": test_reference_schema,
+        "message": reference_bundle,
+    }
+
+    parsing_response = httpx.post(PARSE_MESSAGE, json=request)
+
+    assert parsing_response.status_code == 200
+    assert parsing_response.json() == expected_reference_response
+
+
+@pytest.mark.integration
+def test_fhir_to_phdc(setup):
+    request = {
+        "parsing_schema": test_reference_schema,
+        "message": reference_bundle,
+    }
+
+    parsing_response = httpx.post(FHIR_TO_PHDC, json=request)
+
+    # TODO: Once the PHDC builder work is completed, this test can be
+    # developed further to check the structure and content of the
+    # generated PHDC message.
+    assert parsing_response.status_code == 200


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR adds integration tests for the message parser service. It tests out both endpoints--`parse-message` and `fhir-to-phdc`--as well as implements and test a new health check endpoint.

## Related Issue
Fixes #1088 

## Additional Information
For now, the scope of the test for `fhir-to-phdc` is to just check the status code returned by the service, since the PHDC builders aren't ready yet.
