### PR TITLE
Move `<recordTarget>` and swap `<author>` and `<custodian>`

### DIFF
--- a/containers/message-parser/app/phdc/builder.py
+++ b/containers/message-parser/app/phdc/builder.py
@@ -234,9 +234,6 @@ class PHDCBuilder:
         root.append(self._get_confidentiality_code(confidentiality="normal"))
         root.append(self._get_setId())
         root.append(self._get_version_number())
-
-        root.append(self._build_custodian(organizations=self.input_data.organization))
-        root.append(self._build_author(family_name="DIBBS"))
         root.append(
             self._build_recordTarget(
                 id=str(uuid.uuid4()),
@@ -247,6 +244,8 @@ class PHDCBuilder:
                 patient_data=self.input_data.patient,
             )
         )
+        root.append(self._build_author(family_name="CDC PRIME DIBBs"))
+        root.append(self._build_custodian(organizations=self.input_data.organization))
 
     def build_body(self):
         """

--- a/containers/message-parser/assets/demo_phdc.xml
+++ b/containers/message-parser/assets/demo_phdc.xml
@@ -10,34 +10,6 @@
   <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
   <setId extension="CLOSED_CASE" displayable="true"/>
   <versionNumber value="1"/>
-  <custodian>
-    <assignedCustodian>
-      <representedCustodianOrganization>
-        <id extension="495669c7-96bf-4573-9dd8-59e745e05576"/>
-        <name>Sunny Vale</name>
-        <telecom value="999-999-9999"/>
-        <addr>
-          <streetAddressLine>999 North Ridge Road</streetAddressLine>
-          <streetAddressLine>Building 3</streetAddressLine>
-          <city>Amherst</city>
-          <state>Massachusetts</state>
-          <postalCode>33721</postalCode>
-          <county>Duvall</county>
-        </addr>
-      </representedCustodianOrganization>
-    </assignedCustodian>
-  </custodian>
-  <author>
-    <time value="20101215000000"/>
-    <assignedAuthor>
-      <id root="2.16.840.1.113883.19.5"/>
-      <assignedPerson>
-        <name>
-          <family>DIBBS</family>
-        </name>
-      </assignedPerson>
-    </assignedAuthor>
-  </author>
   <recordTarget>
     <patientRole>
       <id extension="495669c7-96bf-4573-9dd8-59e745e05576" root="2.16.840.1.113883.4.1" assigningAuthorityName="LR"/>
@@ -69,6 +41,34 @@
       </patient>
     </patientRole>
   </recordTarget>
+  <author>
+    <time value="20101215000000"/>
+    <assignedAuthor>
+      <id root="2.16.840.1.113883.19.5"/>
+      <assignedPerson>
+        <name>
+          <family>CDC PRIME DIBBs</family>
+        </name>
+      </assignedPerson>
+    </assignedAuthor>
+  </author>
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <id extension="495669c7-96bf-4573-9dd8-59e745e05576"/>
+        <name>Sunny Vale</name>
+        <telecom value="999-999-9999"/>
+        <addr>
+          <streetAddressLine>999 North Ridge Road</streetAddressLine>
+          <streetAddressLine>Building 3</streetAddressLine>
+          <city>Amherst</city>
+          <state>Massachusetts</state>
+          <postalCode>33721</postalCode>
+          <county>Duvall</county>
+        </addr>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
   <component>
     <section>
       <id extension="495669c7-96bf-4573-9dd8-59e745e05576" assigningAuthorityName="LR"/>

--- a/containers/message-parser/assets/sample_phdc.xml
+++ b/containers/message-parser/assets/sample_phdc.xml
@@ -10,35 +10,6 @@
   <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
   <setId extension="CLOSED_CASE" displayable="true"/>
   <versionNumber value="1"/>
-  <custodian>
-    <assignedCustodian>
-      <representedCustodianOrganization>
-        <id extension="112233"/>
-        <name>Happy Labs</name>
-        <telecom value="8888675309"/>
-        <addr>
-          <streetAddressLine>23 main st</streetAddressLine>
-          <streetAddressLine>apt 12</streetAddressLine>
-          <city>Fort Worth</city>
-          <state>Texas</state>
-          <postalCode>76006</postalCode>
-          <county>Tarrant</county>
-          <country>USA</country>
-        </addr>
-      </representedCustodianOrganization>
-    </assignedCustodian>
-  </custodian>
-  <author>
-    <time value="20101215000000"/>
-    <assignedAuthor>
-      <id root="2.16.840.1.113883.19.5"/>
-      <assignedPerson>
-        <name>
-          <family>DIBBS</family>
-        </name>
-      </assignedPerson>
-    </assignedAuthor>
-  </author>
   <recordTarget>
     <patientRole>
       <id extension="mocked-uuid" root="2.16.840.1.113883.4.1" assigningAuthorityName="LR"/>
@@ -75,6 +46,35 @@
       </patient>
     </patientRole>
   </recordTarget>
+  <author>
+    <time value="20101215000000"/>
+    <assignedAuthor>
+      <id root="2.16.840.1.113883.19.5"/>
+      <assignedPerson>
+        <name>
+          <family>CDC PRIME DIBBs</family>
+        </name>
+      </assignedPerson>
+    </assignedAuthor>
+  </author>
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <id extension="112233"/>
+        <name>Happy Labs</name>
+        <telecom value="8888675309"/>
+        <addr>
+          <streetAddressLine>23 main st</streetAddressLine>
+          <streetAddressLine>apt 12</streetAddressLine>
+          <city>Fort Worth</city>
+          <state>Texas</state>
+          <postalCode>76006</postalCode>
+          <county>Tarrant</county>
+          <country>USA</country>
+        </addr>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
   <component>
     <section>
       <id extension="mocked-uuid" assigningAuthorityName="LR"/>

--- a/containers/message-parser/assets/sample_phdc_header.xml
+++ b/containers/message-parser/assets/sample_phdc_header.xml
@@ -10,24 +10,6 @@
   <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
   <setId extension="CLOSED_CASE" displayable="true"/>
   <versionNumber value="1"/>
-  <custodian>
-    <assignedCustodian>
-      <representedCustodianOrganization>
-        <id extension="112233"/>
-      </representedCustodianOrganization>
-    </assignedCustodian>
-  </custodian>
-  <author>
-    <time value="20101215000000"/>
-    <assignedAuthor>
-      <id root="2.16.840.1.113883.19.5"/>
-      <assignedPerson>
-        <name>
-          <family>DIBBS</family>
-        </name>
-      </assignedPerson>
-    </assignedAuthor>
-  </author>
   <recordTarget>
     <patientRole>
       <id extension="mocked-uuid" root="2.16.840.1.113883.4.1" assigningAuthorityName="LR"/>
@@ -64,4 +46,22 @@
       </patient>
     </patientRole>
   </recordTarget>
+  <author>
+    <time value="20101215000000"/>
+    <assignedAuthor>
+      <id root="2.16.840.1.113883.19.5"/>
+      <assignedPerson>
+        <name>
+          <family>CDC PRIME DIBBs</family>
+        </name>
+      </assignedPerson>
+    </assignedAuthor>
+  </author>
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <id extension="112233"/>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
 </ClinicalDocument>


### PR DESCRIPTION
# PULL REQUEST

## Summary
We need to reorder these fields in order for the PHDC XML validator to be happy. The correct ordering is:

1. `<recordTarget>`
2. `<author>`
3. `<custodian>`

## Related Issue
Fixes:
- #1274 
