### PR TITLE
Fixing various bugs on ECR Viewer and Orchestration

### DIFF
--- a/containers/ecr-viewer/src/app/utils.tsx
+++ b/containers/ecr-viewer/src/app/utils.tsx
@@ -689,7 +689,7 @@ export const evaluateClinicalData = (
     {
       title: "Miscellaneous Notes",
       value: parse(
-        evaluate(fhirBundle, mappings["historyOfPresentIllness"])[0].div,
+        evaluate(fhirBundle, mappings["historyOfPresentIllness"])[0]?.div || "",
       ),
     },
   ];

--- a/containers/orchestration/app/main.py
+++ b/containers/orchestration/app/main.py
@@ -251,9 +251,9 @@ async def apply_workflow_to_message(
         return Response(
             content=json.dumps(
                 {
-                    "message": "Request failed with status code"
+                    "message": "Request failed with status code "
                     + f"{response.status_code}",
-                    "responses": responses,
+                    "responses": _filter_failed_responses(responses),
                     "processed_values": "",
                 }
             ),
@@ -277,6 +277,15 @@ async def apply_workflow_to_message(
             workflow_content = response.text
 
     return Response(content=workflow_content, media_type=content_type)
+
+
+def _filter_failed_responses(responses):
+    failed_responses = {}
+    for key, item in responses.items():
+        if item.status_code != 200:
+            failed_responses[key] = item.json()
+
+    return failed_responses
 
 
 @app.get("/configs", responses=sample_list_configs_response)

--- a/containers/orchestration/app/services.py
+++ b/containers/orchestration/app/services.py
@@ -231,7 +231,7 @@ def save_to_s3(bundle: dict) -> dict:
 
     filename = f"{ecr_id}.json"
     s3 = boto3.client("s3")
-    json_data = json.dumps(b)
+    json_data = json.dumps(b["bundle"])
 
     try:
         # Save the JSON data to S3

--- a/containers/orchestration/app/services.py
+++ b/containers/orchestration/app/services.py
@@ -236,12 +236,13 @@ def save_to_s3(bundle: dict) -> dict:
     try:
         # Save the JSON data to S3
         s3.put_object(Bucket=bucket_name, Key=filename, Body=json_data)
-        return {
+        msg = {
             "status": "success",
             "message": f"File {filename} saved to bucket {bucket_name}.",
         }
+        return CustomJSONResponse(content=jsonable_encoder(msg))
     except Exception as e:
-        return {"status": "error", "message": str(e)}
+        return CustomJSONResponse(content=jsonable_encoder(e), status_code=500)
 
 
 async def call_apis(
@@ -317,7 +318,8 @@ async def call_apis(
                 current_message = service_response.msg_content
             responses[service] = response
         elif service == "save_to_s3":
-            save_to_s3(bundle=bundle)
+            response = save_to_s3(bundle=bundle)
+            responses[service] = response
         else:
             db_request = save_to_db_payload(response=response, bundle=bundle)
             response = save_to_db(url=service_url, payload=db_request)
@@ -331,5 +333,4 @@ async def call_apis(
                 )
 
             responses[service] = response
-
     return (response, responses)

--- a/containers/orchestration/tests/integration/test_orchestration.py
+++ b/containers/orchestration/tests/integration/test_orchestration.py
@@ -124,6 +124,31 @@ def test_process_endpoint_with_zip_and_rr_data(setup):
 
 
 @pytest.mark.integration
+def test_failed_save_to_s3(setup):
+    """
+    Full orchestration test of a zip file containing both an eICR and the
+    associated RR data.
+    """
+    with open(
+        Path(__file__).parent.parent.parent.parent.parent
+        / "tests"
+        / "assets"
+        / "orchestration"
+        / "eICR_RR_combo.zip",
+        "rb",
+    ) as file:
+        form_data = {
+            "message_type": "ecr",
+            "config_file_name": "sample-orchestration-s3-config.json",
+        }
+        files = {"upload_file": ("file.zip", file)}
+        orchestration_response = httpx.post(
+            PROCESS_ENDPOINT, data=form_data, files=files
+        )
+        assert orchestration_response.status_code == 500
+
+
+@pytest.mark.integration
 def test_process_message_fhir(setup):
     """
     Integration test of a different workflow and data type, a FHIR bundle


### PR DESCRIPTION
# PULL REQUEST

## Summary
- Miscellaneous notes now has a handle on null values (returns empty
- Orchestration now can return failed responses 
- Removing the bundle tag from the save to orchestration

