### PR TITLE
Add method for translating FHIR codeSystems to PHDC-compliant codeSystems

### DIFF
--- a/containers/message-parser/app/default_schemas/phdc_case_report_schema.json
+++ b/containers/message-parser/app/default_schemas/phdc_case_report_schema.json
@@ -293,7 +293,7 @@
         "data_type": "float",
         "nullable": true
       },
-      "value_quantitative_code_system": {
+      "value_quant_code_system": {
         "fhir_path": "Observation.valueQuantity.system",
         "data_type": "string",
         "nullable": true
@@ -348,7 +348,7 @@
             "data_type": "float",
             "nullable": true
           },
-          "value_quantitative_code_system": {
+          "value_quant_code_system": {
             "fhir_path": "valueQuantity.system",
             "data_type": "string",
             "nullable": true

--- a/containers/message-parser/app/default_schemas/phdc_case_report_schema.json
+++ b/containers/message-parser/app/default_schemas/phdc_case_report_schema.json
@@ -318,6 +318,11 @@
         "data_type": "string",
         "nullable": true
       },
+      "text": {
+        "fhir_path": "valueCodeableConcept.text",
+        "data_type": "string",
+        "nullable": true
+      },
       "components": {
         "fhir_path": "Observation.component",
         "data_type": "array",

--- a/containers/message-parser/app/phdc/builder.py
+++ b/containers/message-parser/app/phdc/builder.py
@@ -1,4 +1,3 @@
-import copy
 import logging
 import uuid
 from typing import List
@@ -540,7 +539,6 @@ class PHDCBuilder:
         :return: The data for building the observation element as an
             Entry object with update codeSystemName(s).
         """
-        translated_observation = copy.deepcopy(observation)
 
         # TODO: move code_system_translations to assets file for easier config?
         code_system_translations = {
@@ -567,45 +565,44 @@ class PHDCBuilder:
             },
         }
 
-        cs_values = {
-            "code_system": observation.code_system,
-            "code_code_system": observation.code_code_system,
-            "value_qualitative_code_system": observation.value_qualitative_code_system,
-            "value_quant_code_system": observation.value_quant_code_system,
-        }
-
-        for cs, cs_value in cs_values.items():
+        for cs in [
+            "code_system",
+            "code_code_system",
+            "value_qualitative_code_system",
+            "value_quant_code_system",
+        ]:
+            cs_value = getattr(observation, cs)
             if cs_value in code_system_translations:
                 if cs == "code_system":
-                    translated_observation.code_system = code_system_translations[
-                        cs_value
-                    ]["codeSystem"]
-                    translated_observation.code_system_name = code_system_translations[
+                    observation.code_system = code_system_translations[cs_value][
+                        "codeSystem"
+                    ]
+                    observation.code_system_name = code_system_translations[cs_value][
+                        "codeSystemName"
+                    ]
+                elif cs == "code_code_system":
+                    observation.code_code_system = code_system_translations[cs_value][
+                        "codeSystem"
+                    ]
+                    observation.code_code_system_name = code_system_translations[
                         cs_value
                     ]["codeSystemName"]
-                elif cs == "code_code_system":
-                    translated_observation.code_code_system = code_system_translations[
-                        cs_value
-                    ]["codeSystem"]
-                    translated_observation.code_code_system_name = (
-                        code_system_translations[cs_value]["codeSystemName"]
-                    )
                 elif cs == "value_qualitative_code_system":
-                    translated_observation.value_qualitative_code_system = (
+                    observation.value_qualitative_code_system = (
                         code_system_translations[cs_value]["codeSystem"]
                     )
-                    translated_observation.value_qualitative_code_system_name = (
+                    observation.value_qualitative_code_system_name = (
                         code_system_translations[cs_value]["codeSystemName"]
                     )
                 elif cs == "value_quant_code_system":
-                    translated_observation.value_quant_code_system = (
-                        code_system_translations[cs_value]["codeSystem"]
-                    )
-                    translated_observation.value_quant_code_system_name = (
-                        code_system_translations[cs_value]["codeSystemName"]
-                    )
+                    observation.value_quant_code_system = code_system_translations[
+                        cs_value
+                    ]["codeSystem"]
+                    observation.value_quant_code_system_name = code_system_translations[
+                        cs_value
+                    ]["codeSystemName"]
 
-        return translated_observation
+        return observation
 
     def _build_addr(
         self,

--- a/containers/message-parser/app/phdc/models.py
+++ b/containers/message-parser/app/phdc/models.py
@@ -125,6 +125,7 @@ class Observation:
     class_code: Optional[str] = None
     code_display: Optional[str] = None
     code_system: Optional[str] = None
+    code_code_system_name: Optional[str] = None
     quantitative_value: Optional[float] = None
     quantitative_system: Optional[str] = None
     quantitative_code: Optional[str] = None
@@ -137,9 +138,11 @@ class Observation:
     code_code_display: Optional[str] = None
     value_quantitative_code: Optional[str] = None
     value_quantitative_code_system: Optional[str] = None
+    value_quantitative_code_system_name: Optional[str] = None
     value_quantitative_value: Optional[float] = None
     value_qualitative_code: Optional[str] = None
     value_qualitative_code_system: Optional[str] = None
+    value_qualitative_code_system_name: Optional[str] = None
     value_qualitative_value: Optional[str] = None
     components: Optional[list] = None
     code: Optional[CodedElement] = None

--- a/containers/message-parser/app/phdc/models.py
+++ b/containers/message-parser/app/phdc/models.py
@@ -138,8 +138,8 @@ class Observation:
     code_code_system_name: Optional[str] = None
     code_code_display: Optional[str] = None
     value_quantitative_code: Optional[str] = None
-    value_quantitative_code_system: Optional[str] = None
-    value_quantitative_code_system_name: Optional[str] = None
+    value_quant_code_system: Optional[str] = None
+    value_quant_code_system_name: Optional[str] = None
     value_quantitative_value: Optional[float] = None
     value_qualitative_code: Optional[str] = None
     value_qualitative_code_system: Optional[str] = None

--- a/containers/message-parser/app/phdc/models.py
+++ b/containers/message-parser/app/phdc/models.py
@@ -125,7 +125,7 @@ class Observation:
     class_code: Optional[str] = None
     code_display: Optional[str] = None
     code_system: Optional[str] = None
-    code_code_system_name: Optional[str] = None
+    code_system_name: Optional[str] = None
     quantitative_value: Optional[float] = None
     quantitative_system: Optional[str] = None
     quantitative_code: Optional[str] = None
@@ -135,6 +135,7 @@ class Observation:
     mood_code: Optional[str] = None
     code_code: Optional[str] = None
     code_code_system: Optional[str] = None
+    code_code_system_name: Optional[str] = None
     code_code_display: Optional[str] = None
     value_quantitative_code: Optional[str] = None
     value_quantitative_code_system: Optional[str] = None

--- a/containers/message-parser/assets/demo_phdc.xml
+++ b/containers/message-parser/assets/demo_phdc.xml
@@ -78,26 +78,26 @@
           <title>SOCIAL HISTORY INFORMATION</title>
           <entry typeCode="COMP">
             <observation classCode="OBS" moodCode="EVN">
-              <code code="alcohol-type" codeSystem="http://acme-rehab.org" displayName="Type of alcohol consumed"/>
+              <code code="alcohol-type" codeSystem="Acme Rehab" codeSystemName="Acme Rehab" displayName="Type of alcohol consumed"/>
               <value/>
             </observation>
           </entry>
           <entry typeCode="COMP">
             <observation classCode="OBS" moodCode="EVN">
-              <code code="alcohol-type" codeSystem="http://acme-rehab.org"/>
-              <value code="35748005" codeSystem="http://snomed.info/sct" value="Wine (substance)"/>
+              <code code="alcohol-type" codeSystem="Acme Rehab" codeSystemName="Acme Rehab"/>
+              <value code="35748005" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" value="Wine (substance)"/>
             </observation>
           </entry>
           <entry typeCode="COMP">
             <observation classCode="OBS" moodCode="EVN">
-              <code code="alcohol-type" codeSystem="http://acme-rehab.org"/>
-              <value code="53410008" codeSystem="http://snomed.info/sct" value="Beer (substance)"/>
+              <code code="alcohol-type" codeSystem="Acme Rehab" codeSystemName="Acme Rehab"/>
+              <value code="53410008" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" value="Beer (substance)"/>
             </observation>
           </entry>
           <entry typeCode="COMP">
             <observation classCode="OBS" moodCode="EVN">
-              <code code="alcohol-type" codeSystem="http://acme-rehab.org"/>
-              <value code="6524003" codeSystem="http://snomed.info/sct" value="Distilled spirits (substance)"/>
+              <code code="alcohol-type" codeSystem="Acme Rehab" codeSystemName="Acme Rehab"/>
+              <value code="6524003" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" value="Distilled spirits (substance)"/>
             </observation>
           </entry>
         </section>
@@ -109,14 +109,14 @@
           <title>Clinical Information</title>
           <entry typeCode="COMP">
             <observation classCode="OBS" moodCode="EVN">
-              <code code="15074-8" codeSystem="http://loinc.org" displayName="Glucose [Moles/volume] in Blood"/>
+              <code code="15074-8" codeSystem="number" codeSystemName="LOINC" displayName="Glucose [Moles/volume] in Blood"/>
               <value code="mmol/L" codeSystem="http://unitsofmeasure.org" value="6.3"/>
             </observation>
           </entry>
           <entry typeCode="COMP">
             <observation classCode="OBS" moodCode="EVN">
               <code code="104177,600-7" codeSystem="http://acmelabs.org,http://loinc.org" displayName="Blood culture,Bacteria identified in Blood by Culture"/>
-              <value code="3092008" codeSystem="http://snomed.info/sct" value="Staphylococcus aureus"/>
+              <value code="3092008" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" value="Staphylococcus aureus"/>
             </observation>
           </entry>
         </section>
@@ -132,7 +132,7 @@
               <component>
                 <observation classCode="OBS" moodCode="EVN">
                   <code code="C3841750" codeSystem="http://terminology.hl7.org/CodeSystem/umls" displayName="Mass gathering"/>
-                  <value code="264379009" codeSystem="http://snomed.info/sct" value="Sports stadium (environment)"/>
+                  <value code="264379009" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" value="Sports stadium (environment)"/>
                 </observation>
               </component>
             </organizer>
@@ -140,7 +140,7 @@
           <entry typeCode="COMP">
             <observation classCode="OBS" moodCode="EVN">
               <code code="EXPAGNT" codeSystem="http://terminology.hl7.org/CodeSystem/v3-ParticipationType" displayName="ExposureAgent"/>
-              <value code="840533007" codeSystem="http://snomed.info/sct" value="Severe acute respiratory syndrome coronavirus 2 (organism)"/>
+              <value code="840533007" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" value="Severe acute respiratory syndrome coronavirus 2 (organism)"/>
             </observation>
           </entry>
         </section>

--- a/containers/message-parser/assets/sample_phdc_social_history_info.xml
+++ b/containers/message-parser/assets/sample_phdc_social_history_info.xml
@@ -15,7 +15,7 @@
     <entry typeCode="COMP">
       <observation classCode="OBS" moodCode="EVN">
         <code code="NBS104" codeSystem="2.16.840.1.114222.4.5.1" codeSystemName="NEDSS Base System" displayName="Information As of Date"/>
-        <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="TS">20240124</value>
+        <value xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="TS" value="20240124"/>
       </observation>
     </entry>
   </section>

--- a/containers/message-parser/tests/integration/test_message_parser.py
+++ b/containers/message-parser/tests/integration/test_message_parser.py
@@ -130,7 +130,7 @@ def test_parse_message2(setup):
                     "code_code_system": "http://loinc.org",
                     "code_code_display": "Glucose [Moles/volume] in Blood",
                     "value_quantitative_value": "6.3",
-                    "value_quantitative_code_system": "http://unitsofmeasure.org",
+                    "value_quant_code_system": "http://unitsofmeasure.org",
                     "value_quantitative_code": "mmol/L",
                     "value_qualitative_value": None,
                     "value_qualitative_code_system": None,
@@ -145,7 +145,7 @@ def test_parse_message2(setup):
                         "Blood culture,Bacteria identified " + "in Blood by Culture"
                     ),
                     "value_quantitative_value": None,
-                    "value_quantitative_code_system": None,
+                    "value_quant_code_system": None,
                     "value_quantitative_code": None,
                     "value_qualitative_value": "Staphylococcus aureus",
                     "value_qualitative_code_system": "http://snomed.info/sct",
@@ -158,7 +158,7 @@ def test_parse_message2(setup):
                     "code_code_system": "http://acme-rehab.org",
                     "code_code_display": "Type of alcohol consumed",
                     "value_quantitative_value": None,
-                    "value_quantitative_code_system": None,
+                    "value_quant_code_system": None,
                     "value_quantitative_code": None,
                     "value_qualitative_value": None,
                     "value_qualitative_code_system": None,
@@ -169,7 +169,7 @@ def test_parse_message2(setup):
                             "code_code_system": "http://acme-rehab.org",
                             "code_code_display": None,
                             "value_quantitative_value": None,
-                            "value_quantitative_code_system": None,
+                            "value_quant_code_system": None,
                             "value_quantitative_code": None,
                             "value_qualitative_value": "Wine (substance)",
                             "value_qualitative_code_system": ("http://snomed.info/sct"),
@@ -181,7 +181,7 @@ def test_parse_message2(setup):
                             "code_code_system": "http://acme-rehab.org",
                             "code_code_display": None,
                             "value_quantitative_value": None,
-                            "value_quantitative_code_system": None,
+                            "value_quant_code_system": None,
                             "value_quantitative_code": None,
                             "value_qualitative_value": "Beer (substance)",
                             "value_qualitative_code_system": ("http://snomed.info/sct"),
@@ -193,7 +193,7 @@ def test_parse_message2(setup):
                             "code_code_system": "http://acme-rehab.org",
                             "code_code_display": None,
                             "value_quantitative_value": None,
-                            "value_quantitative_code_system": None,
+                            "value_quant_code_system": None,
                             "value_quantitative_code": None,
                             "value_qualitative_value": (
                                 "Distilled spirits (substance)"
@@ -210,7 +210,7 @@ def test_parse_message2(setup):
                     "code_code_system": "http://terminology.hl7.org/CodeSystem/umls",
                     "code_code_display": "Mass gathering",
                     "value_quantitative_value": None,
-                    "value_quantitative_code_system": None,
+                    "value_quant_code_system": None,
                     "value_quantitative_code": None,
                     "value_qualitative_value": "Sports stadium (environment)",
                     "value_qualitative_code_system": "http://snomed.info/sct",
@@ -224,7 +224,7 @@ def test_parse_message2(setup):
                             ),
                             "code_code_display": "ExposureAgent",
                             "value_quantitative_value": None,
-                            "value_quantitative_code_system": None,
+                            "value_quant_code_system": None,
                             "value_quantitative_code": None,
                             "value_qualitative_value": (
                                 "Severe acute respiratory syndrome coronavirus 2 "
@@ -245,11 +245,12 @@ def test_parse_message2(setup):
         "parsing_schema": test_schema,
         "message": test_bundle,
     }
-
+    print(expected_reference_response)
     parsing_response = httpx.post(PARSE_MESSAGE, json=request)
 
     assert parsing_response.status_code == 200
-    assert parsing_response.json() == expected_reference_response
+    print(parsing_response.json())
+    # assert parsing_response.json() == expected_reference_response
 
 
 @pytest.mark.integration

--- a/containers/message-parser/tests/integration/test_message_parser.py
+++ b/containers/message-parser/tests/integration/test_message_parser.py
@@ -34,7 +34,7 @@ with open(test_schema_path, "r") as file:
 
 
 @pytest.mark.integration
-def test_parse_message2(setup):
+def test_parse_message(setup):
     expected_reference_response = {
         "message": "Parsing succeeded!",
         "parsed_values": {
@@ -135,6 +135,7 @@ def test_parse_message2(setup):
                     "value_qualitative_value": None,
                     "value_qualitative_code_system": None,
                     "value_qualitative_code": None,
+                    "text": None,
                     "components": [],
                 },
                 {
@@ -142,7 +143,7 @@ def test_parse_message2(setup):
                     "code_code": "104177,600-7",
                     "code_code_system": "http://acmelabs.org,http://loinc.org",
                     "code_code_display": (
-                        "Blood culture,Bacteria identified " + "in Blood by Culture"
+                        "Blood culture,Bacteria identified in Blood by Culture"
                     ),
                     "value_quantitative_value": None,
                     "value_quant_code_system": None,
@@ -150,6 +151,7 @@ def test_parse_message2(setup):
                     "value_qualitative_value": "Staphylococcus aureus",
                     "value_qualitative_code_system": "http://snomed.info/sct",
                     "value_qualitative_code": "3092008",
+                    "text": None,
                     "components": [],
                 },
                 {
@@ -163,6 +165,7 @@ def test_parse_message2(setup):
                     "value_qualitative_value": None,
                     "value_qualitative_code_system": None,
                     "value_qualitative_code": None,
+                    "text": None,
                     "components": [
                         {
                             "code_code": "alcohol-type",
@@ -172,7 +175,7 @@ def test_parse_message2(setup):
                             "value_quant_code_system": None,
                             "value_quantitative_code": None,
                             "value_qualitative_value": "Wine (substance)",
-                            "value_qualitative_code_system": ("http://snomed.info/sct"),
+                            "value_qualitative_code_system": "http://snomed.info/sct",
                             "value_qualitative_code": "35748005",
                             "text": "Wine",
                         },
@@ -184,7 +187,7 @@ def test_parse_message2(setup):
                             "value_quant_code_system": None,
                             "value_quantitative_code": None,
                             "value_qualitative_value": "Beer (substance)",
-                            "value_qualitative_code_system": ("http://snomed.info/sct"),
+                            "value_qualitative_code_system": "http://snomed.info/sct",
                             "value_qualitative_code": "53410008",
                             "text": "Beer",
                         },
@@ -195,10 +198,8 @@ def test_parse_message2(setup):
                             "value_quantitative_value": None,
                             "value_quant_code_system": None,
                             "value_quantitative_code": None,
-                            "value_qualitative_value": (
-                                "Distilled spirits (substance)"
-                            ),
-                            "value_qualitative_code_system": ("http://snomed.info/sct"),
+                            "value_qualitative_value": "Distilled spirits (substance)",
+                            "value_qualitative_code_system": "http://snomed.info/sct",
                             "value_qualitative_code": "6524003",
                             "text": "Liquor",
                         },
@@ -215,6 +216,7 @@ def test_parse_message2(setup):
                     "value_qualitative_value": "Sports stadium (environment)",
                     "value_qualitative_code_system": "http://snomed.info/sct",
                     "value_qualitative_code": "264379009",
+                    "text": "City Football Stadium",
                     "components": [
                         {
                             "code_code": "EXPAGNT",
@@ -227,10 +229,10 @@ def test_parse_message2(setup):
                             "value_quant_code_system": None,
                             "value_quantitative_code": None,
                             "value_qualitative_value": (
-                                "Severe acute respiratory syndrome coronavirus 2 "
-                                + "(organism)"
+                                "Severe acute respiratory "
+                                + "syndrome coronavirus 2 (organism)"
                             ),
-                            "value_qualitative_code_system": ("http://snomed.info/sct"),
+                            "value_qualitative_code_system": "http://snomed.info/sct",
                             "value_qualitative_code": "840533007",
                             "text": None,
                         }
@@ -245,12 +247,10 @@ def test_parse_message2(setup):
         "parsing_schema": test_schema,
         "message": test_bundle,
     }
-    print(expected_reference_response)
     parsing_response = httpx.post(PARSE_MESSAGE, json=request)
 
     assert parsing_response.status_code == 200
-    print(parsing_response.json())
-    # assert parsing_response.json() == expected_reference_response
+    assert parsing_response.json() == expected_reference_response
 
 
 @pytest.mark.integration

--- a/containers/message-parser/tests/test_phdc.py
+++ b/containers/message-parser/tests/test_phdc.py
@@ -654,7 +654,7 @@ def test_build_clinical_info(build_clinical_info_data, expected_result):
                             ),
                             value=CodedElement(
                                 xsi_type="TS",
-                                text="20240124",
+                                value="20240124",
                             ),
                         ),
                     ]
@@ -900,7 +900,7 @@ def test_add_field():
                 code_code_system="2.16.840.1.114222.4.5.1",
                 code_code_display="Shared Ind",
                 value_quantitative_code=None,
-                value_quantitative_code_system=None,
+                value_quant_code_system=None,
                 value_quantitative_value=None,
                 value_qualitative_code="F",
                 value_qualitative_code_system="1.2.3.5",
@@ -1009,3 +1009,53 @@ def test_build_repeating_questions(build_repeating_questions_data, expected_resu
         ).decode("utf-8")
         == expected_result
     )
+
+
+def test_translate_code_system():
+    input_data = Observation(
+        obs_type="EXPOS",
+        type_code="COMP",
+        class_code="OBS",
+        mood_code="EVN",
+        code_system="http://snomed.info/sct",
+        code_code="1234",
+        code_code_system="http://loinc.org",
+        value_quant_code_system="http://acme-rehab.org",
+        value_qualitative_code_system="2.16.840.1.114222.4.5.1",
+    )
+
+    expected_result = Observation(
+        obs_type="EXPOS",
+        type_code="COMP",
+        class_code="OBS",
+        code_display=None,
+        code_system="2.16.840.1.113883.6.96",
+        code_system_name="SNOMED-CT",
+        quantitative_value=None,
+        quantitative_system=None,
+        quantitative_code=None,
+        qualitative_value=None,
+        qualitative_system=None,
+        qualitative_code=None,
+        mood_code="EVN",
+        code_code="1234",
+        code_code_system="number",
+        code_code_system_name="LOINC",
+        code_code_display=None,
+        value_quantitative_code=None,
+        value_quant_code_system="Acme Rehab",
+        value_quant_code_system_name="Acme Rehab",
+        value_quantitative_value=None,
+        value_qualitative_code=None,
+        value_qualitative_code_system="2.16.840.1.114222.4.5.1",
+        value_qualitative_code_system_name="NEDSS Base System",
+        value_qualitative_value=None,
+        components=None,
+        code=None,
+        value=None,
+        translation=None,
+        text=None,
+    )
+    builder = PHDCBuilder()
+    actual_result = builder._translate_code_system(input_data)
+    assert actual_result == expected_result


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR adds a new helper method to ensure that the codeSystems coming out of a FHIR bundle, e.g., `http://loinc.org`, are translated to the appropriate PHDC-compliant code system data, e.g., `LOINC`. 

## Related Issue
Fixes #1329 

## Additional Information
Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
