### PR TITLE
Add `_build_author` method to PHDCBuilder

### DIFF
--- a/containers/message-parser/app/phdc/phdc.py
+++ b/containers/message-parser/app/phdc/phdc.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import List
 from typing import Literal
 from typing import Union
@@ -159,6 +160,47 @@ class PHDCBuilder:
         custodian_data.append(assignedCustodian)
 
         return custodian_data
+
+    def _build_author(self, family_name: str):
+        """
+        Builds an `author` XML element for author data, which represents the
+            humans and/or machines that authored the document.
+
+            This includes the OID as per HL7 standards, the family name of
+            the author, which will be either the DIBBs project name or the
+            origin/provenance of the data we're migrating as well as the
+            creation timestamp of the document (not a parameter).
+
+        :param family_name: The DIBBs project name or source of the data being migrated.
+        :return: XML element of author data.
+        """
+        author_element = ET.Element("author")
+
+        # time element with the current timestamp
+        current_timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+        time_element = ET.Element("time")
+        time_element.set("value", current_timestamp)
+        author_element.append(time_element)
+
+        # assignedAuthor element
+        assigned_author = ET.Element("assignedAuthor")
+
+        # using the standard OID for the author
+        id_element = ET.Element("id")
+        id_element.set("root", "2.16.840.1.113883.19.5")
+        assigned_author.append(id_element)
+
+        # family name is the example way to add either a project name or source of
+        # the data being migrated
+        name_element = ET.Element("name")
+        family_element = ET.SubElement(name_element, "family")
+        family_element.text = family_name
+
+        assigned_author.append(name_element)
+
+        author_element.append(assigned_author)
+
+        return author_element
 
     def build(self):
         return PHDC(self)

--- a/containers/message-parser/tests/test_phdc.py
+++ b/containers/message-parser/tests/test_phdc.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 from app.phdc.phdc import PHDCBuilder
 from lxml import etree as ET
@@ -195,3 +197,41 @@ def test_build_custodian(build_custodian_test_data, expected_result):
     else:
         xml_custodian_data = PHDCBuilder._build_custodian(**build_custodian_test_data)
         assert ET.tostring(xml_custodian_data).decode() == expected_result
+
+
+@pytest.mark.parametrize(
+    "family_name, expected_oid, expected_date, expected_name",
+    [
+        # test for correct OID and name "CDC PRIME DIBBs"
+        (
+            "CDC PRIME DIBBs",
+            "2.16.840.1.113883.19.5",
+            datetime.now().strftime("%Y%m%d"),
+            (
+                '<author><time value="{}"/><assignedAuthor>'
+                '<id root="2.16.840.1.113883.19.5"/><name>'
+                "<family>CDC PRIME DIBBs</family></name>"
+                "</assignedAuthor></author>"
+            ).format(datetime.now().strftime("%Y%m%d%H%M%S")),
+        ),
+        # test for correct OID and name "Local Health Jurisdiction"
+        (
+            "Local Health Jurisdiction",
+            "2.16.840.1.113883.19.5",
+            datetime.now().strftime("%Y%m%d"),
+            (
+                '<author><time value="{}"/><assignedAuthor>'
+                '<id root="2.16.840.1.113883.19.5"/><name>'
+                "<family>Local Health Jurisdiction</family></name>"
+                "</assignedAuthor></author>"
+            ).format(datetime.now().strftime("%Y%m%d%H%M%S")),
+        ),
+    ],
+)
+def test_build_author(family_name, expected_oid, expected_date, expected_name):
+    xml_author_data = PHDCBuilder()._build_author(family_name)
+    author_string = ET.tostring(xml_author_data).decode()
+
+    assert expected_oid in author_string
+    assert expected_date in author_string
+    assert expected_name in author_string


### PR DESCRIPTION
# PULL REQUEST

## Summary
Adding the `_build_author` method to the `PHDCBuilder` class. Based on our test PHDC files the family name is used to get legacy data migrated into NBS; upon clarification from our partners my hunch is that we'll either use our name in author or the source of the data being migrated. `_build_author` will handle the rest; using the OID id for this section and adding a timestamp for when the document was created.

## Related Issue
Fixes #1056 

## Additional Information
Can review more about the OID structure for [2.16.840.1.113883](https://oidref.com/2.16.840.1.113883) by checking the reference.

[//]: # (PR title: Remember to name your PR descriptively!)
