### PR TITLE
Move `<telecom>` after `<name>` in `build_custodian` method

### DIFF
--- a/containers/message-parser/app/phdc/builder.py
+++ b/containers/message-parser/app/phdc/builder.py
@@ -605,12 +605,12 @@ class PHDCBuilder:
 
             self._add_field(represented_organization, organization.name, "name")
 
-            if organization.address is not None:
-                represented_organization.append(self._build_addr(organization.address))
             if organization.telecom is not None:
                 represented_organization.append(
                     self._build_telecom(organization.telecom)
                 )
+            if organization.address is not None:
+                represented_organization.append(self._build_addr(organization.address))
 
             assigned_custodian.append(represented_organization)
 

--- a/containers/message-parser/app/phdc/models.py
+++ b/containers/message-parser/app/phdc/models.py
@@ -75,8 +75,8 @@ class Organization:
 
     id: str = None
     name: str = None
-    address: Address = None
     telecom: Telecom = None
+    address: Address = None
 
 
 @dataclass

--- a/containers/message-parser/assets/demo_phdc.xml
+++ b/containers/message-parser/assets/demo_phdc.xml
@@ -15,6 +15,7 @@
       <representedCustodianOrganization>
         <id extension="495669c7-96bf-4573-9dd8-59e745e05576"/>
         <name>Sunny Vale</name>
+        <telecom value="999-999-9999"/>
         <addr>
           <streetAddressLine>999 North Ridge Road</streetAddressLine>
           <streetAddressLine>Building 3</streetAddressLine>
@@ -23,7 +24,6 @@
           <postalCode>33721</postalCode>
           <county>Duvall</county>
         </addr>
-        <telecom value="999-999-9999"/>
       </representedCustodianOrganization>
     </assignedCustodian>
   </custodian>

--- a/containers/message-parser/assets/sample_phdc.xml
+++ b/containers/message-parser/assets/sample_phdc.xml
@@ -15,6 +15,7 @@
       <representedCustodianOrganization>
         <id extension="112233"/>
         <name>Happy Labs</name>
+        <telecom value="8888675309"/>
         <addr>
           <streetAddressLine>23 main st</streetAddressLine>
           <streetAddressLine>apt 12</streetAddressLine>
@@ -24,7 +25,6 @@
           <county>Tarrant</county>
           <country>USA</country>
         </addr>
-        <telecom value="8888675309"/>
       </representedCustodianOrganization>
     </assignedCustodian>
   </custodian>

--- a/containers/message-parser/tests/test_phdc.py
+++ b/containers/message-parser/tests/test_phdc.py
@@ -202,6 +202,7 @@ def test_build_name(build_name_test_data, expected_result):
                 Organization(
                     id="112233",
                     name="Happy Labs",
+                    telecom=Telecom(value="8888675309"),
                     address=Address(
                         street_address_line_1="23 main st",
                         street_address_line_2="apt 12",
@@ -211,7 +212,6 @@ def test_build_name(build_name_test_data, expected_result):
                         county="Tarrant",
                         country="USA",
                     ),
-                    telecom=Telecom(value="8888675309"),
                 )
             ],
             (
@@ -220,6 +220,7 @@ def test_build_name(build_name_test_data, expected_result):
                 "    <representedCustodianOrganization>\n"
                 '      <id extension="112233"/>\n'
                 "      <name>Happy Labs</name>\n"
+                '      <telecom value="8888675309"/>\n'
                 "      <addr>\n"
                 "        <streetAddressLine>23 main st</streetAddressLine>\n"
                 "        <streetAddressLine>apt 12</streetAddressLine>\n"
@@ -229,7 +230,6 @@ def test_build_name(build_name_test_data, expected_result):
                 "        <county>Tarrant</county>\n"
                 "        <country>USA</country>\n"
                 "      </addr>\n"
-                '      <telecom value="8888675309"/>\n'
                 "    </representedCustodianOrganization>\n"
                 "  </assignedCustodian>\n"
                 "</custodian>\n"


### PR DESCRIPTION
# PULL REQUEST

## Summary
Currently PHDC validation is throwing an error related to the placement of `<telecom>` inside of `<representedCustodianOrganization>`. In order to begin producing valid PHDC and to build a path towards a PHDC XML validation integration test, we're moving the placement within `build_custodian` .

## Related Issue
Fixes:
- #1280 

[//]: # (PR title: Remember to name your PR descriptively!)
