### PR TITLE
Add `versionNumber` to PHDC header

### DIFF
--- a/containers/message-parser/app/phdc/builder.py
+++ b/containers/message-parser/app/phdc/builder.py
@@ -168,9 +168,11 @@ class PHDCBuilder:
         code.set("displayName", "Public Health Case Report - PHRI")
         return code
 
-    def _get_title(self):
+    def _get_title(self) -> ET.Element:
         """
         Returns the title element of the PHDC header.
+
+        :returns: XML element of <title>.
         """
         title = ET.Element("title")
         title.text = (
@@ -187,9 +189,11 @@ class PHDCBuilder:
 
         return setid
 
-    def _get_version_number(self):
+    def _get_version_number(self) -> ET.Element:
         """
         Returns the versionNumber element of the PHDC header.
+
+        :returns: XML element of <versionNumber>.
         """
         # TODO: once we get prod data, we'll have to determine
         # whether or not this will be data we parse from source data

--- a/containers/message-parser/app/phdc/builder.py
+++ b/containers/message-parser/app/phdc/builder.py
@@ -187,6 +187,17 @@ class PHDCBuilder:
 
         return setid
 
+    def _get_version_number(self):
+        """
+        Returns the versionNumber element of the PHDC header.
+        """
+        # TODO: once we get prod data, we'll have to determine
+        # whether or not this will be data we parse from source data
+        version_number = ET.Element("versionNumber")
+        version_number.set("value", "1")
+
+        return version_number
+
     def build_header(self):
         """
         Builds the header of the PHDC document.
@@ -200,6 +211,7 @@ class PHDCBuilder:
         root.append(self._get_effective_time())
         root.append(self._get_confidentiality_code(confidentiality="normal"))
         root.append(self._get_setId())
+        root.append(self._get_version_number())
 
         root.append(self._build_custodian(id=str(uuid.uuid4())))
         root.append(self._build_author(family_name="DIBBS"))

--- a/containers/message-parser/assets/demo_phdc.xml
+++ b/containers/message-parser/assets/demo_phdc.xml
@@ -9,6 +9,7 @@
   <effectiveTime value="20101215000000"/>
   <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
   <setId extension="CLOSED_CASE" displayable="true"/>
+  <versionNumber value="1"/>
   <custodian>
     <assignedCustodian>
       <representedCustodianOrganization>

--- a/containers/message-parser/assets/sample_phdc.xml
+++ b/containers/message-parser/assets/sample_phdc.xml
@@ -9,6 +9,7 @@
   <effectiveTime value="20101215000000"/>
   <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
   <setId extension="CLOSED_CASE" displayable="true"/>
+  <versionNumber value="1"/>
   <custodian>
     <assignedCustodian>
       <representedCustodianOrganization>

--- a/containers/message-parser/assets/sample_phdc_header.xml
+++ b/containers/message-parser/assets/sample_phdc_header.xml
@@ -9,6 +9,7 @@
   <effectiveTime value="20101215000000"/>
   <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
   <setId extension="CLOSED_CASE" displayable="true"/>
+  <versionNumber value="1"/>
   <custodian>
     <assignedCustodian>
       <representedCustodianOrganization>

--- a/containers/message-parser/tests/test_phdc.py
+++ b/containers/message-parser/tests/test_phdc.py
@@ -420,6 +420,17 @@ def test_get_id():
     )
 
 
+def test_get_title():
+    builder = PHDCBuilder()
+    title = builder._get_title()
+
+    assert (
+        ET.tostring(title)
+        == b"<title>Public Health Case Report - "
+        + b"Data from the DIBBs FHIR to PHDC Converter</title>"
+    )
+
+
 @patch.object(utils, "get_datetime_now", lambda: date(2010, 12, 15))
 def test_get_effective_time():
     builder = PHDCBuilder()

--- a/containers/message-parser/tests/test_phdc.py
+++ b/containers/message-parser/tests/test_phdc.py
@@ -443,6 +443,13 @@ def test_get_setId():
     assert ET.tostring(setid) == b'<setId extension="CLOSED_CASE" displayable="true"/>'
 
 
+def test_get_version_number():
+    builder = PHDCBuilder()
+    version_number = builder._get_version_number()
+
+    assert ET.tostring(version_number) == b'<versionNumber value="1"/>'
+
+
 def test_get_realmCode():
     builder = PHDCBuilder()
     realmCode = builder._get_realmCode()


### PR DESCRIPTION
# PULL REQUEST

## Summary
Adding `<versionNumber>` to our PHDC header and hard coding the value to `value="1"` until we have a chance to see production source data to learn more.

Also adding an additional individual test for the `_get_title` method (referenced in _Fixes_ below).

## Related Issue
Fixes #1162 #1192 
