### PR TITLE
Add `assignedPerson` to `assignedAuthor`

### DIFF
--- a/containers/message-parser/app/phdc/builder.py
+++ b/containers/message-parser/app/phdc/builder.py
@@ -645,6 +645,7 @@ class PHDCBuilder:
         id_element = ET.Element("id")
         id_element.set("root", "2.16.840.1.113883.19.5")
         assigned_author.append(id_element)
+        assigned_person = ET.SubElement(assigned_author, "assignedPerson")
 
         # family name is the example way to add either a project name or source of
         # the data being migrated
@@ -652,7 +653,8 @@ class PHDCBuilder:
         family_element = ET.SubElement(name_element, "family")
         family_element.text = family_name
 
-        assigned_author.append(name_element)
+        assigned_person.append(name_element)
+        assigned_author.append(assigned_person)
 
         author_element.append(assigned_author)
 

--- a/containers/message-parser/assets/demo_phdc.xml
+++ b/containers/message-parser/assets/demo_phdc.xml
@@ -31,9 +31,11 @@
     <time value="20101215000000"/>
     <assignedAuthor>
       <id root="2.16.840.1.113883.19.5"/>
-      <name>
-        <family>DIBBS</family>
-      </name>
+      <assignedPerson>
+        <name>
+          <family>DIBBS</family>
+        </name>
+      </assignedPerson>
     </assignedAuthor>
   </author>
   <recordTarget>

--- a/containers/message-parser/assets/sample_phdc.xml
+++ b/containers/message-parser/assets/sample_phdc.xml
@@ -32,9 +32,11 @@
     <time value="20101215000000"/>
     <assignedAuthor>
       <id root="2.16.840.1.113883.19.5"/>
-      <name>
-        <family>DIBBS</family>
-      </name>
+      <assignedPerson>
+        <name>
+          <family>DIBBS</family>
+        </name>
+      </assignedPerson>
     </assignedAuthor>
   </author>
   <recordTarget>

--- a/containers/message-parser/assets/sample_phdc_header.xml
+++ b/containers/message-parser/assets/sample_phdc_header.xml
@@ -21,9 +21,11 @@
     <time value="20101215000000"/>
     <assignedAuthor>
       <id root="2.16.840.1.113883.19.5"/>
-      <name>
-        <family>DIBBS</family>
-      </name>
+      <assignedPerson>
+        <name>
+          <family>DIBBS</family>
+        </name>
+      </assignedPerson>
     </assignedAuthor>
   </author>
   <recordTarget>

--- a/containers/message-parser/tests/test_phdc.py
+++ b/containers/message-parser/tests/test_phdc.py
@@ -259,7 +259,7 @@ def test_build_custodian(build_custodian_test_data, expected_result):
 
 @patch.object(utils, "get_datetime_now", lambda: date(2010, 12, 15))
 @pytest.mark.parametrize(
-    "family_name, expected_oid, expected_date, expected_name",
+    "family_name, expected_oid, expected_date, expected_author",
     [
         # test for correct OID and name "CDC PRIME DIBBs"
         (
@@ -267,10 +267,9 @@ def test_build_custodian(build_custodian_test_data, expected_result):
             "2.16.840.1.113883.19.5",
             "20101215000000",
             (
-                '<author><time value="20101215000000"/><assignedAuthor>'
-                '<id root="2.16.840.1.113883.19.5"/><name>'
-                "<family>CDC PRIME DIBBs</family></name>"
-                "</assignedAuthor></author>"
+                '<author><time value="20101215000000"/><assignedAuthor><id root='
+                + '"2.16.840.1.113883.19.5"/><assignedPerson><name><family>CDC PRIME '
+                + "DIBBs</family></name></assignedPerson></assignedAuthor></author>"
             ),
         ),
         # test for correct OID and name "Local Health Jurisdiction"
@@ -279,21 +278,21 @@ def test_build_custodian(build_custodian_test_data, expected_result):
             "2.16.840.1.113883.19.5",
             "20101215000000",
             (
-                '<author><time value="20101215000000"/><assignedAuthor>'
-                '<id root="2.16.840.1.113883.19.5"/><name>'
-                "<family>Local Health Jurisdiction</family></name>"
-                "</assignedAuthor></author>"
+                '<author><time value="20101215000000"/><assignedAuthor><id root="2.16.'
+                + '840.1.113883.19.5"/><assignedPerson><name><family>Local Health '
+                + "Jurisdiction</family></name></assignedPerson></assignedAuthor>"
+                + "</author>"
             ),
         ),
     ],
 )
-def test_build_author(family_name, expected_oid, expected_date, expected_name):
+def test_build_author(family_name, expected_oid, expected_date, expected_author):
     xml_author_data = PHDCBuilder()._build_author(family_name)
     author_string = ET.tostring(xml_author_data).decode()
-
     assert expected_oid in author_string
     assert expected_date in author_string
-    assert expected_name in author_string
+    assert expected_author in author_string
+    assert expected_author == author_string
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR adds the `assignedPerson` subelement to the `assignedAuthor` element in order to pass validation.

## Related Issue
Fixes #1279 

## Additional Information
Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
