### PR TITLE
add dotnet tests for fhir-converter

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -208,3 +208,16 @@ jobs:
       - name: Run tests
         working-directory: ./containers/ecr-viewer # Navigate to your Node.js app directory
         run: npm test
+
+  unit-test-fhir-converter:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '8.0.x'
+      - name: Run tests
+        working-directory: ./containers/fhir-converter # Navigate to your Node.js app directory
+        run: dotnet test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -217,7 +217,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: "8.0.x"
       - name: Run tests
         working-directory: ./containers/fhir-converter # Navigate to your Node.js app directory
         run: dotnet test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -209,7 +209,7 @@ jobs:
         working-directory: ./containers/ecr-viewer # Navigate to your Node.js app directory
         run: npm test
 
-  unit-test-fhir-converter:
+  unit-test-dotnet-fhir-converter:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
# PULL REQUEST

## Summary
Add github action to run dotnet tests in the fhir-converter.

## Related Issue
Fixes https://github.com/CDCgov/phdi/pull/1320#pullrequestreview-1885604629

## Additional Information
See the running test here:
https://github.com/CDCgov/phdi/actions/runs/7935167615/job/21667717617?pr=1335

