### PR TITLE
Update workflows to release ecr-viewer container image

### DIFF
--- a/.github/workflows/buildContainers.yaml
+++ b/.github/workflows/buildContainers.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        container-to-build: ${{fromJson(needs.list-containers.outputs.containers)}}
+        container-to-build: ${{fromJson(needs.list-containers.outputs.all-containers)}}
     steps:
       - name: Check Out Changes
         uses: actions/checkout@v3

--- a/.github/workflows/buildReleaseContainers.yaml
+++ b/.github/workflows/buildReleaseContainers.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        container-to-build: ${{fromJson(needs.list-containers.outputs.containers)}}
+        container-to-build: ${{fromJson(needs.list-containers.outputs.all-containers)}}
     permissions:
       contents: "read"
       id-token: "write"

--- a/.github/workflows/buildReleaseContainers.yaml
+++ b/.github/workflows/buildReleaseContainers.yaml
@@ -26,15 +26,17 @@ jobs:
     #   contents: "read"
     #   id-token: "write"
     #   packages: "write"
-    # steps:
-    #   - name: Check Out Changes
-    #     uses: actions/checkout@v3
-    #     with:
-    #       fetch-depth: 0
-    #       ref: ${{ inputs.container-tag }}
+    steps:
+      - name: Check Out Changes
+        uses: actions/checkout@v3
 
-    #   - name: Set up Docker Buildx
-    #     uses: docker/setup-buildx-action@v2
+      - name: Print container list
+        run: |
+          echo "Containers List: "
+          echo ${{matrix.container-to-build}}
+
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v2
 
     #   - name: Log in to the Container registry
     #     uses: docker/login-action@v2

--- a/.github/workflows/buildReleaseContainers.yaml
+++ b/.github/workflows/buildReleaseContainers.yaml
@@ -7,10 +7,10 @@ on:
         type: string
         required: true
   workflow_dispatch:
-    inputs:
-      container-tag:
-        type: string
-        required: true
+    # inputs:
+    #   container-tag:
+    #     type: string
+    #     required: true
 
 jobs:
   list-containers:
@@ -22,53 +22,53 @@ jobs:
     strategy:
       matrix:
         container-to-build: ${{fromJson(needs.list-containers.outputs.containers)}}
-    permissions:
-      contents: "read"
-      id-token: "write"
-      packages: "write"
-    steps:
-      - name: Check Out Changes
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          ref: ${{ inputs.container-tag }}
+    # permissions:
+    #   contents: "read"
+    #   id-token: "write"
+    #   packages: "write"
+    # steps:
+    #   - name: Check Out Changes
+    #     uses: actions/checkout@v3
+    #     with:
+    #       fetch-depth: 0
+    #       ref: ${{ inputs.container-tag }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+    #   - name: Set up Docker Buildx
+    #     uses: docker/setup-buildx-action@v2
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+    #   - name: Log in to the Container registry
+    #     uses: docker/login-action@v2
+    #     with:
+    #       registry: ghcr.io
+    #       username: ${{ github.actor }}
+    #       password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          ref: ${{ inputs.container-tag }}
-          images: ghcr.io/${{ github.repository }}/${{matrix.container-to-build}}
-          # this sets the version for tags and labels for each of the containers to be
-          # be the same as the version/tag where the code was pulled from
-          tags: |
-            type=semver,pattern={{raw}},value=${{ inputs.container-tag }}
-            type=ref,event=branch
-            type=ref,event=tag,pattern={{raw}},value=${{ inputs.container-tag }}
-          labels: |
-            org.opencontainers.image.version=${{ inputs.container-tag }}
+    #   - name: Extract metadata (tags, labels) for Docker
+    #     id: meta
+    #     uses: docker/metadata-action@v4
+    #     with:
+    #       ref: ${{ inputs.container-tag }}
+    #       images: ghcr.io/${{ github.repository }}/${{matrix.container-to-build}}
+    #       # this sets the version for tags and labels for each of the containers to be
+    #       # be the same as the version/tag where the code was pulled from
+    #       tags: |
+    #         type=semver,pattern={{raw}},value=${{ inputs.container-tag }}
+    #         type=ref,event=branch
+    #         type=ref,event=tag,pattern={{raw}},value=${{ inputs.container-tag }}
+    #       labels: |
+    #         org.opencontainers.image.version=${{ inputs.container-tag }}
 
-      - name: Target phdi release in requirements.txt
-        working-directory: ./containers/${{matrix.container-to-build}}
-        run: |
-          sed 's/phdi @ git+https:\/\/github.com\/CDCgov\/phdi.git@main/phdi @ git+https:\/\/github.com\/CDCgov\/phdi.git@${{ inputs.container-tag }}/g' requirements.txt > requirements_new.txt && mv requirements_new.txt requirements.txt
+    #   - name: Target phdi release in requirements.txt
+    #     working-directory: ./containers/${{matrix.container-to-build}}
+    #     run: |
+    #       sed 's/phdi @ git+https:\/\/github.com\/CDCgov\/phdi.git@main/phdi @ git+https:\/\/github.com\/CDCgov\/phdi.git@${{ inputs.container-tag }}/g' requirements.txt > requirements_new.txt && mv requirements_new.txt requirements.txt
 
-      - name: Build and push
-        uses: docker/build-push-action@v3
-        with:
-          context: ./containers/${{matrix.container-to-build}}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+    #   - name: Build and push
+    #     uses: docker/build-push-action@v3
+    #     with:
+    #       context: ./containers/${{matrix.container-to-build}}
+    #       push: true
+    #       tags: ${{ steps.meta.outputs.tags }}
+    #       labels: ${{ steps.meta.outputs.labels }}
+    #       cache-from: type=gha
+    #       cache-to: type=gha,mode=max

--- a/.github/workflows/buildReleaseContainers.yaml
+++ b/.github/workflows/buildReleaseContainers.yaml
@@ -7,10 +7,10 @@ on:
         type: string
         required: true
   workflow_dispatch:
-    # inputs:
-    #   container-tag:
-    #     type: string
-    #     required: true
+    inputs:
+      container-tag:
+        type: string
+        required: true
 
 jobs:
   list-containers:
@@ -22,55 +22,53 @@ jobs:
     strategy:
       matrix:
         container-to-build: ${{fromJson(needs.list-containers.outputs.containers)}}
-    # permissions:
-    #   contents: "read"
-    #   id-token: "write"
-    #   packages: "write"
+    permissions:
+      contents: "read"
+      id-token: "write"
+      packages: "write"
     steps:
       - name: Check Out Changes
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.container-tag }}
 
-      - name: Print container list
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          ref: ${{ inputs.container-tag }}
+          images: ghcr.io/${{ github.repository }}/${{matrix.container-to-build}}
+          # this sets the version for tags and labels for each of the containers to be
+          # be the same as the version/tag where the code was pulled from
+          tags: |
+            type=semver,pattern={{raw}},value=${{ inputs.container-tag }}
+            type=ref,event=branch
+            type=ref,event=tag,pattern={{raw}},value=${{ inputs.container-tag }}
+          labels: |
+            org.opencontainers.image.version=${{ inputs.container-tag }}
+
+      - name: Target phdi release in requirements.txt
+        working-directory: ./containers/${{matrix.container-to-build}}
         run: |
-          echo "Containers List: "
-          echo ${{matrix.container-to-build}}
+          sed 's/phdi @ git+https:\/\/github.com\/CDCgov\/phdi.git@main/phdi @ git+https:\/\/github.com\/CDCgov\/phdi.git@${{ inputs.container-tag }}/g' requirements.txt > requirements_new.txt && mv requirements_new.txt requirements.txt
 
-      # - name: Set up Docker Buildx
-      #   uses: docker/setup-buildx-action@v2
-
-    #   - name: Log in to the Container registry
-    #     uses: docker/login-action@v2
-    #     with:
-    #       registry: ghcr.io
-    #       username: ${{ github.actor }}
-    #       password: ${{ secrets.GITHUB_TOKEN }}
-
-    #   - name: Extract metadata (tags, labels) for Docker
-    #     id: meta
-    #     uses: docker/metadata-action@v4
-    #     with:
-    #       ref: ${{ inputs.container-tag }}
-    #       images: ghcr.io/${{ github.repository }}/${{matrix.container-to-build}}
-    #       # this sets the version for tags and labels for each of the containers to be
-    #       # be the same as the version/tag where the code was pulled from
-    #       tags: |
-    #         type=semver,pattern={{raw}},value=${{ inputs.container-tag }}
-    #         type=ref,event=branch
-    #         type=ref,event=tag,pattern={{raw}},value=${{ inputs.container-tag }}
-    #       labels: |
-    #         org.opencontainers.image.version=${{ inputs.container-tag }}
-
-    #   - name: Target phdi release in requirements.txt
-    #     working-directory: ./containers/${{matrix.container-to-build}}
-    #     run: |
-    #       sed 's/phdi @ git+https:\/\/github.com\/CDCgov\/phdi.git@main/phdi @ git+https:\/\/github.com\/CDCgov\/phdi.git@${{ inputs.container-tag }}/g' requirements.txt > requirements_new.txt && mv requirements_new.txt requirements.txt
-
-    #   - name: Build and push
-    #     uses: docker/build-push-action@v3
-    #     with:
-    #       context: ./containers/${{matrix.container-to-build}}
-    #       push: true
-    #       tags: ${{ steps.meta.outputs.tags }}
-    #       labels: ${{ steps.meta.outputs.labels }}
-    #       cache-from: type=gha
-    #       cache-to: type=gha,mode=max
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: ./containers/${{matrix.container-to-build}}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/createNewRelease.yaml
+++ b/.github/workflows/createNewRelease.yaml
@@ -196,7 +196,7 @@ jobs:
           - 5432:5432
     strategy:
       matrix:
-        container: ${{fromJson(needs.list-containers.outputs.python_containers)}}
+        container: ${{fromJson(needs.list-containers.outputs.python-container-dirs)}}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/createNewRelease.yaml
+++ b/.github/workflows/createNewRelease.yaml
@@ -196,7 +196,7 @@ jobs:
           - 5432:5432
     strategy:
       matrix:
-        container: ${{fromJson(needs.list-containers.outputs.python-container-dirs)}}
+        container: ${{fromJson(needs.list-containers.outputs.python-containers)}}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/createNewRelease.yaml
+++ b/.github/workflows/createNewRelease.yaml
@@ -196,7 +196,7 @@ jobs:
           - 5432:5432
     strategy:
       matrix:
-        container: ${{fromJson(needs.list-containers.outputs.containers)}}
+        container: ${{fromJson(needs.list-containers.outputs.python_containers)}}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/listContainers.yaml
+++ b/.github/workflows/listContainers.yaml
@@ -43,7 +43,7 @@ jobs:
         # find all subdirectories with a requirements.txt file at the base (the python containers)
         run: |
           find . -maxdepth 2 -type f -name "requirements.txt" -exec dirname {} \; | sort -u | xargs -n 1 basename | jq -nR '[inputs]'
-          echo "python_containers=$(find . -maxdepth 2 -type f -name "requirements.txt" -exec dirname {} \; | sort -u | xargs -n 1 basename | jq -nR '[inputs]')" >> $GITHUB_OUTPUT
+          echo "python_containers=$(find . -maxdepth 2 -type f -name "requirements.txt" -exec dirname {} \; | sort -u | xargs -n 1 basename | jq -R -s -c 'split("\n")[:-1] ')" >> $GITHUB_OUTPUT
   list-integration-test-directories:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/listContainers.yaml
+++ b/.github/workflows/listContainers.yaml
@@ -3,7 +3,7 @@ name: "List Containers"
 on:
   workflow_call:
     outputs:
-      containers:
+      all-containers:
         value: ${{ jobs.list-containers.outputs.container-dirs }}
       python-container-dirs:
         value: ${{ jobs.list-python-containers.outputs.python-container-dirs }}

--- a/.github/workflows/listContainers.yaml
+++ b/.github/workflows/listContainers.yaml
@@ -42,7 +42,7 @@ jobs:
         working-directory: ./containers
         # find all subdirectories with a requirements.txt file at the base (the python containers)
         run: |
-          find . -maxdepth 2 -type f -name "requirements.txt" -exec dirname {} \; | sort -u | xargs -n 1 basename | jq -nR '[inputs]'
+          find . -maxdepth 2 -type f -name "requirements.txt" -exec dirname {} \; | sort -u | xargs -n 1 basename | jq -R -s -c 'split("\n")[:-1] '
           echo "python_containers=$(find . -maxdepth 2 -type f -name "requirements.txt" -exec dirname {} \; | sort -u | xargs -n 1 basename | jq -R -s -c 'split("\n")[:-1] ')" >> $GITHUB_OUTPUT
   list-integration-test-directories:
     runs-on: ubuntu-latest

--- a/.github/workflows/listContainers.yaml
+++ b/.github/workflows/listContainers.yaml
@@ -9,7 +9,6 @@ on:
         value: ${{ jobs.list-python-containers.outputs.python-container-dirs }}
       integration-dirs:
         value: ${{ jobs.list-integration-test-directories.outputs.integration-dirs }}
-  workflow_dispatch:
 
 jobs:
   list-containers:

--- a/.github/workflows/listContainers.yaml
+++ b/.github/workflows/listContainers.yaml
@@ -5,8 +5,8 @@ on:
     outputs:
       all-containers:
         value: ${{ jobs.list-containers.outputs.container-dirs }}
-      python-container-dirs:
-        value: ${{ jobs.list-python-containers.outputs.python-container-dirs }}
+      python-containers:
+        value: ${{ jobs.list-python-containers.outputs.python-containers }}
       integration-dirs:
         value: ${{ jobs.list-integration-test-directories.outputs.integration-dirs }}
 
@@ -31,7 +31,7 @@ jobs:
   list-python-containers:
     runs-on: ubuntu-latest
     outputs:
-      python-container-dirs: ${{steps.generate-python-list.outputs.python_containers}}
+      python-containers: ${{steps.generate-python-list.outputs.python_containers}}
     steps:
       - name: Check Out Changes
         uses: actions/checkout@v3

--- a/.github/workflows/listContainers.yaml
+++ b/.github/workflows/listContainers.yaml
@@ -7,6 +7,7 @@ on:
         value: ${{ jobs.list-containers.outputs.container-dirs }}
       integration-dirs:
         value: ${{ jobs.list-integration-test-directories.outputs.integration-dirs }}
+  workflow_dispatch:
 
 jobs:
   list-containers:

--- a/.github/workflows/listContainers.yaml
+++ b/.github/workflows/listContainers.yaml
@@ -5,6 +5,8 @@ on:
     outputs:
       containers:
         value: ${{ jobs.list-containers.outputs.container-dirs }}
+      python-container-dirs:
+        value: ${{ jobs.list-python-containers.outputs.python-container-dirs }}
       integration-dirs:
         value: ${{ jobs.list-integration-test-directories.outputs.integration-dirs }}
   workflow_dispatch:

--- a/.github/workflows/listContainers.yaml
+++ b/.github/workflows/listContainers.yaml
@@ -25,7 +25,24 @@ jobs:
         # use jq to produce json output and filter out the empty item caused by final newline
         run: |
           ls -d * | jq -R -s -c 'split("\n")[:-1]'
-          echo "containers=$(ls -d */ | cut -f1 -d'/' | jq -R -s -c 'split("\n")[:-1] | map(select(. != "ecr-viewer"))')" >> $GITHUB_OUTPUT
+          echo "containers=$(ls -d */ | cut -f1 -d'/' | jq -R -s -c 'split("\n")[:-1] ')" >> $GITHUB_OUTPUT
+  list-python-containers:
+    runs-on: ubuntu-latest
+    outputs:
+      python-container-dirs: ${{steps.generate-python-list.outputs.python_containers}}
+    steps:
+      - name: Check Out Changes
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt-get install jq
+      - id: generate-python-list
+        name: Generate list of python-specific directories within containers/
+        working-directory: ./containers
+        # find all subdirectories with a requirements.txt file at the base (the python containers)
+        run: |
+          find . -maxdepth 2 -type f -name "requirements.txt" -exec dirname {} \; | sort -u | xargs -n 1 basename | jq -nR '[inputs]'
+          echo "python_containers=$(find . -maxdepth 2 -type f -name "requirements.txt" -exec dirname {} \; | sort -u | xargs -n 1 basename | jq -nR '[inputs]')" >> $GITHUB_OUTPUT
   list-integration-test-directories:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -128,7 +128,7 @@ jobs:
           - 5432:5432
     strategy:
       matrix:
-        container-to-test: ${{fromJson(needs.list-containers.outputs.python-container-dirs)}}
+        container-to-test: ${{fromJson(needs.list-containers.outputs.python-containers)}}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -128,7 +128,7 @@ jobs:
           - 5432:5432
     strategy:
       matrix:
-        container-to-test: ${{fromJson(needs.list-containers.outputs.containers)}}
+        container-to-test: ${{fromJson(needs.list-containers.outputs.python_containers)}}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -128,7 +128,7 @@ jobs:
           - 5432:5432
     strategy:
       matrix:
-        container-to-test: ${{fromJson(needs.list-containers.outputs.python_containers)}}
+        container-to-test: ${{fromJson(needs.list-containers.outputs.python-container-dirs)}}
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
# PULL REQUEST

## Summary
Updates our release workflows to release the ecr-viewer container image.

## Related Issue
Fixes #1189 

## Additional Information
The meat of the change here is in `list-containers` - there's now a job specifically to list Python containers, and one to list all containers. Previously, the `buildReleaseContainers` job didn't include the ecr-viewer in its list of containers to operate on; this should fix that.

## Checklist

- [x] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
