### PR TITLE
Create bundled config and steps

### DIFF
--- a/containers/orchestration/app/default_configs/sample-fhir-test-config-new.json
+++ b/containers/orchestration/app/default_configs/sample-fhir-test-config-new.json
@@ -1,0 +1,45 @@
+{
+  "workflow": [
+    {
+      "service": "validation",
+      "url": "${VALIDATION_URL}",
+      "endpoint": "/validate",
+      "params": {
+        "include_error_types": "error"
+      }
+    },
+    {
+      "service": "ingestion",
+      "url": "${INGESTION_URL}",
+      "endpoint": "/fhir/harmonization/standardization/standardize_names",
+      "params": {
+        "overwrite": true
+      }
+    },
+    {
+      "service": "ingestion",
+      "url": "${INGESTION_URL}",
+      "endpoint": "/fhir/harmonization/standardization/standardize_dob",
+      "params": {
+        "overwrite": true,
+        "dob_format": ""
+      }
+    },
+    {
+      "service": "ingestion",
+      "url": "${INGESTION_URL}",
+      "endpoint": "/fhir/harmonization/standardization/standardize_phones",
+      "params": {
+        "overwrite": true
+      }
+    },
+    {
+      "service": "message_parser",
+      "url": "${MESSAGE_PARSER_URL}",
+      "endpoint": "/fhir_to_phdc",
+      "params": {
+        "phdc_report_type": "case_report"
+      }
+    }
+  ]
+}

--- a/containers/orchestration/app/default_configs/sample-fhir-test-config-new.json
+++ b/containers/orchestration/app/default_configs/sample-fhir-test-config-new.json
@@ -11,27 +11,20 @@
     {
       "service": "ingestion",
       "url": "${INGESTION_URL}",
-      "endpoint": "/fhir/harmonization/standardization/standardize_names",
-      "params": {
-        "overwrite": true
-      }
+      "endpoint": "/fhir/harmonization/standardization/standardize_names"
     },
     {
       "service": "ingestion",
       "url": "${INGESTION_URL}",
       "endpoint": "/fhir/harmonization/standardization/standardize_dob",
       "params": {
-        "overwrite": true,
         "dob_format": ""
       }
     },
     {
       "service": "ingestion",
       "url": "${INGESTION_URL}",
-      "endpoint": "/fhir/harmonization/standardization/standardize_phones",
-      "params": {
-        "overwrite": true
-      }
+      "endpoint": "/fhir/harmonization/standardization/standardize_phones"
     },
     {
       "service": "message_parser",

--- a/containers/orchestration/app/default_configs/sample-hl7-test-config-new.json
+++ b/containers/orchestration/app/default_configs/sample-hl7-test-config-new.json
@@ -16,27 +16,20 @@
     {
       "service": "ingestion",
       "url": "${INGESTION_URL}",
-      "endpoint": "/fhir/harmonization/standardization/standardize_names",
-      "params": {
-        "overwrite": true
-      }
+      "endpoint": "/fhir/harmonization/standardization/standardize_names"
     },
     {
       "service": "ingestion",
       "url": "${INGESTION_URL}",
       "endpoint": "/fhir/harmonization/standardization/standardize_dob",
       "params": {
-        "overwrite": true,
         "dob_format": ""
       }
     },
     {
       "service": "ingestion",
       "url": "${INGESTION_URL}",
-      "endpoint": "/fhir/harmonization/standardization/standardize_phones",
-      "params": {
-        "overwrite": true
-      }
+      "endpoint": "/fhir/harmonization/standardization/standardize_phones"
     }
   ]
 }

--- a/containers/orchestration/app/default_configs/sample-hl7-test-config-new.json
+++ b/containers/orchestration/app/default_configs/sample-hl7-test-config-new.json
@@ -1,0 +1,42 @@
+{
+  "workflow": [
+    {
+      "service": "validation",
+      "url": "${VALIDATION_URL}",
+      "endpoint": "/validate",
+      "params": {
+        "include_error_types": "error"
+      }
+    },
+    {
+      "service": "convert_to_fhir",
+      "url": "${FHIR_CONVERTER_URL}",
+      "endpoint": "/convert-to-fhir"
+    },
+    {
+      "service": "ingestion",
+      "url": "${INGESTION_URL}",
+      "endpoint": "/fhir/harmonization/standardization/standardize_names",
+      "params": {
+        "overwrite": true
+      }
+    },
+    {
+      "service": "ingestion",
+      "url": "${INGESTION_URL}",
+      "endpoint": "/fhir/harmonization/standardization/standardize_dob",
+      "params": {
+        "overwrite": true,
+        "dob_format": ""
+      }
+    },
+    {
+      "service": "ingestion",
+      "url": "${INGESTION_URL}",
+      "endpoint": "/fhir/harmonization/standardization/standardize_phones",
+      "params": {
+        "overwrite": true
+      }
+    }
+  ]
+}

--- a/containers/orchestration/app/default_configs/sample-orchestration-config-new.json
+++ b/containers/orchestration/app/default_configs/sample-orchestration-config-new.json
@@ -16,27 +16,20 @@
     {
       "service": "ingestion",
       "url": "${INGESTION_URL}",
-      "endpoint": "/fhir/harmonization/standardization/standardize_names",
-      "params": {
-        "overwrite": true
-      }
+      "endpoint": "/fhir/harmonization/standardization/standardize_names"
     },
     {
       "service": "ingestion",
       "url": "${INGESTION_URL}",
       "endpoint": "/fhir/harmonization/standardization/standardize_dob",
       "params": {
-        "overwrite": true,
         "dob_format": ""
       }
     },
     {
       "service": "ingestion",
       "url": "${INGESTION_URL}",
-      "endpoint": "/fhir/harmonization/standardization/standardize_phones",
-      "params": {
-        "overwrite": true
-      }
+      "endpoint": "/fhir/harmonization/standardization/standardize_phones"
     },
     {
       "service": "message_parser",

--- a/containers/orchestration/app/default_configs/sample-orchestration-config-new.json
+++ b/containers/orchestration/app/default_configs/sample-orchestration-config-new.json
@@ -1,0 +1,57 @@
+{
+  "workflow": [
+    {
+      "service": "validation",
+      "url": "${VALIDATION_URL}",
+      "endpoint": "/validate",
+      "params": {
+        "include_error_types": "error"
+      }
+    },
+    {
+      "service": "convert_to_fhir",
+      "url": "${FHIR_CONVERTER_URL}",
+      "endpoint": "/convert-to-fhir"
+    },
+    {
+      "service": "ingestion",
+      "url": "${INGESTION_URL}",
+      "endpoint": "/fhir/harmonization/standardization/standardize_names",
+      "params": {
+        "overwrite": true
+      }
+    },
+    {
+      "service": "ingestion",
+      "url": "${INGESTION_URL}",
+      "endpoint": "/fhir/harmonization/standardization/standardize_dob",
+      "params": {
+        "overwrite": true,
+        "dob_format": ""
+      }
+    },
+    {
+      "service": "ingestion",
+      "url": "${INGESTION_URL}",
+      "endpoint": "/fhir/harmonization/standardization/standardize_phones",
+      "params": {
+        "overwrite": true
+      }
+    },
+    {
+      "service": "message_parser",
+      "url": "${MESSAGE_PARSER_URL}",
+      "endpoint": "/parse_message",
+      "params": {
+        "message_format": "fhir",
+        "parsing_schema_name": "ecr.json",
+        "credential_manager": "azure"
+      }
+    },
+    {
+      "service": "save_to_db",
+      "url": "${DATABASE_URL}",
+      "endpoint": ""
+    }
+  ]
+}

--- a/containers/orchestration/app/models.py
+++ b/containers/orchestration/app/models.py
@@ -32,6 +32,11 @@ class ProcessMessageRequest(BaseModel):
             " passed data."
         )
     )
+    # TODO: Once we land the new orchestrataion overhaul, we should delete this
+    # parameter. It's used only in the input specification for the validation
+    # service rather than shared across services as a whole, so it's just an
+    # unnecessary value we pass around to services that don't need to know
+    # about it.
     include_error_types: str = Field(
         description=(
             "A comma separated list of the types of errors that should be"


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR creates workflow configurations in the new format devised during the orchestration service overhaul meeting. Configuration and steps are now bundled together for easier iteration during `call_apis` and easier access of the params for each specific service.

## Related Issue
Fixes #1287 

## Additional Information
JSON dictionaries _do not_ preserve key order, and neither does Python when performing a `json.loads`. That means we can't just use the first level of the JSON dict as the workflow steps, but putting them all into a list will force an ordered serialization. It's a minimal but necessary extra step.