### PR TITLE
Add config name param

### DIFF
--- a/containers/orchestration/app/main.py
+++ b/containers/orchestration/app/main.py
@@ -190,12 +190,17 @@ async def apply_workflow_to_message(
     """
     try:
         processing_config = load_processing_config(config_file_name)
-    except FileNotFoundError:
-        return {
-            "status_code": 400,
-            # "message": error.__str__(),
-            # "processed_values": {},
-        }
+    except FileNotFoundError as error:
+        response = Response(
+            content=json.dumps(
+                {
+                    "message": error.__str__(),
+                    "processed_values": {},
+                }
+            ),
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+        return response
 
     api_input = {
         "message_type": message_type,

--- a/containers/orchestration/app/main.py
+++ b/containers/orchestration/app/main.py
@@ -190,11 +190,11 @@ async def apply_workflow_to_message(
     """
     try:
         processing_config = load_processing_config(config_file_name)
-    except FileNotFoundError as error:
+    except FileNotFoundError:
         return {
             "status_code": 400,
-            "message": error.__str__(),
-            "processed_values": {},
+            # "message": error.__str__(),
+            # "processed_values": {},
         }
 
     api_input = {

--- a/containers/orchestration/app/main.py
+++ b/containers/orchestration/app/main.py
@@ -77,6 +77,7 @@ async def process_message_endpoint_ws(
             # Hardcoded message_type for MVP
             initial_input = {
                 "message_type": "ecr",
+                "config_file_name": "sample-orchestration-config.json",
                 "include_error_types": "errors",
                 "message": unzipped_data.get("ecr"),
                 "rr_data": unzipped_data.get("rr"),
@@ -118,6 +119,7 @@ async def process_message_endpoint_ws(
 @app.post("/process", status_code=200, responses=process_message_response_examples)
 async def process_endpoint(
     message_type: str = Form(None),
+    config_file_name: str = Form(None),
     include_error_types: str = Form(None),
     upload_file: UploadFile = File(None),
 ) -> ProcessMessageResponse:
@@ -133,8 +135,12 @@ async def process_endpoint(
 
     zip_content = unzip_http(upload_file)
 
-    building_block_response = await process_http_request(
-        message_type, include_error_types, zip_content.get("ecr"), zip_content.get("rr")
+    building_block_response = await apply_workflow_to_message(
+        message_type,
+        config_file_name,
+        include_error_types,
+        zip_content.get("ecr"),
+        zip_content.get("rr"),
     )
 
     return building_block_response
@@ -150,8 +156,9 @@ async def process_message_endpoint(
     Processes a message through a series of microservices.
     """
     process_request = dict(request)
-    building_block_response = await process_http_request(
+    building_block_response = await apply_workflow_to_message(
         process_request.get("message_type"),
+        process_request.get("config_file_name"),
         process_request.get("include_error_types"),
         process_request.get("message"),
         process_request.get("rr_data"),
@@ -160,11 +167,36 @@ async def process_message_endpoint(
     return building_block_response
 
 
-async def process_http_request(
-    message_type, include_error_types, ecr_content, rr_content
+async def apply_workflow_to_message(
+    message_type, config_file_name, include_error_types, ecr_content, rr_content
 ):
-    # Change below to grab from uploaded configs once we've got them
-    processing_config = load_processing_config("sample-orchestration-config.json")
+    """
+    Main orchestration function that applies a config-defined workflow to an
+    uploaded piece of data. The workflow applied is determined by loading the
+    configuration file of the provided name, and each step of this workflow
+    is applied by an appropriate API call.
+
+    :param message_type: The type of data being supplied for orchestration. May
+      be either 'ecr', 'elr', 'vxu', or 'fhir'.
+    :param config_file_name: The name of the workflow configuration file to
+      load and apply stepwise to the data. File must be located in the custom
+      or default configs directory on the service's disk space.
+    :param include_error_types: Whether to include error typing in the API
+      responses.
+    :param ecr_content: The data content of the provided eCR message.
+    :param rr_content: The reportability response associated with the eCR.
+    :return: JSON of whether the workflow succeeded and what its outputs
+      were.
+    """
+    try:
+        processing_config = load_processing_config(config_file_name)
+    except FileNotFoundError as error:
+        return {
+            "status_code": status.HTTP_400_BAD_REQUEST,
+            "message": error.__str__(),
+            "processed_values": "",
+        }
+
     api_input = {
         "message_type": message_type,
         "include_error_types": include_error_types,

--- a/containers/orchestration/app/main.py
+++ b/containers/orchestration/app/main.py
@@ -77,7 +77,6 @@ async def process_message_endpoint_ws(
             # Hardcoded message_type for MVP
             initial_input = {
                 "message_type": "ecr",
-                "config_file_name": "sample-orchestration-config.json",
                 "include_error_types": "errors",
                 "message": unzipped_data.get("ecr"),
                 "rr_data": unzipped_data.get("rr"),

--- a/containers/orchestration/app/main.py
+++ b/containers/orchestration/app/main.py
@@ -192,9 +192,9 @@ async def apply_workflow_to_message(
         processing_config = load_processing_config(config_file_name)
     except FileNotFoundError as error:
         return {
-            "status_code": status.HTTP_400_BAD_REQUEST,
+            "status_code": 400,
             "message": error.__str__(),
-            "processed_values": "",
+            "processed_values": {},
         }
 
     api_input = {

--- a/containers/orchestration/app/models.py
+++ b/containers/orchestration/app/models.py
@@ -17,6 +17,13 @@ class ProcessMessageRequest(BaseModel):
     message_type: Literal["ecr", "elr", "vxu", "fhir"] = Field(
         description="The type of message to be validated."
     )
+    config_file_name: str = Field(
+        description=(
+            "The name of a config file in either the `default/` or `custom/`"
+            " schemas directory that will define the workflow applied to the"
+            " passed data."
+        )
+    )
     include_error_types: str = Field(
         description=(
             "A comma separated list of the types of errors that should be"
@@ -33,7 +40,7 @@ class ProcessMessageRequest(BaseModel):
     )
 
     @root_validator()
-    def validate_fields(cls, values):
+    def validate_rr_with_ecr(cls, values):
         message_type = values.get("message_type")
         rr_data = values.get("rr_data")
 

--- a/containers/orchestration/tests/integration/test_orchestration.py
+++ b/containers/orchestration/tests/integration/test_orchestration.py
@@ -47,6 +47,7 @@ def test_process_message_endpoint(setup):
     ).read()
     request = {
         "message_type": "ecr",
+        "config_file_name": "sample-orchestration-config.json",
         "include_error_types": "errors",
         "message": message,
     }
@@ -67,6 +68,7 @@ def test_process_endpoint_with_zip(setup):
     ) as file:
         form_data = {
             "message_type": "ecr",
+            "config_file_name": "sample-orchestration-config.json",
             "include_error_types": "errors",
         }
         files = {"upload_file": ("file.zip", file)}
@@ -89,6 +91,7 @@ def test_process_endpoint_with_zip_and_rr_data(setup):
     ) as file:
         form_data = {
             "message_type": "ecr",
+            "config_file_name": "sample-orchestration-config.json",
             "include_error_types": "errors",
         }
         files = {"upload_file": ("file.zip", file)}

--- a/containers/orchestration/tests/test_process_message_endpoint.py
+++ b/containers/orchestration/tests/test_process_message_endpoint.py
@@ -84,8 +84,8 @@ def test_process_message_invalid_config():
     }
 
     actual_response = client.post("/process-message", json=request)
+    assert actual_response.status_code == 400
     assert actual_response.json() == {
-        "status_code": 400,
         "message": "A config with the name 'non_existent_schema.json' could not be found.",  # noqa
         "processed_values": {},
     }
@@ -212,8 +212,8 @@ def test_process_invalid_config():
         files = {"upload_file": ("file.zip", f)}
 
         actual_response = client.post("/process", data=form_data, files=files)
+        assert actual_response.status_code == 400
         assert actual_response.json() == {
-            "status_code": 400,
             "message": "A config with the name 'non_existent_schema.json' could not be found.",  # noqa
             "processed_values": {},
         }

--- a/containers/orchestration/tests/test_process_message_endpoint.py
+++ b/containers/orchestration/tests/test_process_message_endpoint.py
@@ -39,6 +39,7 @@ with open(test_config_path, "r") as file:
 def test_process_message_success(patched_post_request, patched_save_to_db):
     request = {
         "message_type": "ecr",
+        "config_file_name": "sample-orchestration-config.json",
         "include_error_types": "errors",
         "message": '{"foo": "bar"}',
     }
@@ -74,9 +75,26 @@ def test_process_message_input_validation():
     assert actual_response.status_code == 422
 
 
+def test_process_message_invalid_config():
+    request = {
+        "message_type": "elr",
+        "message": "foo",
+        "config_file_name": "non_existent_schema.json",
+        "include_error_types": "errors",
+    }
+
+    actual_response = client.post("/process-message", json=request)
+    assert actual_response.json() == {
+        "status_code": 400,
+        "message": "A config with the name 'non_existent_schema.json' could not be found.",  # noqa
+        "processed_values": "",
+    }
+
+
 def test_process_message_input_validation_with_rr_data():
     request = {
         "message": "foo",
+        "config_file_name": "sample-orchestration-config.json",
         "message_type": "elr",
         "include_error_types": "errors",
         "rr_data": "bar",
@@ -100,6 +118,7 @@ def test_process_success(patched_post_request, patched_save_to_db):
     ) as f:
         form_data = {
             "message_type": "ecr",
+            "config_file_name": "sample-orchestration-config.json",
             "include_error_types": "errors",
         }
         files = {"upload_file": ("file.zip", f)}
@@ -141,6 +160,7 @@ def test_process_with_empty_zip():
     ) as f:
         form_data = {
             "message_type": "ecr",
+            "config_file_name": "sample-orchestration-config.json",
             "include_error_types": "errors",
         }
         files = {"upload_file": ("file.zip", f)}
@@ -162,6 +182,7 @@ def test_process_with_non_zip():
     ) as f:
         form_data = {
             "message_type": "ecr",
+            "config_file_name": "sample-orchestration-config.json",
             "include_error_types": "errors",
         }
         files = {"upload_file": ("file.xml", f)}
@@ -172,3 +193,28 @@ def test_process_with_non_zip():
             actual_response.json()["detail"]
             == "Only .zip files are accepted at this time."
         )
+
+
+def test_process_invalid_config():
+    with open(
+        Path(__file__).parent.parent.parent.parent
+        / "tests"
+        / "assets"
+        / "orchestration"
+        / "eICR_RR_combo.zip",
+        "rb",
+    ) as f:
+        form_data = {
+            "message_type": "ecr",
+            "config_file_name": "non_existent_schema.json",
+            "include_error_types": "errors",
+        }
+        files = {"upload_file": ("file.zip", f)}
+
+        actual_response = client.post("/process", data=form_data, files=files)
+        assert actual_response.status_code == 400
+        assert actual_response.json() == {
+            "status_code": 400,
+            "message": "A config with the name 'non_existent_schema.json' could not be found.",  # noqa
+            "processed_values": "",
+        }

--- a/containers/orchestration/tests/test_process_message_endpoint.py
+++ b/containers/orchestration/tests/test_process_message_endpoint.py
@@ -87,7 +87,7 @@ def test_process_message_invalid_config():
     assert actual_response.json() == {
         "status_code": 400,
         "message": "A config with the name 'non_existent_schema.json' could not be found.",  # noqa
-        "processed_values": "",
+        "processed_values": {},
     }
 
 
@@ -212,9 +212,8 @@ def test_process_invalid_config():
         files = {"upload_file": ("file.zip", f)}
 
         actual_response = client.post("/process", data=form_data, files=files)
-        assert actual_response.status_code == 400
         assert actual_response.json() == {
             "status_code": 400,
             "message": "A config with the name 'non_existent_schema.json' could not be found.",  # noqa
-            "processed_values": "",
+            "processed_values": {},
         }


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR modifies the input to the orchestration service's `process` and `process-message` endpoints to enforce the user providing a configuration file name. This name is used to look up the relevant workflow on the back end for application to the data the user provided.

## Related Issue
Fixes #1227 

## Additional Information
This work will not touch the `process-ws` endpoint, since that involves directly sending zipped messages as filebytes and will need other work to alter the input.