### PR TITLE
Add repeating questions section to PHDC builder

### DIFF
--- a/containers/message-parser/app/phdc/builder.py
+++ b/containers/message-parser/app/phdc/builder.py
@@ -297,10 +297,9 @@ class PHDCBuilder:
         section.append(title)
 
         # add observation data to section
-        if self.input_data.clinical_info is not None:
-            for observation in self.input_data.clinical_info:
-                observation_element = self._build_observation(observation)
-                section.append(observation_element)
+        for observation in self.input_data.clinical_info:
+            observation_element = self._build_observation(observation)
+            section.append(observation_element)
 
         component.append(section)
         return component
@@ -335,10 +334,9 @@ class PHDCBuilder:
         section.append(title)
 
         # add observation data to section
-        if self.input_data.social_history_info is not None:
-            for observation in self.input_data.social_history_info:
-                observation_element = self._build_observation(observation)
-                section.append(observation_element)
+        for observation in self.input_data.social_history_info:
+            observation_element = self._build_observation(observation)
+            section.append(observation_element)
 
         component.append(section)
         return component
@@ -366,10 +364,9 @@ class PHDCBuilder:
         section.append(title)
 
         # add observation data to section
-        if self.input_data.repeating_questions is not None:
-            for observation in self.input_data.repeating_questions:
-                observation_element = self._build_observation(observation)
-                section.append(observation_element)
+        for observation in self.input_data.repeating_questions:
+            observation_element = self._build_observation(observation)
+            section.append(observation_element)
 
         component.append(section)
         return component

--- a/containers/message-parser/app/phdc/builder.py
+++ b/containers/message-parser/app/phdc/builder.py
@@ -365,12 +365,6 @@ class PHDCBuilder:
         section.append(code)
         section.append(title)
 
-        # Add entry
-        # add organizer to entry
-        # add code and status code to entry
-
-        # for each q, add a component and add the repeating ques to component
-
         # add observation data to section
         if self.input_data.repeating_questions is not None:
             for observation in self.input_data.repeating_questions:

--- a/containers/message-parser/app/phdc/models.py
+++ b/containers/message-parser/app/phdc/models.py
@@ -115,11 +115,11 @@ class CodedElement:
 
 @dataclass
 class Observation:
-    obs_type: str = "laboratory"
     """
     A class containing all of the data elements for an observation element.
     """
 
+    obs_type: str = "laboratory"
     type_code: Optional[str] = None
     class_code: Optional[str] = None
     code_display: Optional[str] = None
@@ -156,7 +156,8 @@ class PHDCInputData:
         "case_report", "contact_record", "lab_report", "morbidity_report"
     ] = "case_report"
     patient: Patient = None
-    clinical_info: List[Observation] = None
-    social_history_info: List[Observation] = None
     organization: List[Organization] = None
     observations: List[Observation] = None
+    clinical_info: List[Observation] = None
+    social_history_info: List[Observation] = None
+    repeating_questions: List[Observation] = None

--- a/containers/message-parser/app/utils.py
+++ b/containers/message-parser/app/utils.py
@@ -492,9 +492,12 @@ def transform_to_phdc_input_data(parsed_values: dict) -> PHDCInputData:
             case "observations":
                 input_data.clinical_info = []
                 input_data.social_history_info = []
+                input_data.repeating_questions = []
                 for obs in value:
                     if obs["obs_type"] == "social-history":
                         input_data.social_history_info.append(Observation(**obs))
+                    elif obs["obs_type"] == "EXPOS":
+                        input_data.repeating_questions.append(Observation(**obs))
                     else:
                         input_data.clinical_info.append(Observation(**obs))
             case "custodian_represented_custodian_organization":

--- a/containers/message-parser/assets/demo_phdc.xml
+++ b/containers/message-parser/assets/demo_phdc.xml
@@ -99,4 +99,22 @@
       </entry>
     </section>
   </component>
+  <component>
+    <section>
+      <code code="1234567-RPT" codeSystem="Local-codesystem-oid" codeSystemName="LocalSystem" displayName="Generic Repeating Questions Section"/>
+      <title>REPEATING QUESTIONS</title>
+      <entry typeCode="COMP">
+        <organizer classCode="CLUSTER" moodCode="EVN">
+          <code code="1" displayName="Exposure Information" codeSytemName="LocalSystem"/>
+          <status_code code="completed"/>
+          <component>
+            <observation classCode="OBS" moodCode="EVN">
+              <code code="C3841750" codeSystem="http://terminology.hl7.org/CodeSystem/umls" displayName="Mass gathering"/>
+              <value code="264379009" codeSystem="http://snomed.info/sct" value="Sports stadium (environment)"/>
+            </observation>
+          </component>
+        </organizer>
+      </entry>
+    </section>
+  </component>
 </ClinicalDocument>

--- a/containers/message-parser/assets/demo_phdc_conversion_bundle.json
+++ b/containers/message-parser/assets/demo_phdc_conversion_bundle.json
@@ -549,6 +549,94 @@
           }
         ]
       }
+    },
+    {
+      "fullUrl": "url",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "observation-us-ph-exposure-contact-info-football-game",
+        "meta": {
+          "versionId": "6",
+          "lastUpdated": "2021-08-21T03:52:28.637+00:00",
+          "source": "#4mfRzWw4DxNmp8a8",
+          "profile": [
+            "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-exposure-contact-information"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: Observation</b><a name=\"observation-us-ph-exposure-contact-info-football-game\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-us-ph-exposure-contact-info-football-game&quot; Version &quot;6&quot; Updated &quot;2021-08-21 03:52:28+0000&quot; </p><p style=\"margin-bottom: 0px\">Information Source: #4mfRzWw4DxNmp8a8!</p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-exposure-contact-information.html\">US Public Health Exposure Contact Information</a></p></div><p><b>status</b>: final</p><p><b>category</b>: An interaction between entities that provides opportunity for transmission of a physical, chemical, or biological agent from an exposure source entity to an exposure target entity. <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.3.0/CodeSystem-v3-ActClass.html\">ActClass</a>#EXPOS &quot;exposure&quot;)</span></p><p><b>code</b>: Mass gathering (football game) <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.3.0/CodeSystem-umls.html\">Unified Medical Language System</a>#C3841750 &quot;Mass gathering&quot;)</span></p><p><b>subject</b>: <a href=\"Patient-patient-ecr-eve-everywoman.html\">Patient/patient-ecr-eve-everywoman: Eve Everywoman</a> &quot;&quot;</p><p><b>focus</b>: <a href=\"Location-location-ecr-city-football-stadium.html\">Location/location-ecr-city-football-stadium: City Football Stadium</a> &quot;City Football Stadium&quot;</p><p><b>effective</b>: 2020-01-11 18:00:00+0000 --&gt; 2020-01-11 21:30:00+0000</p><p><b>value</b>: City Football Stadium <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT</a>#264379009 &quot;Sports stadium (environment)&quot;)</span></p><h3>Components</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Code</b></td><td><b>Value[x]</b></td></tr><tr><td style=\"display: none\">*</td><td>ExposureAgent <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.3.0/CodeSystem-v3-ParticipationType.html\">ParticipationType</a>#EXPAGNT)</span></td><td>Severe acute respiratory syndrome coronavirus 2 (organism) <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT</a>#840533007)</span></td></tr></table></div>"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ActClass",
+                "code": "EXPOS",
+                "display": "exposure"
+              }
+            ],
+            "text": "An interaction between entities that provides opportunity for transmission of a physical, chemical, or biological agent from an exposure source entity to an exposure target entity."
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/umls",
+              "code": "C3841750",
+              "display": "Mass gathering"
+            }
+          ],
+          "text": "Mass gathering (football game)"
+        },
+        "subject": {
+          "reference": "Patient/patient-ecr-eve-everywoman",
+          "display": "Eve Everywoman"
+        },
+        "focus": [
+          {
+            "reference": "Location/location-ecr-city-football-stadium",
+            "display": "City Football Stadium"
+          }
+        ],
+        "effectivePeriod": {
+          "start": "2020-01-11T18:00:00Z",
+          "end": "2020-01-11T21:30:00Z"
+        },
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "264379009",
+              "display": "Sports stadium (environment)"
+            }
+          ],
+          "text": "City Football Stadium"
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                  "code": "EXPAGNT",
+                  "display": "ExposureAgent"
+                }
+              ]
+            },
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "840533007",
+                  "display": "Severe acute respiratory syndrome coronavirus 2 (organism)"
+                }
+              ]
+            }
+          }
+        ]
+      }
     }
   ]
 }

--- a/containers/message-parser/assets/sample_phdc.xml
+++ b/containers/message-parser/assets/sample_phdc.xml
@@ -117,4 +117,34 @@
       </entry>
     </section>
   </component>
+  <component>
+    <section>
+      <code code="1234567-RPT" codeSystem="Local-codesystem-oid" codeSystemName="LocalSystem" displayName="Generic Repeating Questions Section"/>
+      <title>REPEATING QUESTIONS</title>
+      <entry typeCode="COMP">
+        <organizer classCode="CLUSTER" moodCode="EVN">
+          <code code="1" displayName="Exposure Information" codeSytemName="LocalSystem"/>
+          <status_code code="completed"/>
+          <component>
+            <observation classCode="OBS" moodCode="EVN">
+              <code code="INV502" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Country of Exposure"/>
+              <value xsi:type="CE" code="ATA" codeSystem="1.0.3166.1" codeSystemName="Country (ISO 3166-1)" displayName="ANTARCTICA"/>
+            </observation>
+          </component>
+        </organizer>
+      </entry>
+      <entry typeCode="COMP">
+        <organizer classCode="CLUSTER" moodCode="EVN">
+          <code code="1" displayName="Exposure Information" codeSytemName="LocalSystem"/>
+          <status_code code="completed"/>
+          <component>
+            <observation classCode="OBS" moodCode="EVN">
+              <code code="INV504" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="City of Exposure"/>
+              <value xsi:type="TS">Esperanze</value>
+            </observation>
+          </component>
+        </organizer>
+      </entry>
+    </section>
+  </component>
 </ClinicalDocument>

--- a/containers/message-parser/assets/sample_phdc_repeating_questions.xml
+++ b/containers/message-parser/assets/sample_phdc_repeating_questions.xml
@@ -1,0 +1,33 @@
+<?xml version='1.0' encoding='utf-8'?>
+<component>
+  <section>
+    <code code="1234567-RPT" codeSystem="Local-codesystem-oid" codeSystemName="LocalSystem" displayName="Generic Repeating Questions Section"/>
+    <title>REPEATING QUESTIONS</title>
+    <entry typeCode="COMP">
+      <organizer classCode="CLUSTER" moodCode="EVN">
+        <code code="1" displayName="Exposure Information" codeSytemName="LocalSystem"/>
+        <status_code code="completed"/>
+        <component>
+          <observation classCode="OBS" moodCode="EVN">
+            <code code="DEM127" codeSystem="2.16.840.1.114222.4.5.232" codeSystemName="PHIN Questions" displayName="Is this person deceased?"/>
+            <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CE" code="N" codeSystem="2.16.840.1.113883.12.136" codeSystemName="Yes/No Indicator (HL7)" displayName="No">
+              <translation code="N" codeSystem="2.16.840.1.113883.12.136" codeSystemName="2.16.840.1.113883.12.136" displayName="No"/>
+            </value>
+          </observation>
+        </component>
+      </organizer>
+    </entry>
+    <entry typeCode="COMP">
+      <organizer classCode="CLUSTER" moodCode="EVN">
+        <code code="1" displayName="Exposure Information" codeSytemName="LocalSystem"/>
+        <status_code code="completed"/>
+        <component>
+          <observation classCode="OBS" moodCode="EVN">
+            <code code="NBS104" codeSystem="2.16.840.1.114222.4.5.1" codeSystemName="NEDSS Base System" displayName="Information As of Date"/>
+            <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="TS">20240124</value>
+          </observation>
+        </component>
+      </organizer>
+    </entry>
+  </section>
+</component>

--- a/containers/message-parser/tests/integration/test_message_parser.py
+++ b/containers/message-parser/tests/integration/test_message_parser.py
@@ -162,6 +162,18 @@ def test_parse_message(setup):
                     "value_qualitative_code_system": None,
                     "value_qualitative_code": None,
                 },
+                {
+                    "obs_type": "EXPOS",
+                    "code_code": "C3841750",
+                    "code_code_system": "http://terminology.hl7.org/CodeSystem/umls",
+                    "code_code_display": "Mass gathering",
+                    "value_quantitative_value": None,
+                    "value_quantitative_code_system": None,
+                    "value_quantitative_code": None,
+                    "value_qualitative_value": "Sports stadium (environment)",
+                    "value_qualitative_code_system": "http://snomed.info/sct",
+                    "value_qualitative_code": "264379009",
+                },
             ],
         },
     }

--- a/containers/message-parser/tests/test_fhir_to_phdc_endpoint.py
+++ b/containers/message-parser/tests/test_fhir_to_phdc_endpoint.py
@@ -41,4 +41,3 @@ def test_endpoint():
     actual_response = client.post("/fhir_to_phdc", json=test_request)
     assert actual_response.status_code == 200
     assert actual_response.text == expected_successful_response
-    # print(actual_response.text)

--- a/containers/message-parser/tests/test_phdc.py
+++ b/containers/message-parser/tests/test_phdc.py
@@ -822,6 +822,43 @@ def test_build_social_history_info(build_social_history_info_data, expected_resu
                         ),
                     ),
                 ],
+                repeating_questions=[
+                    Observation(
+                        obs_type="EXPOS",
+                        type_code="COMP",
+                        class_code="OBS",
+                        mood_code="EVN",
+                        code=CodedElement(
+                            code="INV502",
+                            code_system="2.16.840.1.113883.6.1",
+                            code_system_name="LOINC",
+                            display_name="Country of Exposure",
+                        ),
+                        value=CodedElement(
+                            xsi_type="CE",
+                            code="ATA",
+                            code_system_name="Country (ISO 3166-1)",
+                            display_name="ANTARCTICA",
+                            code_system="1.0.3166.1",
+                        ),
+                    ),
+                    Observation(
+                        obs_type="EXPOS",
+                        type_code="COMP",
+                        class_code="OBS",
+                        mood_code="EVN",
+                        code=CodedElement(
+                            code="INV504",
+                            code_system="2.16.840.1.113883.6.1",
+                            code_system_name="LOINC",
+                            display_name="City of Exposure",
+                        ),
+                        value=CodedElement(
+                            xsi_type="TS",
+                            text="Esperanze",
+                        ),
+                    ),
+                ],
                 organization=[
                     Organization(
                         id="112233",
@@ -907,3 +944,75 @@ def test_sort_observation(sort_observation_test_data, expected_result):
 
     assert actual_result.code == expected_result.code
     assert actual_result.value == expected_result.value
+
+
+@pytest.mark.parametrize(
+    "build_repeating_questions_data, expected_result",
+    [
+        # Example test case
+        (
+            (
+                PHDCInputData(
+                    repeating_questions=[
+                        Observation(
+                            obs_type="EXPOS",
+                            type_code="COMP",
+                            class_code="OBS",
+                            mood_code="EVN",
+                            code=CodedElement(
+                                code="DEM127",
+                                code_system="2.16.840.1.114222.4.5.232",
+                                code_system_name="PHIN Questions",
+                                display_name="Is this person deceased?",
+                            ),
+                            value=CodedElement(
+                                xsi_type="CE",
+                                code="N",
+                                code_system_name="Yes/No Indicator (HL7)",
+                                display_name="No",
+                                code_system="2.16.840.1.113883.12.136",
+                            ),
+                            translation=CodedElement(
+                                code="N",
+                                code_system="2.16.840.1.113883.12.136",
+                                code_system_name="2.16.840.1.113883.12.136",
+                                display_name="No",
+                            ),
+                        ),
+                        Observation(
+                            obs_type="EXPOS",
+                            type_code="COMP",
+                            class_code="OBS",
+                            mood_code="EVN",
+                            code=CodedElement(
+                                code="NBS104",
+                                code_system="2.16.840.1.114222.4.5.1",
+                                code_system_name="NEDSS Base System",
+                                display_name="Information As of Date",
+                            ),
+                            value=CodedElement(
+                                xsi_type="TS",
+                                text="20240124",
+                            ),
+                        ),
+                    ]
+                )
+            ),
+            # Expected XML output as a string
+            utils.read_file_from_assets("sample_phdc_repeating_questions.xml"),
+        ),
+    ],
+)
+def test_build_repeating_questions(build_repeating_questions_data, expected_result):
+    builder = PHDCBuilder()
+    builder.set_input_data(build_repeating_questions_data)
+    repeating_questions = builder._build_repeating_questions()
+    assert (
+        ET.tostring(
+            repeating_questions,
+            pretty_print=True,
+            xml_declaration=True,
+            encoding="utf-8",
+        ).decode("utf-8")
+        == expected_result
+    )


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR adds a repeating questions section. For the MVP and until we know more from Texas/NBS, we are only adding Observations where `category` == `EXPOS` (exposure) to the repeating questions section. 

## Related Issue
Fixes #1243 

## Additional Information
Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
