### PR TITLE
Fix `<structuredBody>`; ensure all `_build` related elements are attributes of `<structuredBody>`

### DIFF
--- a/containers/message-parser/app/phdc/builder.py
+++ b/containers/message-parser/app/phdc/builder.py
@@ -257,9 +257,9 @@ class PHDCBuilder:
 
         match self.input_data.type:
             case "case_report":
-                self.phdc.getroot().append(self._build_social_history_info())
-                self.phdc.getroot().append(self._build_clinical_info())
-                self.phdc.getroot().append(self._build_repeating_questions())
+                structured_body.append(self._build_social_history_info())
+                structured_body.append(self._build_clinical_info())
+                structured_body.append(self._build_repeating_questions())
 
             case "contact_record":
                 pass
@@ -267,6 +267,8 @@ class PHDCBuilder:
                 pass
             case "morbidity_report":
                 pass
+
+        self.phdc.getroot().append(body)
 
     def _build_clinical_info(self) -> ET.Element:
         """

--- a/containers/message-parser/assets/demo_phdc.xml
+++ b/containers/message-parser/assets/demo_phdc.xml
@@ -70,53 +70,57 @@
     </assignedCustodian>
   </custodian>
   <component>
-    <section>
-      <id extension="495669c7-96bf-4573-9dd8-59e745e05576" assigningAuthorityName="LR"/>
-      <code code="29762-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Social history"/>
-      <title>SOCIAL HISTORY INFORMATION</title>
-      <entry typeCode="COMP">
-        <observation classCode="OBS" moodCode="EVN">
-          <code code="alcohol-type" codeSystem="http://acme-rehab.org" displayName="Type of alcohol consumed"/>
-          <value/>
-        </observation>
-      </entry>
-    </section>
-  </component>
-  <component>
-    <section>
-      <id extension="495669c7-96bf-4573-9dd8-59e745e05576" assigningAuthorityName="LR"/>
-      <code code="55752-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Clinical Information"/>
-      <title>Clinical Information</title>
-      <entry typeCode="COMP">
-        <observation classCode="OBS" moodCode="EVN">
-          <code code="15074-8" codeSystem="http://loinc.org" displayName="Glucose [Moles/volume] in Blood"/>
-          <value code="mmol/L" codeSystem="http://unitsofmeasure.org" value="6.3"/>
-        </observation>
-      </entry>
-      <entry typeCode="COMP">
-        <observation classCode="OBS" moodCode="EVN">
-          <code code="104177,600-7" codeSystem="http://acmelabs.org,http://loinc.org" displayName="Blood culture,Bacteria identified in Blood by Culture"/>
-          <value code="3092008" codeSystem="http://snomed.info/sct" value="Staphylococcus aureus"/>
-        </observation>
-      </entry>
-    </section>
-  </component>
-  <component>
-    <section>
-      <code code="1234567-RPT" codeSystem="Local-codesystem-oid" codeSystemName="LocalSystem" displayName="Generic Repeating Questions Section"/>
-      <title>REPEATING QUESTIONS</title>
-      <entry typeCode="COMP">
-        <organizer classCode="CLUSTER" moodCode="EVN">
-          <code code="1" displayName="Exposure Information" codeSytemName="LocalSystem"/>
-          <status_code code="completed"/>
-          <component>
+    <structuredBody>
+      <component>
+        <section>
+          <id extension="495669c7-96bf-4573-9dd8-59e745e05576" assigningAuthorityName="LR"/>
+          <code code="29762-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Social history"/>
+          <title>SOCIAL HISTORY INFORMATION</title>
+          <entry typeCode="COMP">
             <observation classCode="OBS" moodCode="EVN">
-              <code code="C3841750" codeSystem="http://terminology.hl7.org/CodeSystem/umls" displayName="Mass gathering"/>
-              <value code="264379009" codeSystem="http://snomed.info/sct" value="Sports stadium (environment)"/>
+              <code code="alcohol-type" codeSystem="http://acme-rehab.org" displayName="Type of alcohol consumed"/>
+              <value/>
             </observation>
-          </component>
-        </organizer>
-      </entry>
-    </section>
+          </entry>
+        </section>
+      </component>
+      <component>
+        <section>
+          <id extension="495669c7-96bf-4573-9dd8-59e745e05576" assigningAuthorityName="LR"/>
+          <code code="55752-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Clinical Information"/>
+          <title>Clinical Information</title>
+          <entry typeCode="COMP">
+            <observation classCode="OBS" moodCode="EVN">
+              <code code="15074-8" codeSystem="http://loinc.org" displayName="Glucose [Moles/volume] in Blood"/>
+              <value code="mmol/L" codeSystem="http://unitsofmeasure.org" value="6.3"/>
+            </observation>
+          </entry>
+          <entry typeCode="COMP">
+            <observation classCode="OBS" moodCode="EVN">
+              <code code="104177,600-7" codeSystem="http://acmelabs.org,http://loinc.org" displayName="Blood culture,Bacteria identified in Blood by Culture"/>
+              <value code="3092008" codeSystem="http://snomed.info/sct" value="Staphylococcus aureus"/>
+            </observation>
+          </entry>
+        </section>
+      </component>
+      <component>
+        <section>
+          <code code="1234567-RPT" codeSystem="Local-codesystem-oid" codeSystemName="LocalSystem" displayName="Generic Repeating Questions Section"/>
+          <title>REPEATING QUESTIONS</title>
+          <entry typeCode="COMP">
+            <organizer classCode="CLUSTER" moodCode="EVN">
+              <code code="1" displayName="Exposure Information" codeSytemName="LocalSystem"/>
+              <status_code code="completed"/>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <code code="C3841750" codeSystem="http://terminology.hl7.org/CodeSystem/umls" displayName="Mass gathering"/>
+                  <value code="264379009" codeSystem="http://snomed.info/sct" value="Sports stadium (environment)"/>
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+        </section>
+      </component>
+    </structuredBody>
   </component>
 </ClinicalDocument>

--- a/containers/message-parser/assets/sample_phdc.xml
+++ b/containers/message-parser/assets/sample_phdc.xml
@@ -76,77 +76,81 @@
     </assignedCustodian>
   </custodian>
   <component>
-    <section>
-      <id extension="mocked-uuid" assigningAuthorityName="LR"/>
-      <code code="29762-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Social history"/>
-      <title>SOCIAL HISTORY INFORMATION</title>
-      <entry typeCode="COMP">
-        <observation classCode="OBS" moodCode="EVN">
-          <code code="DEM127" codeSystem="2.16.840.1.114222.4.5.232" codeSystemName="PHIN Questions" displayName="Is this person deceased?"/>
-          <value xsi:type="CE" code="N" codeSystem="2.16.840.1.113883.12.136" codeSystemName="Yes/No Indicator (HL7)" displayName="No">
-            <translation code="N" codeSystem="2.16.840.1.113883.12.136" codeSystemName="2.16.840.1.113883.12.136" displayName="No"/>
-          </value>
-        </observation>
-      </entry>
-      <entry typeCode="COMP">
-        <observation classCode="OBS" moodCode="EVN">
-          <code code="NBS104" codeSystem="2.16.840.1.114222.4.5.1" codeSystemName="NEDSS Base System" displayName="Information As of Date"/>
-          <value xsi:type="TS">20240124</value>
-        </observation>
-      </entry>
-    </section>
-  </component>
-  <component>
-    <section>
-      <id extension="mocked-uuid" assigningAuthorityName="LR"/>
-      <code code="55752-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Clinical Information"/>
-      <title>Clinical Information</title>
-      <entry typeCode="COMP">
-        <observation classCode="OBS" moodCode="EVN">
-          <code code="INV169" codeSystem="2.16.840.1.114222.4.5.1" displayName="Condition"/>
-          <value xsi:type="CE" code="10274" codeSystem="1.2.3.5" displayName="Chlamydia trachomatis infection">
-            <translation xsi:type="CE" code="350" codeSystem="L" codeSystemName="STD*MIS" displayName="Local Label"/>
-          </value>
-        </observation>
-      </entry>
-      <entry typeCode="COMP">
-        <observation classCode="OBS" moodCode="EVN">
-          <code code="NBS012" codeSystem="2.16.840.1.114222.4.5.1" displayName="Shared Ind"/>
-          <value xsi:type="CE" code="F" codeSystem="1.2.3.5" displayName="False">
-            <translation xsi:type="CE" code="T" codeSystem="L" codeSystemName="STD*MIS" displayName="Local Label"/>
-          </value>
-        </observation>
-      </entry>
-    </section>
-  </component>
-  <component>
-    <section>
-      <code code="1234567-RPT" codeSystem="Local-codesystem-oid" codeSystemName="LocalSystem" displayName="Generic Repeating Questions Section"/>
-      <title>REPEATING QUESTIONS</title>
-      <entry typeCode="COMP">
-        <organizer classCode="CLUSTER" moodCode="EVN">
-          <code code="1" displayName="Exposure Information" codeSytemName="LocalSystem"/>
-          <status_code code="completed"/>
-          <component>
+    <structuredBody>
+      <component>
+        <section>
+          <id extension="mocked-uuid" assigningAuthorityName="LR"/>
+          <code code="29762-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Social history"/>
+          <title>SOCIAL HISTORY INFORMATION</title>
+          <entry typeCode="COMP">
             <observation classCode="OBS" moodCode="EVN">
-              <code code="INV502" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Country of Exposure"/>
-              <value xsi:type="CE" code="ATA" codeSystem="1.0.3166.1" codeSystemName="Country (ISO 3166-1)" displayName="ANTARCTICA"/>
+              <code code="DEM127" codeSystem="2.16.840.1.114222.4.5.232" codeSystemName="PHIN Questions" displayName="Is this person deceased?"/>
+              <value xsi:type="CE" code="N" codeSystem="2.16.840.1.113883.12.136" codeSystemName="Yes/No Indicator (HL7)" displayName="No">
+                <translation code="N" codeSystem="2.16.840.1.113883.12.136" codeSystemName="2.16.840.1.113883.12.136" displayName="No"/>
+              </value>
             </observation>
-          </component>
-        </organizer>
-      </entry>
-      <entry typeCode="COMP">
-        <organizer classCode="CLUSTER" moodCode="EVN">
-          <code code="1" displayName="Exposure Information" codeSytemName="LocalSystem"/>
-          <status_code code="completed"/>
-          <component>
+          </entry>
+          <entry typeCode="COMP">
             <observation classCode="OBS" moodCode="EVN">
-              <code code="INV504" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="City of Exposure"/>
-              <value xsi:type="TS">Esperanze</value>
+              <code code="NBS104" codeSystem="2.16.840.1.114222.4.5.1" codeSystemName="NEDSS Base System" displayName="Information As of Date"/>
+              <value xsi:type="TS">20240124</value>
             </observation>
-          </component>
-        </organizer>
-      </entry>
-    </section>
+          </entry>
+        </section>
+      </component>
+      <component>
+        <section>
+          <id extension="mocked-uuid" assigningAuthorityName="LR"/>
+          <code code="55752-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Clinical Information"/>
+          <title>Clinical Information</title>
+          <entry typeCode="COMP">
+            <observation classCode="OBS" moodCode="EVN">
+              <code code="INV169" codeSystem="2.16.840.1.114222.4.5.1" displayName="Condition"/>
+              <value xsi:type="CE" code="10274" codeSystem="1.2.3.5" displayName="Chlamydia trachomatis infection">
+                <translation xsi:type="CE" code="350" codeSystem="L" codeSystemName="STD*MIS" displayName="Local Label"/>
+              </value>
+            </observation>
+          </entry>
+          <entry typeCode="COMP">
+            <observation classCode="OBS" moodCode="EVN">
+              <code code="NBS012" codeSystem="2.16.840.1.114222.4.5.1" displayName="Shared Ind"/>
+              <value xsi:type="CE" code="F" codeSystem="1.2.3.5" displayName="False">
+                <translation xsi:type="CE" code="T" codeSystem="L" codeSystemName="STD*MIS" displayName="Local Label"/>
+              </value>
+            </observation>
+          </entry>
+        </section>
+      </component>
+      <component>
+        <section>
+          <code code="1234567-RPT" codeSystem="Local-codesystem-oid" codeSystemName="LocalSystem" displayName="Generic Repeating Questions Section"/>
+          <title>REPEATING QUESTIONS</title>
+          <entry typeCode="COMP">
+            <organizer classCode="CLUSTER" moodCode="EVN">
+              <code code="1" displayName="Exposure Information" codeSytemName="LocalSystem"/>
+              <status_code code="completed"/>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <code code="INV502" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Country of Exposure"/>
+                  <value xsi:type="CE" code="ATA" codeSystem="1.0.3166.1" codeSystemName="Country (ISO 3166-1)" displayName="ANTARCTICA"/>
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+          <entry typeCode="COMP">
+            <organizer classCode="CLUSTER" moodCode="EVN">
+              <code code="1" displayName="Exposure Information" codeSytemName="LocalSystem"/>
+              <status_code code="completed"/>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <code code="INV504" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="City of Exposure"/>
+                  <value xsi:type="TS">Esperanze</value>
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+        </section>
+      </component>
+    </structuredBody>
   </component>
 </ClinicalDocument>


### PR DESCRIPTION
# PULL REQUEST

## Summary
In our `PHDCBuilder` the public `build_body` method was adding the three private methods to our PHDC Case Report but the main `<component>` and `<structuredBody>` were not being added to the `self` object; they were just added as variables and ultimately not returned. What we're doing now attaching the three private methods to the `<structuredBody>` and then appending what we've created after the `mach`/`case` logic to `root` since `build_header` has already run.

Built a local container of the branch to make sure that our `sample_fhir_bundle_for_phdc_conversion.json` was showing clinical info and social history correctly--looking particularly for the hierarchy we expect to see:

```xml
<component>
		<structuredBody>
			<component>
				<section>
					<id extension="8345d20d-c4b6-4172-95ed-4b74cdac29dd" assigningAuthorityName="LR"/>
					<code code="29762-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Social history"/>
					<title>SOCIAL HISTORY INFORMATION</title>
				</section>
			</component>
			<component>
				<section>
					<id extension="625564b3-6a2a-4418-8cc9-d8459c1f5750" assigningAuthorityName="LR"/>
					<code code="55752-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Clinical Information"/>
					<title>Clinical Information</title>
					<entry typeCode="COMP">
						<observation classCode="OBS" moodCode="EVN">
							<code code="22322-2" codeSystem="http://loinc.org" displayName="Hepatitis A virus IgM antibody [Presence] in Serum by Immunoassay"/>
							<value/>
						</observation>
					</entry>
					<entry typeCode="COMP">
						<observation classCode="OBS" moodCode="EVN">
							<code code="22320-6" codeSystem="http://loinc.org" displayName="Hepatitis A virus IgG Ab [Presence] in Serum by Immunoassay"/>
							<value/>
						</observation>
					</entry>
				</section>
			</component>
			<component>
				<section>
					<code code="1234567-RPT" codeSystem="Local-codesystem-oid" codeSystemName="LocalSystem" displayName="Generic Repeating Questions Section"/>
					<title>REPEATING QUESTIONS</title>
				</section>
			</component>
		</structuredBody>
	</component>
```

## Related Issue
Fixes:
- #1328 

## Additional Information
There are still a couple of blockers before validation can be run on the output from the endpoint


[//]: # (PR title: Remember to name your PR descriptively!)
