### PR TITLE
Add `<title>` to `build_header()`

### DIFF
--- a/containers/message-parser/app/phdc/builder.py
+++ b/containers/message-parser/app/phdc/builder.py
@@ -148,6 +148,16 @@ class PHDCBuilder:
         code.set("displayName", "Public Health Case Report - PHRI")
         return code
 
+    def _get_title(self):
+        """
+        Returns the title element of the PHDC header.
+        """
+        title = ET.Element("title")
+        title.text = (
+            "Public Health Case Report - Data from the DIBBs FHIR to PHDC Converter"
+        )
+        return title
+
     def build_header(self):
         """
         Builds the header of the PHDC document.
@@ -156,6 +166,7 @@ class PHDCBuilder:
         root.append(self._get_type_id())
         root.append(self._get_id())
         root.append(self._get_case_report_code())
+        root.append(self._get_title())
         root.append(self._get_effective_time())
         root.append(self._get_confidentiality_code(confidentiality="normal"))
 

--- a/containers/message-parser/assets/demo_phdc.xml
+++ b/containers/message-parser/assets/demo_phdc.xml
@@ -4,6 +4,7 @@
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000020"/>
   <id root="2.16.840.1.113883.19" extension="495669c7-96bf-4573-9dd8-59e745e05576"/>
   <code code="55751-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Public Health Case Report - PHRI"/>
+  <title>Public Health Case Report - Data from the DIBBs FHIR to PHDC Converter</title>
   <effectiveTime value="20101215000000"/>
   <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
   <custodian>

--- a/containers/message-parser/assets/sample_phdc.xml
+++ b/containers/message-parser/assets/sample_phdc.xml
@@ -4,6 +4,7 @@
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000020"/>
   <id root="2.16.840.1.113883.19" extension="mocked-uuid"/>
   <code code="55751-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Public Health Case Report - PHRI"/>
+  <title>Public Health Case Report - Data from the DIBBs FHIR to PHDC Converter</title>
   <effectiveTime value="20101215000000"/>
   <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
   <custodian>

--- a/containers/message-parser/assets/sample_phdc_header.xml
+++ b/containers/message-parser/assets/sample_phdc_header.xml
@@ -4,6 +4,7 @@
   <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000020"/>
   <id root="2.16.840.1.113883.19" extension="mocked-uuid"/>
   <code code="55751-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Public Health Case Report - PHRI"/>
+  <title>Public Health Case Report - Data from the DIBBs FHIR to PHDC Converter</title>
   <effectiveTime value="20101215000000"/>
   <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
   <custodian>


### PR DESCRIPTION
# PULL REQUEST

## Summary
Add `<title>` to the PHDC header's `build_header()` method. This value is hard-coded to: `"Public Health Case Report - Data from the DIBBs FHIR to PHDC Converter"`. This adds a minimum level of provenance to the PHDC creation process, as it denotes that the data was processed via the FHIR to PHDC Converter endpoint.

## Related Issue
Fixes #1160 
