### PR TITLE
Add setId to PHDC header

### DIFF
--- a/containers/message-parser/app/phdc/builder.py
+++ b/containers/message-parser/app/phdc/builder.py
@@ -169,6 +169,15 @@ class PHDCBuilder:
         )
         return title
 
+    def _get_setId(self):
+        """
+        Returns the setId element of the PHDC header.
+        """
+        setid_attributes = {"extension": "CLOSED_CASE", "displayable": "true"}
+        setid = ET.Element("setId", attrib=setid_attributes)
+
+        return setid
+
     def build_header(self):
         """
         Builds the header of the PHDC document.
@@ -180,6 +189,7 @@ class PHDCBuilder:
         root.append(self._get_title())
         root.append(self._get_effective_time())
         root.append(self._get_confidentiality_code(confidentiality="normal"))
+        root.append(self._get_setId())
 
         root.append(self._build_custodian(id=str(uuid.uuid4())))
         root.append(self._build_author(family_name="DIBBS"))

--- a/containers/message-parser/assets/demo_phdc.xml
+++ b/containers/message-parser/assets/demo_phdc.xml
@@ -7,6 +7,7 @@
   <title>Public Health Case Report - Data from the DIBBs FHIR to PHDC Converter</title>
   <effectiveTime value="20101215000000"/>
   <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+  <setId extension="CLOSED_CASE" displayable="true"/>
   <custodian>
     <assignedCustodian>
       <representedCustodianOrganization>

--- a/containers/message-parser/assets/sample_phdc.xml
+++ b/containers/message-parser/assets/sample_phdc.xml
@@ -7,6 +7,7 @@
   <title>Public Health Case Report - Data from the DIBBs FHIR to PHDC Converter</title>
   <effectiveTime value="20101215000000"/>
   <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+  <setId extension="CLOSED_CASE" displayable="true"/>
   <custodian>
     <assignedCustodian>
       <representedCustodianOrganization>

--- a/containers/message-parser/assets/sample_phdc_header.xml
+++ b/containers/message-parser/assets/sample_phdc_header.xml
@@ -7,6 +7,7 @@
   <title>Public Health Case Report - Data from the DIBBs FHIR to PHDC Converter</title>
   <effectiveTime value="20101215000000"/>
   <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+  <setId extension="CLOSED_CASE" displayable="true"/>
   <custodian>
     <assignedCustodian>
       <representedCustodianOrganization>

--- a/containers/message-parser/tests/test_phdc.py
+++ b/containers/message-parser/tests/test_phdc.py
@@ -440,6 +440,13 @@ def test_get_confidentiality_code():
     )
 
 
+def test_get_setId():
+    builder = PHDCBuilder()
+    setid = builder._get_setId()
+
+    assert ET.tostring(setid) == b'<setId extension="CLOSED_CASE" displayable="true"/>'
+
+
 def test_get_case_report_code():
     builder = PHDCBuilder()
     case_report_code = builder._get_case_report_code()


### PR DESCRIPTION
# PULL REQUEST

## Summary
Adds the hardcoded (for now) setId element to the PHDC header.

## Related Issue
Fixes #1161

## Additional Information
I used  `set_attrib` to add the setId information, which might be easier than using `.set()` for each component. 

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
