### PR TITLE
Update `birthTime` for validation & add direct xml comparison in test

### DIFF
--- a/containers/message-parser/app/phdc/builder.py
+++ b/containers/message-parser/app/phdc/builder.py
@@ -717,6 +717,17 @@ class PHDCBuilder:
             )
             patient_data.append(v)
 
+        if patient.birth_time is not None:
+            e = ET.Element(
+                "birthTime",
+                {
+                    "value": "".join(
+                        [num for num in patient.birth_time if num.isnumeric()]
+                    )
+                },
+            )
+            patient_data.append(e)
+
         if patient.race_code is not None:
             if patient.race_code in race_code_and_mapping:
                 display_name = race_code_and_mapping[patient.race_code]
@@ -750,11 +761,6 @@ class PHDCBuilder:
                     f"Ethnic group code {patient.ethnic_group_code} not "
                     "found in OMB classification."
                 )
-
-        if patient.birth_time is not None:
-            e = ET.Element("birthTime")
-            e.text = patient.birth_time
-            patient_data.append(e)
 
         return patient_data
 

--- a/containers/message-parser/app/utils.py
+++ b/containers/message-parser/app/utils.py
@@ -20,6 +20,7 @@ from app.phdc.models import PHDCInputData
 from app.phdc.models import Telecom
 from fastapi import status
 from frozendict import frozendict
+from lxml import etree as ET
 
 from phdi.cloud.azure import AzureCredentialManager
 from phdi.cloud.core import BaseCredentialManager
@@ -325,6 +326,24 @@ def read_file_from_assets(filename: str) -> str:
         (pathlib.Path(__file__).parent.parent / "assets" / filename), "r"
     ) as file:
         return file.read()
+
+
+def parse_file_from_assets(filename: str) -> ET.ElementTree:
+    """
+    Parses a file from the assets directory into an ElementTree.
+
+    :param filename: The name of the file to read.
+    :return: An ElementTree containing the contents of the file.
+    """
+    with open(
+        (pathlib.Path(__file__).parent.parent / "assets" / filename), "r"
+    ) as file:
+        parser = ET.XMLParser(remove_blank_text=True)
+        tree = ET.parse(
+            file,
+            parser,
+        )
+        return tree
 
 
 def get_datetime_now() -> datetime.datetime:

--- a/containers/message-parser/assets/demo_phdc.xml
+++ b/containers/message-parser/assets/demo_phdc.xml
@@ -63,9 +63,9 @@
           <family>Levinson</family>
         </name>
         <administrativeGenderCode displayName="female"/>
+        <birthTime value="19960417"/>
         <sdt:raceCode code="2028-9" codeSystem="2.16.840.1.113883.6.238" displayName="Asian" codeSystemName="Race &amp; Ethnicity"/>
         <ethnicGroupCode code="2186-5" codeSystem="2.16.840.1.113883.6.238" displayName="Not Hispanic or Latino" codeSystemName="Race &amp; Ethnicity"/>
-        <birthTime>1996-04-17</birthTime>
       </patient>
     </patientRole>
   </recordTarget>

--- a/containers/message-parser/assets/sample_phdc.xml
+++ b/containers/message-parser/assets/sample_phdc.xml
@@ -69,9 +69,9 @@
           <family>Schmidt</family>
         </name>
         <administrativeGenderCode displayName="Male"/>
+        <birthTime value="01012000"/>
         <sdt:raceCode code="2106-3" codeSystem="2.16.840.1.113883.6.238" displayName="White" codeSystemName="Race &amp; Ethnicity"/>
         <ethnicGroupCode code="2186-5" codeSystem="2.16.840.1.113883.6.238" displayName="Not Hispanic or Latino" codeSystemName="Race &amp; Ethnicity"/>
-        <birthTime>01-01-2000</birthTime>
       </patient>
     </patientRole>
   </recordTarget>

--- a/containers/message-parser/assets/sample_phdc_header.xml
+++ b/containers/message-parser/assets/sample_phdc_header.xml
@@ -58,9 +58,9 @@
           <family>Schmidt</family>
         </name>
         <administrativeGenderCode displayName="Male"/>
+        <birthTime value="01012000"/>
         <sdt:raceCode code="2106-3" codeSystem="2.16.840.1.113883.6.238" displayName="White" codeSystemName="Race &amp; Ethnicity"/>
         <ethnicGroupCode code="2186-5" codeSystem="2.16.840.1.113883.6.238" displayName="Not Hispanic or Latino" codeSystemName="Race &amp; Ethnicity"/>
-        <birthTime>01-01-2000</birthTime>
       </patient>
     </patientRole>
   </recordTarget>

--- a/containers/message-parser/assets/sample_phdc_patient_element.xml
+++ b/containers/message-parser/assets/sample_phdc_patient_element.xml
@@ -1,0 +1,12 @@
+<patient>
+  <name>
+    <prefix>Mr.</prefix>
+    <given>John</given>
+    <given>Jacob</given>
+    <family>Schmidt</family>
+  </name>
+  <administrativeGenderCode displayName="Male"/>
+  <birthTime value="01012000"/>
+  <sdt:raceCode xmlns:sdt="urn:hl7-org:sdtc" code="2106-3" codeSystem="2.16.840.1.113883.6.238" displayName="White" codeSystemName="Race &amp; Ethnicity"/>
+  <ethnicGroupCode code="2186-5" codeSystem="2.16.840.1.113883.6.238" displayName="Not Hispanic or Latino" codeSystemName="Race &amp; Ethnicity"/>
+</patient>

--- a/containers/message-parser/requirements.txt
+++ b/containers/message-parser/requirements.txt
@@ -6,3 +6,4 @@ httpx
 pytest
 frozendict
 testcontainers[compose]==3.7.1
+xmldiff

--- a/containers/message-parser/tests/test_phdc.py
+++ b/containers/message-parser/tests/test_phdc.py
@@ -14,6 +14,8 @@ from app.phdc.models import Patient
 from app.phdc.models import PHDCInputData
 from app.phdc.models import Telecom
 from lxml import etree as ET
+from xmldiff import formatting
+from xmldiff import main as xmldiff
 
 
 @pytest.mark.parametrize(
@@ -309,27 +311,33 @@ def test_build_author(family_name, expected_oid, expected_date, expected_author)
                 administrative_gender_code="Male",
                 birth_time="01-01-2000",
             ),
-            (
-                "<patient><name><prefix>Mr.</prefix><given>John</given>"
-                + "<given>Jacob</given><family>Schmidt</family></name>"
-                + '<administrativeGenderCode displayName="Male"/>'
-                + '<sdt:raceCode xmlns:sdt="urn:hl7-org:sdtc" code="2106-3" '
-                + 'codeSystem="2.16.840.1.113883.6.238" '
-                + 'displayName="White" codeSystemName="Race &amp; Ethnicity"/>'
-                + '<ethnicGroupCode code="2186-5" codeSystem="2.16.840.1.113883.6.238" '
-                + 'displayName="Not Hispanic or Latino" '
-                + 'codeSystemName="Race &amp; Ethnicity"/>'
-                + "<birthTime>01-01-2000</birthTime>"
-                + "</patient>"
-            ),
+            (utils.parse_file_from_assets("sample_phdc_patient_element.xml")),
         )
     ],
 )
 def test_build_patient(build_patient_test_data, expected_result):
     builder = PHDCBuilder()
-
     xml_patient_data = builder._build_patient(build_patient_test_data)
-    assert ET.tostring(xml_patient_data).decode() == expected_result
+    formatter = formatting.DiffFormatter(
+        normalize=formatting.WS_BOTH, pretty_print=True
+    )
+    diff = xmldiff.diff_trees(xml_patient_data, expected_result, formatter=formatter)
+
+    assert diff == ""
+
+
+def elements_equal(e1, e2):
+    if e1.tag != e2.tag:
+        return False
+    if e1.text != e2.text:
+        return False
+    if e1.tail != e2.tail:
+        return False
+    if e1.attrib != e2.attrib:
+        return False
+    if len(e1) != len(e2):
+        return False
+    return all(elements_equal(c1, c2) for c1, c2 in zip(e1, e2))
 
 
 @pytest.mark.parametrize(

--- a/containers/message-parser/tests/test_phdc.py
+++ b/containers/message-parser/tests/test_phdc.py
@@ -326,20 +326,6 @@ def test_build_patient(build_patient_test_data, expected_result):
     assert diff == ""
 
 
-def elements_equal(e1, e2):
-    if e1.tag != e2.tag:
-        return False
-    if e1.text != e2.text:
-        return False
-    if e1.tail != e2.tail:
-        return False
-    if e1.attrib != e2.attrib:
-        return False
-    if len(e1) != len(e2):
-        return False
-    return all(elements_equal(c1, c2) for c1, c2 in zip(e1, e2))
-
-
 @pytest.mark.parametrize(
     "build_rt_test_data, expected_result",
     [


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR updates the `birthTime` element so that it is in the correct place and formatted correctly with a `value` for validation. I also implemented a new function in utils.py to parse XML files to make it easier to make comparisons of XML trees in our tests (instead of stringified versions of the XMLs). I used [xmldiff](https://xmldiff.readthedocs.io/en/stable/index.html) because it had documentation that was easy to follow and would allow us to compare files, trees, or text versions, but I'm not strongly attached to it if we go another route for testing.


## Related Issue
Fixes #1278 

## Additional Information
Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
