### PR TITLE
Adding Observation and generic CodedElement

### DIFF
--- a/containers/message-parser/app/phdc/builder.py
+++ b/containers/message-parser/app/phdc/builder.py
@@ -5,7 +5,9 @@ from typing import Optional
 
 from app import utils
 from app.phdc.models import Address
+from app.phdc.models import CodedElement
 from app.phdc.models import Name
+from app.phdc.models import Observation
 from app.phdc.models import Patient
 from app.phdc.models import PHDCInputData
 from app.phdc.models import Telecom
@@ -211,6 +213,55 @@ class PHDCBuilder:
             e = ET.Element(field_name)
             e.text = data
             parent_element.append(e)
+
+    def _add_coded_elements(
+        self, parent_element: ET.Element, elements: List[CodedElement], tag: str
+    ):
+        """
+        Adds multiple coded elements as child elements to a parent XML element.
+        Each coded element is added with a specified tag and attributes derived
+        from the properties of the CodedElement object.
+
+        This method is used to create and append XML elements with attributes,
+        such as 'xsi:type', 'code', 'codeSystem', 'codeSystemName', and 'displayName',
+        which are common in coded XML structures.
+
+        :param parent_element: The parent element to add the child element to.
+        :param elements: A list of CodedElement objects to be added as child elements.
+        :param tag: The tag name to be used for each created child element.
+        """
+        for element in elements:
+            if element is not None:
+                # Filter out None values from attributes
+                attrib = element.to_attributes()
+                # Replace 'display_name' with 'displayName'
+                attrib = {k: v for k, v in attrib.items() if v is not None}
+                ET.SubElement(parent_element, tag, attrib)
+
+    def _build_observation_method(self, observation: Observation) -> ET.Element:
+        # Create the 'entry' element
+        entry_data = ET.Element("entry", attrib={"typeCode": observation.type_code})
+
+        # Create the 'observation' element and append it to 'entry'
+        observation_data = ET.SubElement(
+            entry_data,
+            "observation",
+            {"classCode": observation.class_code, "moodCode": observation.mood_code},
+        )
+        # Add 'code' elements
+        if observation.code:
+            self._add_coded_elements(observation_data, observation.code, "code")
+
+        # Add 'value' elements
+        if observation.value:
+            v = self._add_coded_elements(observation_data, observation.value, "value")
+        # Add 'translation' elements to value
+        if observation.translation:
+            self._add_coded_elements(v, observation.translation, "translation")
+
+        print(ET.tostring(entry_data, encoding="unicode"))
+
+        return entry_data
 
     def _build_addr(
         self,

--- a/containers/message-parser/app/phdc/builder.py
+++ b/containers/message-parser/app/phdc/builder.py
@@ -239,6 +239,13 @@ class PHDCBuilder:
                 ET.SubElement(parent_element, tag, attrib)
 
     def _build_observation_method(self, observation: Observation) -> ET.Element:
+        """
+        Creates Entry XML element for observation data.
+
+        :param observation: The data for building the observation element as an
+          Entry object.
+        :return entry_data: XML element of Entry data
+        """
         # Create the 'entry' element
         entry_data = ET.Element("entry", attrib={"typeCode": observation.type_code})
 

--- a/containers/message-parser/app/phdc/models.py
+++ b/containers/message-parser/app/phdc/models.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Dict
 from typing import List
 from typing import Optional
 
@@ -46,6 +47,36 @@ class Patient:
     race_code: Optional[str] = None
     ethnic_group_code: Optional[str] = None
     birth_time: Optional[str] = None
+
+
+@dataclass
+class CodedElement:
+    xsi_type: Optional[str] = None
+    code: Optional[str] = None
+    code_system: Optional[str] = None
+    code_system_name: Optional[str] = None
+    display_name: Optional[str] = None
+
+    def to_attributes(self) -> Dict[str, str]:
+        # Create a dictionary with XML attribute names
+        attrib = {
+            "xsi:type": self.xsi_type,
+            "code": self.code,
+            "codeSystem": self.code_system,
+            "codeSystemName": self.code_system_name,
+            "displayName": self.display_name,
+        }
+        return attrib
+
+
+@dataclass
+class Observation:
+    type_code: Optional[str] = None
+    class_code: Optional[str] = None
+    mood_code: Optional[str] = None
+    code: List[CodedElement] = None
+    value: List[CodedElement] = None
+    translation: List[CodedElement] = None
 
 
 @dataclass


### PR DESCRIPTION
# PULL REQUEST

## Summary
Adds Observations to enhance the ClinicalInformation section.

## Related Issue
Fixes #1146 

## Additional Information
the `xsi:type` code caused me a lot of grief; I ended up suppressing this; is there a better way we should handle the fact that the xmlns is created earlier in the document as we develop tests that might use this `xsi:type` logic?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
