### PR TITLE
Switching .env file back to postgres

### DIFF
--- a/containers/ecr-viewer/.env
+++ b/containers/ecr-viewer/.env
@@ -1,4 +1,4 @@
 DATABASE_URL=postgres://postgres:pw@localhost:5432/ecr_viewer_db
 AWS_REGION=us-east-1
 ECR_BUCKET_NAME=ecr-viewer-files
-NEXT_PUBLIC_SOURCE=s3
+NEXT_PUBLIC_SOURCE=postgres


### PR DESCRIPTION
# PULL REQUEST

## Summary
This was a breaking issue that switches everyone to s3 pulling when it should be postgres by default