### PR TITLE
Add check and test for null observations in Diagnostic Report

### DIFF
--- a/containers/ecr-viewer/src/app/evaluate-service.tsx
+++ b/containers/ecr-viewer/src/app/evaluate-service.tsx
@@ -33,9 +33,18 @@ export const evaluateReference = (
   })[0];
 };
 
+/**
+ * Evaluates and generates a table of observations based on the provided DiagnosticReport,
+ * FHIR bundle, mappings, and column information.
+ * @param {DiagnosticReport} report - The DiagnosticReport containing observations to be evaluated.
+ * @param {Bundle} fhirBundle - The FHIR bundle containing observation data.
+ * @param {PathMappings} mappings - An object containing the FHIR path mappings.
+ * @param {ColumnInfoInput[]} columnInfo - An array of column information objects specifying column names and information paths.
+ * @returns {React.JSX.Element | undefined} The JSX representation of the evaluated observation table, or undefined if there are no observations.
+ */
 export function evaluateObservationTable(
   report: DiagnosticReport,
-  fhirBundle: Bundle<FhirResource>,
+  fhirBundle: Bundle,
   mappings: PathMappings,
   columnInfo: ColumnInfoInput[],
 ) {

--- a/containers/ecr-viewer/src/app/tests/evaluate-service.test.tsx
+++ b/containers/ecr-viewer/src/app/tests/evaluate-service.test.tsx
@@ -2,9 +2,10 @@ import {
   evaluateReference,
   evaluateDiagnosticReportData,
   evaluateValue,
+  evaluateObservationTable,
 } from "@/app/evaluate-service";
 import BundleWithMiscNotes from "@/app/tests/assets/BundleMiscNotes.json";
-import { Bundle } from "fhir/r4";
+import { Bundle, DiagnosticReport } from "fhir/r4";
 import BundleWithPatient from "@/app/tests/assets/BundlePatient.json";
 import BundleLabInfo from "@/app/tests/assets/BundleLabInfo.json";
 import { loadYamlConfig } from "@/app/api/utils";
@@ -55,6 +56,27 @@ describe("Evaluate Diagnostic Report", () => {
 
     expect(screen.getByText("Phencyclidine Screen, Urine")).toBeInTheDocument();
     expect(screen.getByText("Negative")).toBeInTheDocument();
+  });
+  it("the table should not appear when there are no results", () => {
+    const diagnosticReport = {
+      resource: {
+        resourceType: "DiagnosticReport",
+        code: {
+          coding: [
+            {
+              display: "Drugs Of Abuse Comprehensive Screen, Ur",
+            },
+          ],
+        },
+      },
+    };
+    const actual = evaluateObservationTable(
+      diagnosticReport as DiagnosticReport,
+      null as Bundle,
+      mappings,
+      [],
+    );
+    expect(actual).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
# PULL REQUEST

## Summary
- Add check for null observations in evaluate-service.evaluateDiagnosticReportData()
- Add test to ensure fix 

## Related Issue
Fixes # N/A

## Additional Information
Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
