### PR TITLE
Add remaining fields, example data

### DIFF
--- a/containers/message-parser/app/default_schemas/demo_phdc.json
+++ b/containers/message-parser/app/default_schemas/demo_phdc.json
@@ -138,12 +138,12 @@
         "data_type": "string",
         "nullable": true
       },
-      "usable_period_low": {
+      "useable_period_low": {
         "fhir_path": "ContactPoint.period.start",
         "data_type": "string",
         "nullable": true
       },
-      "usable_period_high": {
+      "useable_period_high": {
         "fhir_path": "ContactPoint.period.end",
         "data_type": "string",
         "nullable": true

--- a/containers/message-parser/app/default_schemas/demo_phdc.json
+++ b/containers/message-parser/app/default_schemas/demo_phdc.json
@@ -122,5 +122,187 @@
     "fhir_path": "Bundle.entry.resource.where(resourceType = 'Patient').birthDate",
     "data_type": "date",
     "nullable": true
+  },
+  "patient_telecom": {
+    "fhir_path": "Bundle.entry.resource.where(resourceType = 'Patient').telecom",
+    "data_type": "array",
+    "nullable": true,
+    "secondary_schema": {
+      "value": {
+        "fhir_path": "ContactPoint.value",
+        "data_type": "string",
+        "nullable": true
+      },
+      "type": {
+        "fhir_path": "ContactPoint.use",
+        "data_type": "string",
+        "nullable": true
+      },
+      "usable_period_low": {
+        "fhir_path": "ContactPoint.period.start",
+        "data_type": "string",
+        "nullable": true
+      },
+      "usable_period_high": {
+        "fhir_path": "ContactPoint.period.end",
+        "data_type": "string",
+        "nullable": true
+      }
+    }
+  },
+  "author_time": {
+    "fhir_path": "Bundle.entry.resource.where(resourceType = 'Composition').date",
+    "data_type": "datetime",
+    "nullable": true
+  },
+  "author_assigned_person": {
+    "fhir_path": "Bundle.entry.resource.where(resourceType = 'Composition')",
+    "data_type": "array",
+    "nullable": true,
+    "secondary_schema": {
+      "prefix": {
+        "fhir_path": "Bundle.entry.resource.where(resourceType = 'Practitioner').where(id = '#REF#').name.first().prefix[0]",
+        "reference_lookup": "Composition.author.first().reference",
+        "data_type": "string",
+        "nullable": true
+      },
+      "first": {
+        "fhir_path": "Bundle.entry.resource.where(resourceType = 'Practitioner').where(id = '#REF#').name.first().given[0]",
+        "reference_lookup": "Composition.author.first().reference",
+        "data_type": "string",
+        "nullable": true
+      },
+      "middle": {
+        "fhir_path": "Bundle.entry.resource.where(resourceType = 'Practitioner').where(id = '#REF#').name.first().given[1]",
+        "reference_lookup": "Composition.author.first().reference",
+        "data_type": "string",
+        "nullable": true
+      },
+      "family": {
+        "fhir_path": "Bundle.entry.resource.where(resourceType = 'Practitioner').where(id = '#REF#').name.first().family",
+        "reference_lookup": "Composition.author.first().reference",
+        "data_type": "string",
+        "nullable": true
+      },
+      "suffix": {
+        "fhir_path": "Bundle.entry.resource.where(resourceType = 'Practitioner').where(id = '#REF#').name.first().suffix",
+        "reference_lookup": "Composition.author.first().reference",
+        "data_type": "string",
+        "nullable": true
+      }
+    }
+  },
+  "custodian_represented_custodian_organization": {
+    "fhir_path": "Bundle.entry.resource.where(resourceType = 'Composition')",
+    "data_type": "struct",
+    "nullable": true,
+    "secondary_schema": {
+      "name": {
+        "fhir_path": "Bundle.entry.resource.where(resourceType = 'Organization').where(id = '#REF#').name",
+        "reference_lookup": "Composition.custodian.reference",
+        "data_type": "string",
+        "nullable": true
+      },
+      "phone": {
+        "fhir_path": "Bundle.entry.resource.where(resourceType = 'Organization').where(id = '#REF#').contact.telecom.where(system = 'phone').value",
+        "reference_lookup": "Composition.custodian.reference",
+        "data_type": "string",
+        "nullable": true
+      },
+      "street_address_line_1": {
+        "fhir_path": "Bundle.entry.resource.where(resourceType = 'Organization').where(id = '#REF#').contact.address[0].line[0]",
+        "reference_lookup": "Composition.custodian.reference",
+        "data_type": "string",
+        "nullable": true
+      },
+      "street_address_line_2": {
+        "fhir_path": "Bundle.entry.resource.where(resourceType = 'Organization').where(id = '#REF#').contact.address[0].line[1]",
+        "reference_lookup": "Composition.custodian.reference",
+        "data_type": "string",
+        "nullable": true
+      },
+      "city": {
+        "fhir_path": "Bundle.entry.resource.where(resourceType = 'Organization').where(id = '#REF#').contact.address[0].city",
+        "reference_lookup": "Composition.custodian.reference",
+        "data_type": "string",
+        "nullable": true
+      },
+      "state": {
+        "fhir_path": "Bundle.entry.resource.where(resourceType = 'Organization').where(id = '#REF#').contact.address[0].state",
+        "reference_lookup": "Composition.custodian.reference",
+        "data_type": "string",
+        "nullable": true
+      },
+      "postal_code": {
+        "fhir_path": "Bundle.entry.resource.where(resourceType = 'Organization').where(id = '#REF#').contact.address[0].postalCode",
+        "reference_lookup": "Composition.custodian.reference",
+        "data_type": "string",
+        "nullable": true
+      },
+      "county": {
+        "fhir_path": "Bundle.entry.resource.where(resourceType = 'Organization').where(id = '#REF#').contact.address[0].district",
+        "reference_lookup": "Composition.custodian.reference",
+        "data_type": "string",
+        "nullable": true
+      },
+      "country": {
+        "fhir_path": "Bundle.entry.resource.where(resourceType = 'Organization').where(id = '#REF#').contact.address[0].country",
+        "reference_lookup": "Composition.custodian.reference",
+        "data_type": "string",
+        "nullable": true
+      }
+    }
+  },
+  "clinical_information_observations": {
+    "fhir_path": "Bundle.entry.resource.where(resourceType='Observation')",
+    "data_type": "array",
+    "nullable": true,
+    "secondary_schema": {
+      "code": {
+        "fhir_path": "Observation.code.coding.code",
+        "data_type": "string",
+        "nullable": true
+      },
+      "code_system": {
+        "fhir_path": "Observation.code.coding.system",
+        "data_type": "string",
+        "nullable": true
+      },
+      "code_display": {
+        "fhir_path": "Observation.code.coding.display",
+        "data_type": "string",
+        "nullable": true
+      },
+      "quantitative_value": {
+        "fhir_path": "Observation.valueQuantity.value",
+        "data_type": "float",
+        "nullable": true
+      },
+      "quantitative_system": {
+        "fhir_path": "Observation.valueQuantity.system",
+        "data_type": "string",
+        "nullable": true
+      },
+      "quantitative_code": {
+        "fhir_path": "Observation.valueQuantity.code",
+        "data_type": "string",
+        "nullable": true
+      },
+      "qualitative_value": {
+        "fhir_path": "Observation.valueCodeableConcept.coding[0].display",
+        "data_type": "string",
+        "nullable": true
+      },
+      "qualitative_system": {
+        "fhir_path": "Observation.valueCodeableConcept.coding[0].system",
+        "data_type": "string",
+        "nullable": true
+      },
+      "qualitative_code": {
+        "fhir_path": "Observation.valueCodeableConcept.coding[0].code",
+        "data_type": "string",
+        "nullable": true
+      }
+    }
   }
 }

--- a/containers/message-parser/app/main.py
+++ b/containers/message-parser/app/main.py
@@ -81,9 +81,21 @@ def extract_and_apply_parsers(parsing_schema, message, response):
         # Use the secondary field data structure, remembering that some
         # fhir paths might not be compiled yet
         else:
-            inital_values = parser["primary_parser"](message)
+            initial_values = parser["primary_parser"](message)
             values = []
-            for initial_value in inital_values:
+
+            # This check allows us to use secondary schemas on fields that
+            # are just datatype structs, rather than full arrays. This is
+            # useful when we want multiple fields of information from a
+            # referenced resource, but there's only one instance of the
+            # resource type referencing another resource in the bundle
+            # (e.g. we want multiple values about the Bundle's Custodian:
+            # bundle.custodian is a dict with a reference, so we only need
+            # to find that reference once)
+            if type(initial_values) is not list:
+                initial_values = [initial_values]
+
+            for initial_value in initial_values:
                 value = {}
                 for secondary_field, path_struct in parser["secondary_parsers"].items():
                     # Base cases for a secondary field:
@@ -152,13 +164,7 @@ def extract_and_apply_parsers(parsing_schema, message, response):
                             reference_path = fhirpathpy.compile(reference_path)
                             referenced_value = reference_path(message)
                             if len(referenced_value) == 0:
-                                response.status_code = status.HTTP_400_BAD_REQUEST
-                                return {
-                                    "message": "Provided bundle does not contain a "
-                                    "resource matching reference criteria defined "
-                                    "in schema",
-                                    "parsed_values": {},
-                                }
+                                value[secondary_field] = None
                             else:
                                 value[secondary_field] = ",".join(
                                     map(str, referenced_value)

--- a/containers/message-parser/app/models.py
+++ b/containers/message-parser/app/models.py
@@ -8,7 +8,7 @@ from pydantic import Field
 from pydantic import root_validator
 
 PARSING_SCHEMA_DATA_TYPES = Literal[
-    "string", "integer", "float", "boolean", "date", "datetime", "array"
+    "string", "integer", "float", "boolean", "date", "datetime", "array", "struct"
 ]
 
 

--- a/containers/message-parser/assets/demo_phdc_conversion_bundle.json
+++ b/containers/message-parser/assets/demo_phdc_conversion_bundle.json
@@ -4,18 +4,81 @@
   "meta": {
     "lastUpdated": "2022-06-07T14:13:02.511737+00:00"
   },
-  "type": "searchset",
-  "link": [
+  "type": "batch",
+  "entry": [
     {
-      "relation": "next",
-      "url": "https://phdi-pilot.azurehealthcareapis.com/Patient?ct=LJPRbttGEEX%2FhXpUAtsqo6IE8nBmuaTWNE1LFC1viz4ogTJWA3mj1LKspsmP5SGflF8oxihfFlwMZ%2B49c%2Fnz%2B4%2Bnyb9%2FfMke08fNQ1Zk40Uoi2%2B3r33NTTym4RjkyP%2FP27ejxbK4GC0Xrrg4H4X%2BtpiMgu%2BK6Zs3019H1Y0rUA9zadHtbBZlqXJAEjuVLTHRqjTUdu88RP5WObFOBPUnXKRRDoScpcqGq4RXt6XOedKy4TrKPej8Khen5Z55xFv9LEmp4gi53BMc14mobmr3zwTcZU5Sd%2BAq56RVwKFz3J4%2BSqeMIfGXlj1NZKucCIn3Nm84UuEgYDrHXOZc2bkM9FbfzkGXjlYdHuUuyKB0tIEbdTvqyM50hEgyP5c5By2nXEce1e2ZBT5YnY9ELcfms9XS40VqrWok8lmZ0gVU%2FY4QeFJqysBEy5r3iV7Z44K8Uz9lljO270v4ZHzaRFLf0yRO6k7USbzpayK%2FaXnA55xre5J5Qo7eGZ%2BJzhp8YqFs7P13lZ2dS3W19bk1vZK4V%2BlY5Hw0Hz5yZ3WzKAvj2ZsOvzL%2Fvyg7hjlByxNDLqJuQx%2BN45TeeEnDdTAuY6tjKDvb%2Bz8qa%2BrExUvfnFzrseWjVj%2BmetHzkpcPNr%2FNEZWam8QzeLnM2dh8n3iwebOcZ%2BPYBKmViel71Gpv%2FTF%2BbWBtex3m%2BOA83osqjjLJzHxXya2031v%2BzpW16Rssbz7g1K2Nz72yMi6PWvfme2X6u8inF32BWvEDsrKdRmVrWb3TruWsOzsDXPYq%2B7x%2B0E1WfMl2W%2FsRs1fZbv2cFVlVZV%2B%2F%2FvkfAAAA%2F%2F8%3D"
+      "fullUrl": "https://phdi-pilot.azurehealthcareapis.com/Composition/40234gi0-16h5-ffdf-n18d-d93jbn19dajj",
+      "resource": {
+        "resourceType": "Composition",
+        "id": "40234gi0-16h5-ffdf-n18d-d93jbn19dajj",
+        "status": "registered",
+        "type": {
+          "coding": {
+            "system": "https://loinc.org",
+            "code": "100459-7",
+            "display": "Summary"
+          },
+          "text": "Patient COVID summary"
+        },
+        "date": "2022-08-08",
+        "author": [
+          {
+            "reference": "Practitioner/3nf82nby-js82-xnxw-1j39-js8143gzvs",
+            "type": "Practitioner"
+          }
+        ],
+        "custodian": {
+          "reference": "Organization/org800201",
+          "type": "Organization"
+        }
+      }
     },
     {
-      "relation": "self",
-      "url": "https://phdi-pilot.azurehealthcareapis.com/Patient"
-    }
-  ],
-  "entry": [
+      "fullUrl": "https://phdi-pilot.azurehealthcareapis.com/Organization/org800201",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "org800201",
+        "name": "Sunny Vale",
+        "contact": {
+          "telecom": [
+            {
+              "system": "phone",
+              "value": "999-999-9999"
+            }
+          ],
+          "address": [
+            {
+              "line": [
+                "999 North Ridge Road",
+                "Building 3"
+              ],
+              "city": "Amherst",
+              "state": "Massachusetts",
+              "district": "Duvall",
+              "postalCode": "33721"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "",
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "3nf82nby-js82-xnxw-1j39-js8143gzvs",
+        "name": [
+          {
+            "prefix": "Doctor",
+            "given": [
+              "Charles",
+              "Macintyre-Downing"
+            ],
+            "family": "Britishmun",
+            "suffix": "III"
+          }
+        ]
+      }
+    },
     {
       "fullUrl": "https://phdi-pilot.azurehealthcareapis.com/Patient/907844f6-7c99-eabc-f68e-d92189729a55",
       "resource": {
@@ -144,7 +207,23 @@
           {
             "system": "phone",
             "value": "555-690-3898",
-            "use": "home"
+            "use": "home",
+            "period": {
+              "start": "2004-01-01",
+              "end": "2010-02-02"
+            }
+          },
+          {
+            "system": "phone",
+            "value": "863-507-9999",
+            "use": "mobile",
+            "period": {
+              "start": "2008-03-18"
+            }
+          },
+          {
+            "system": "email",
+            "value": "kp73@gmail.com"
           }
         ],
         "gender": "female",
@@ -206,6 +285,123 @@
       },
       "search": {
         "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://phdi-pilot.azurehealthcareapis.com/Observation/f001",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "f001",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: Observation</b><a name=\"f001\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;f001&quot; </p></div><p><b>identifier</b>: id:\u00a06323\u00a0(use:\u00a0OFFICIAL)</p><p><b>status</b>: final</p><p><b>code</b>: Glucose [Moles/volume] in Blood <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#15074-8)</span></p><p><b>subject</b>: <a href=\"patient-example-f001-pieter.html\">Patient/f001: P. van de Heuvel</a> &quot;Pieter VAN DE HEUVEL&quot;</p><p><b>effective</b>: 2013-04-02T09:30:10+01:00</p><p><b>issued</b>: Apr 3, 2013, 2:30:10 PM</p><p><b>performer</b>: <a href=\"practitioner-example-f005-al.html\">Practitioner/f005: A. Langeveld</a> &quot;Langeveld ANNE&quot;</p><p><b>value</b>: 6.3 mmol/l<span style=\"background: LightGoldenRodYellow\"> (Details: UCUM code mmol/L = 'mmol/L')</span></p><p><b>interpretation</b>: High <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.4.0/CodeSystem-v3-ObservationInterpretation.html\">ObservationInterpretation</a>#H)</span></p><h3>ReferenceRanges</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Low</b></td><td><b>High</b></td></tr><tr><td style=\"display: none\">*</td><td>3.1 mmol/l<span style=\"background: LightGoldenRodYellow\"> (Details: UCUM code mmol/L = 'mmol/L')</span></td><td>6.2 mmol/l<span style=\"background: LightGoldenRodYellow\"> (Details: UCUM code mmol/L = 'mmol/L')</span></td></tr></table></div>"
+        },
+        "identifier": [
+          {
+            "use": "official",
+            "system": "http://www.bmc.nl/zorgportal/identifiers/observations",
+            "value": "6323"
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "15074-8",
+              "display": "Glucose [Moles/volume] in Blood"
+            }
+          ]
+        },
+        "effectiveDateTime": "2013-04-02T09:30:10+01:00",
+        "issued": "2013-04-03T15:30:10+01:00",
+        "valueQuantity": {
+          "value": 6.3,
+          "unit": "mmol/l",
+          "system": "http://unitsofmeasure.org",
+          "code": "mmol/L"
+        },
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                "code": "H",
+                "display": "High"
+              }
+            ]
+          }
+        ],
+        "referenceRange": [
+          {
+            "low": {
+              "value": 3.1,
+              "unit": "mmol/l",
+              "system": "http://unitsofmeasure.org",
+              "code": "mmol/L"
+            },
+            "high": {
+              "value": 6.2,
+              "unit": "mmol/l",
+              "system": "http://unitsofmeasure.org",
+              "code": "mmol/L"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "https://phdi-pilot.azurehealthcareapis.com/Observation/f206",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "f206",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: Observation</b><a name=\"f206\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;f206&quot; </p></div><p><b>status</b>: final</p><p><b>code</b>: Blood culture <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (acmelabs.org#104177; <a href=\"https://loinc.org/\">LOINC</a>#600-7 &quot;Bacteria identified in Blood by Culture&quot;)</span></p><p><b>subject</b>: <span title=\"  No identifier could be provided to this observation  \"><a href=\"patient-example-f201-roel.html\">Patient/f201: Roel</a> &quot;Roel&quot;</span></p><p><b>issued</b>: Mar 11, 2013, 9:28:00 AM</p><p><b>performer</b>: <a href=\"practitioner-example-f202-lm.html\">Practitioner/f202: Luigi Maas</a> &quot;Luigi Maas&quot;</p><p><b>value</b>: Staphylococcus aureus <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT</a>#3092008)</span></p><p><b>interpretation</b>: Positive <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.4.0/CodeSystem-v3-ObservationInterpretation.html\">ObservationInterpretation</a>#POS)</span></p><p><b>method</b>: <span title=\"  BodySite not relevant  \">Blood culture for bacteria, including anaerobic screen <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT</a>#104177005)</span></span></p></div>"
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://acmelabs.org",
+              "code": "104177",
+              "display": "Blood culture"
+            },
+            {
+              "system": "http://loinc.org",
+              "code": "600-7",
+              "display": "Bacteria identified in Blood by Culture"
+            }
+          ]
+        },
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "3092008",
+              "display": "Staphylococcus aureus"
+            }
+          ]
+        },
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                "code": "POS"
+              }
+            ]
+          }
+        ],
+        "method": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "104177005",
+              "display": "Blood culture for bacteria, including anaerobic screen"
+            }
+          ]
+        }
       }
     }
   ]

--- a/containers/message-parser/tests/integration/test_message_parser.py
+++ b/containers/message-parser/tests/integration/test_message_parser.py
@@ -75,6 +75,73 @@ def test_parse_message(setup):
             "patient_race_code": None,
             "patient_ethnic_group_code": None,
             "patient_birth_time": "1996-04-17",
+            "patient_telecom": [
+                {
+                    "value": "555-690-3898",
+                    "type": "home",
+                    "useable_period_low": "2004-01-01",
+                    "useable_period_high": "2010-02-02",
+                },
+                {
+                    "value": "863-507-9999",
+                    "type": "mobile",
+                    "useable_period_low": "2008-03-18",
+                    "useable_period_high": None,
+                },
+                {
+                    "value": "kp73@gmail.com",
+                    "type": None,
+                    "useable_period_low": None,
+                    "useable_period_high": None,
+                },
+            ],
+            "author_time": "2022-08-08",
+            "author_assigned_person": [
+                {
+                    "author_assigned_person_prefix": "Doctor",
+                    "author_assigned_person_first": "Charles",
+                    "author_assigned_person_middle": "Macintyre-Downing",
+                    "author_assigned_person_family": "Britishmun",
+                    "author_assigned_person_suffix": "III",
+                }
+            ],
+            "custodian_represented_custodian_organization": [
+                {
+                    "name": "Sunny Vale",
+                    "phone": "999-999-9999",
+                    "street_address_line_1": "999 North Ridge Road",
+                    "street_address_line_2": "Building 3",
+                    "city": "Amherst",
+                    "state": "Massachusetts",
+                    "postal_code": None,
+                    "county": "Duvall",
+                    "country": None,
+                }
+            ],
+            "clinical_information_observations": [
+                {
+                    "code": "15074-8",
+                    "code_system": "http://loinc.org",
+                    "code_display": "Glucose [Moles/volume] in Blood",
+                    "quantitative_value": "6.3",
+                    "quantitative_system": "http://unitsofmeasure.org",
+                    "quantitative_code": "mmol/L",
+                    "qualitative_value": None,
+                    "qualitative_system": None,
+                    "qualitative_code": None,
+                },
+                {
+                    "code": "104177,600-7",
+                    "code_system": "http://acmelabs.org,http://loinc.org",
+                    "code_display": "Blood culture,Bacteria identified in Blood by Culture",  # noqa
+                    "quantitative_value": None,
+                    "quantitative_system": None,
+                    "quantitative_code": None,
+                    "qualitative_value": "Staphylococcus aureus",
+                    "qualitative_system": "http://snomed.info/sct",
+                    "qualitative_code": "3092008",
+                },
+            ],
         },
     }
 

--- a/containers/message-parser/tests/integration/test_message_parser.py
+++ b/containers/message-parser/tests/integration/test_message_parser.py
@@ -113,7 +113,7 @@ def test_parse_message(setup):
                     "street_address_line_2": "Building 3",
                     "city": "Amherst",
                     "state": "Massachusetts",
-                    "postal_code": 33721,
+                    "postal_code": "33721",
                     "county": "Duvall",
                     "country": None,
                 }

--- a/containers/message-parser/tests/integration/test_message_parser.py
+++ b/containers/message-parser/tests/integration/test_message_parser.py
@@ -98,11 +98,11 @@ def test_parse_message(setup):
             "author_time": "2022-08-08",
             "author_assigned_person": [
                 {
-                    "author_assigned_person_prefix": "Doctor",
-                    "author_assigned_person_first": "Charles",
-                    "author_assigned_person_middle": "Macintyre-Downing",
-                    "author_assigned_person_family": "Britishmun",
-                    "author_assigned_person_suffix": "III",
+                    "prefix": "Doctor",
+                    "first": "Charles",
+                    "middle": "Macintyre-Downing",
+                    "family": "Britishmun",
+                    "suffix": "III",
                 }
             ],
             "custodian_represented_custodian_organization": [

--- a/containers/message-parser/tests/integration/test_message_parser.py
+++ b/containers/message-parser/tests/integration/test_message_parser.py
@@ -113,7 +113,7 @@ def test_parse_message(setup):
                     "street_address_line_2": "Building 3",
                     "city": "Amherst",
                     "state": "Massachusetts",
-                    "postal_code": None,
+                    "postal_code": 33721,
                     "county": "Duvall",
                     "country": None,
                 }


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR adds the rest of the fields for the PHDC schema specified [here](https://github.com/CDCgov/phdi/issues/1020). The sample data file is also expanded to showcase this new retrieval. We now have the full range of data type accessors, referenced resources, secondary schemas, and some additional flattening. 

## Additional Information
Two changes had to get made in main for this work:
1. we now type control the initial values for schema fields that rely on a secondary schema; checking if they're a list (and casting them if they're not) allows us to pull out information from non-array fields without duplicative retrieval
2. had to remove an error message if the fully built and compiled reference path returns an empty list, because this wasn't accounting for the possibility that one or more fields on the secondary referenced resource might not be present or have the desired information; e.g., for the extraction of the custodian organization's address, if street address line 2 doesn't exist, the whole process will fail. This is now no longer the case, and we just set this value to null as with all the other missing fields we encounter.