### PR TITLE
Add `_build_custodian` method to PHDCBuilder

### DIFF
--- a/containers/message-parser/app/phdc/phdc.py
+++ b/containers/message-parser/app/phdc/phdc.py
@@ -130,5 +130,32 @@ class PHDCBuilder:
 
         return name_data
 
+    def _build_custodian(
+        id: str,
+    ):
+        """
+        Builds a `custodian` XML element for custodian data, which refers to the
+          organization from which the PHDC originates and that is in charge of
+          maintaining the document.
+
+        :param id: Custodian identifier.
+        :return: XML element of custodian data.
+        """
+        custodian_data = ET.Element("custodian")
+        assignedCustodian = ET.Element("assignedCustodian")
+        representedCustodianOrganization = ET.Element(
+            "representedCustodianOrganization"
+        )
+
+        if id is not None:
+            id_element = ET.Element("id")
+            id_element.set("extension", id)
+            representedCustodianOrganization.append(id_element)
+
+        assignedCustodian.append(representedCustodianOrganization)
+        custodian_data.append(assignedCustodian)
+
+        return custodian_data
+
     def build(self):
         return PHDC(self)

--- a/containers/message-parser/app/phdc/phdc.py
+++ b/containers/message-parser/app/phdc/phdc.py
@@ -90,6 +90,7 @@ class PHDCBuilder:
         :param given_name: String or list of strings representing given name(s),
           defaults to None.
         :param last_name: Last name, defaults to None.
+        :return: XML element of name data.
         """
         name_elements = locals()
 

--- a/containers/message-parser/app/phdc/phdc.py
+++ b/containers/message-parser/app/phdc/phdc.py
@@ -142,16 +142,18 @@ class PHDCBuilder:
         :param id: Custodian identifier.
         :return: XML element of custodian data.
         """
+        if id is None:
+            raise ValueError("The Custodian id parameter must be a defined.")
+
         custodian_data = ET.Element("custodian")
         assignedCustodian = ET.Element("assignedCustodian")
         representedCustodianOrganization = ET.Element(
             "representedCustodianOrganization"
         )
 
-        if id is not None:
-            id_element = ET.Element("id")
-            id_element.set("extension", id)
-            representedCustodianOrganization.append(id_element)
+        id_element = ET.Element("id")
+        id_element.set("extension", id)
+        representedCustodianOrganization.append(id_element)
 
         assignedCustodian.append(representedCustodianOrganization)
         custodian_data.append(assignedCustodian)

--- a/containers/message-parser/tests/test_phdc.py
+++ b/containers/message-parser/tests/test_phdc.py
@@ -159,3 +159,39 @@ def test_build_addr(build_addr_test_data, expected_result):
 def test_build_name(build_name_test_data, expected_result):
     xml_name_data = PHDCBuilder._build_name(**build_name_test_data)
     assert ET.tostring(xml_name_data).decode() == expected_result
+
+
+@pytest.mark.parametrize(
+    "build_custodian_test_data, expected_result",
+    [
+        # Success with `id`
+        (
+            {
+                "id": "TEST ID",
+            },
+            (
+                "<custodian><assignedCustodian><representedCustodianOrganization>"
+                + '<id extension="TEST ID"/></representedCustodianOrganization>'
+                + "</assignedCustodian></custodian>"
+            ),
+        ),
+        # ValueError is raised when `id` is None
+        (
+            {
+                "id": None,
+            },
+            ValueError("The Custodian id parameter must be a defined."),
+        ),
+    ],
+)
+def test_build_custodian(build_custodian_test_data, expected_result):
+    if isinstance(expected_result, ValueError):
+        with pytest.raises(ValueError) as e:
+            xml_custodian_data = PHDCBuilder._build_custodian(
+                **build_custodian_test_data
+            )
+            assert str(e.value) == str(expected_result)
+
+    else:
+        xml_custodian_data = PHDCBuilder._build_custodian(**build_custodian_test_data)
+        assert ET.tostring(xml_custodian_data).decode() == expected_result


### PR DESCRIPTION
# PULL REQUEST

## Summary
What changes are being proposed?
This PR adds an internal method for building out the custodian section of a PHDC where the only required element is `id`.

## Related Issue
Fixes #1050 

## Additional Information
Anything else the review team should know?
The custodian section can also contain other information about the custodian of the PHDC, such as address or name, but I chose to leave it out for now. 

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
