### PR TITLE
Incorporate basic OT into orchestration

### DIFF
--- a/containers/orchestration/Dockerfile
+++ b/containers/orchestration/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && \
 
 COPY ./requirements.txt /code/requirements.txt
 RUN pip install -r requirements.txt
+RUN opentelemetry-bootstrap -a install
 
 COPY ./app /code/app
 COPY ./assets /code/assets
@@ -29,4 +30,5 @@ ENV SMARTY_AUTH_TOKEN=$SMARTY_AUTH_TOKEN
 
 
 EXPOSE 8080
-CMD uvicorn app.main:app --host 0.0.0.0 --port 8080 --log-config app/log_config.yml
+RUN export OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
+CMD opentelemetry-instrument --traces_exporter console --metrics_exporter none uvicorn app.main:app --host 0.0.0.0 --port 8080 --log-config app/log_config.yml

--- a/containers/orchestration/requirements.txt
+++ b/containers/orchestration/requirements.txt
@@ -17,3 +17,4 @@ asyncio
 sqlalchemy
 requests-mock 
 pytest-mock
+opentelemetry-distro


### PR DESCRIPTION
## Summary
This PR incorporates automatic integration of OpenTelemetry into the orchestration service. It makes only the most rudimentary of additions, adding it to our requirements file and modifying the docker compose appropriately. With these changes in effect, using docker compose to run the service locally, you can see trace spans produced for every call to the service.

## Related Issue
Fixes #1476 

## Additional Information
The very raw form of this output gives us a lot to think about. Right now, it's not formatted particularly helpfully, since we get a giant barf of spans for every call we make (since we're using automated instrumentation, we do get the bonus of having one Span for each service, so we can actually trace the HTTP calls through the respective containers, which is pretty cool). Also, the existing logger we're using is sort of interweaved with OTel console output, but that should only be a problem for now since we ultimately will want to package this up and save it rather than showing it in the console. We'll also want to start thinking about if/how we want to use environment variables to start setting up the automatic instrumentation when the service launches (some food for thought [here](https://opentelemetry.io/docs/languages/python/automatic/)).