### PR TITLE
Add prometheus to orchestration

### DIFF
--- a/containers/orchestration/docker-compose.yml
+++ b/containers/orchestration/docker-compose.yml
@@ -9,7 +9,7 @@ services:
         validation-service,
         fhir-converter-service,
         ingestion-service,
-        message-parser-service,
+        message-parser-service
       ]
     ports:
       - "${ORCHESTRATION_PORT_NUMBER}:8080"
@@ -59,3 +59,13 @@ services:
     depends_on:
       db:
         condition: service_healthy
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      - "./prometheus.yml:/etc/prometheus/prometheus.yml"
+      - "prom_data:/prometheus"
+
+volumes:
+  prom_data:

--- a/containers/orchestration/docker-compose.yml
+++ b/containers/orchestration/docker-compose.yml
@@ -9,7 +9,7 @@ services:
         validation-service,
         fhir-converter-service,
         ingestion-service,
-        message-parser-service
+        message-parser-service,
       ]
     ports:
       - "${ORCHESTRATION_PORT_NUMBER}:8080"

--- a/containers/orchestration/prometheus.yml
+++ b/containers/orchestration/prometheus.yml
@@ -2,7 +2,7 @@ global:
   scrape_interval: 15s
 
 scrape_configs:
-  - job_name: 'prometheus'
+  - job_name: "prometheus"
 
     static_configs:
-      - targets: ['localhost:9090']
+      - targets: ["localhost:9090"]

--- a/containers/orchestration/prometheus.yml
+++ b/containers/orchestration/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+
+    static_configs:
+      - targets: ['localhost:9090']


### PR DESCRIPTION
## Summary
This PR adds prometheus into the orchestration service via docker compose. We fetch the latest image of prometheus, build it and appropriately mount volumes for both the job configs and the DB storage, and then set prometheus to monitor  how many times I ask it to monitor itself (baby steps). You can see the prometheus data working by rebuilding all the images, running `docker compose up`, letting prometheus run for a few seconds while it starts scraping the endpoint, and then going to `http://localhost:9090/metrics`. Scroll to the bottom and you'll see the number of requests of each type prometheus makes about itself! Every time you refresh will increase the count by 1, as will every 15 seconds that elapses.

## Additional Information
This is an important first step, but we've got more to do. We need to:
- configure an OTel collector with a prometheus remote-write exporter
- _I think_ set up open telemetry as its own receiver (more digging required here though)
- possibly look into different volume mountings for the persistent storage (this is just a docker volume called prom_data)
- think about what sorts of dummy metrics we want for our first vertical MVP slice, because that'll lead to changes in the config file

Next step though is definitely just getting Prometheus to scrape exposed request data from orchestration.