### PR TITLE
set ecr viewer's auth parameter as cookie

### DIFF
--- a/containers/ecr-viewer/src/app/view-data/service.tsx
+++ b/containers/ecr-viewer/src/app/view-data/service.tsx
@@ -1,4 +1,4 @@
-export const processSnomedCode = (snomedCode) => {
+export const processSnomedCode = (snomedCode: string) => {
   //Placeholder
   console.log("SNOMED code: ", snomedCode);
   return snomedCode;

--- a/containers/ecr-viewer/src/middleware.test.ts
+++ b/containers/ecr-viewer/src/middleware.test.ts
@@ -1,0 +1,23 @@
+/**
+ * @jest-environment node
+ */
+import { middleware } from "@/middleware";
+import { NextRequest, NextResponse } from "next/server";
+import { NextURL } from "next/dist/server/web/next-url";
+
+describe('Middleware', () => {
+  const redirectSpy = jest.spyOn(NextResponse, 'redirect');
+
+  afterEach(() => {
+    redirectSpy.mockReset();
+  });
+  it('should strip the auth query param and set the token', async () => {
+
+    const req = new NextRequest("https://www.example.com/view-data?id=1234&auth=abcd");
+
+    const resp = middleware(req);
+    expect(resp.cookies.get("auth-token")).toEqual({name: "auth-token", path: "/", value: "abcd", httpOnly: true});
+    expect(redirectSpy).toHaveBeenCalledTimes(1);
+    expect(redirectSpy as unknown as NextURL).toHaveBeenCalledWith(new NextURL('view-data?id=1234', req.url, {headers: {}, nextConfig: undefined}));
+  });
+});

--- a/containers/ecr-viewer/src/middleware.test.ts
+++ b/containers/ecr-viewer/src/middleware.test.ts
@@ -5,19 +5,30 @@ import { middleware } from "@/middleware";
 import { NextRequest, NextResponse } from "next/server";
 import { NextURL } from "next/dist/server/web/next-url";
 
-describe('Middleware', () => {
-  const redirectSpy = jest.spyOn(NextResponse, 'redirect');
+describe("Middleware", () => {
+  const redirectSpy = jest.spyOn(NextResponse, "redirect");
 
   afterEach(() => {
     redirectSpy.mockReset();
   });
-  it('should strip the auth query param and set the token', async () => {
-
-    const req = new NextRequest("https://www.example.com/view-data?id=1234&auth=abcd");
+  it("should strip the auth query param and set the token", async () => {
+    const req = new NextRequest(
+      "https://www.example.com/view-data?id=1234&auth=abcd",
+    );
 
     const resp = middleware(req);
-    expect(resp.cookies.get("auth-token")).toEqual({name: "auth-token", path: "/", value: "abcd", httpOnly: true});
+    expect(resp.cookies.get("auth-token")).toEqual({
+      name: "auth-token",
+      path: "/",
+      value: "abcd",
+      httpOnly: true,
+    });
     expect(redirectSpy).toHaveBeenCalledTimes(1);
-    expect(redirectSpy as unknown as NextURL).toHaveBeenCalledWith(new NextURL('view-data?id=1234', req.url, {headers: {}, nextConfig: undefined}));
+    expect(redirectSpy as unknown as NextURL).toHaveBeenCalledWith(
+      new NextURL("view-data?id=1234", req.url, {
+        headers: {},
+        nextConfig: undefined,
+      }),
+    );
   });
 });

--- a/containers/ecr-viewer/src/middleware.ts
+++ b/containers/ecr-viewer/src/middleware.ts
@@ -1,14 +1,14 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from "next/server";
 
 export function middleware(req: NextRequest) {
   let response = NextResponse.next();
-  const url = req.nextUrl
+  const url = req.nextUrl;
 
   const auth = url.searchParams.get("auth");
   if (auth) {
-    url.searchParams.delete('auth')
+    url.searchParams.delete("auth");
     response = NextResponse.redirect(url);
-    response.cookies.set("auth-token", auth, {httpOnly: true});
+    response.cookies.set("auth-token", auth, { httpOnly: true });
   }
 
   return response;

--- a/containers/ecr-viewer/src/middleware.ts
+++ b/containers/ecr-viewer/src/middleware.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export function middleware(req: NextRequest) {
+  let response = NextResponse.next();
+  const url = req.nextUrl
+
+  const auth = url.searchParams.get("auth");
+  if (auth) {
+    url.searchParams.delete('auth')
+    response = NextResponse.redirect(url);
+    response.cookies.set("auth-token", auth, {httpOnly: true});
+  }
+
+  return response;
+}


### PR DESCRIPTION
# PULL REQUEST

## Summary
Create a middleware that will create an `auth-token` cookie and strip the `auth` query parameter from url.

## Related Issue
Fixes #1354 
Fixes #1355 

## Additional Information

https://github.com/CDCgov/phdi/assets/10108172/dc4d2e12-4605-4f43-8abe-ed80d36aa14d



