### PR TITLE
Fix RL TypeError when Address is `None`

### DIFF
--- a/phdi/linkage/link.py
+++ b/phdi/linkage/link.py
@@ -1285,7 +1285,7 @@ def _compare_name_elements(
     return feature_comp
 
 
-def _condense_extract_address_from_resource(resource: dict, field: str):
+def _condense_extract_address_from_resource(resource: dict, field: str) -> List[str]:
     """
     Formatting function to account for patient resources that have multiple
     associated addresses. Each address is a self-contained object, replete
@@ -1293,6 +1293,10 @@ def _condense_extract_address_from_resource(resource: dict, field: str):
     function condenses that `line` into a single concatenated string, for
     each address object, and returns the result in a properly formatted
     list.
+
+    :param resource: The patient resource to extract the address from.
+    :param field: The field to extract the address from.
+    :return: A list of strings, each string representing a single address.
     """
     expanded_address_fhirpath = LINKING_FIELDS_TO_FHIRPATHS[field]
     expanded_address_fhirpath = ".".join(expanded_address_fhirpath.split(".")[:-1])

--- a/phdi/linkage/link.py
+++ b/phdi/linkage/link.py
@@ -1296,9 +1296,13 @@ def _condense_extract_address_from_resource(resource: dict, field: str):
     """
     expanded_address_fhirpath = LINKING_FIELDS_TO_FHIRPATHS[field]
     expanded_address_fhirpath = ".".join(expanded_address_fhirpath.split(".")[:-1])
-    list_of_address_objects = extract_value_with_resource_path(
-        resource, expanded_address_fhirpath, "all"
+    list_of_address_objects = (
+        extract_value_with_resource_path(resource, expanded_address_fhirpath, "all")
+        or []
     )
+    if not list_of_address_objects:
+        return None
+
     if field == "address":
         list_of_address_lists = [
             ao.get(LINKING_FIELDS_TO_FHIRPATHS[field].split(".")[-1], [])
@@ -1313,6 +1317,7 @@ def _condense_extract_address_from_resource(resource: dict, field: str):
             list_of_usable_address_elements.append(
                 address_object.get(LINKING_FIELDS_TO_FHIRPATHS[field].split(".")[-1])
             )
+
     return list_of_usable_address_elements
 
 

--- a/tests/linkage/test_linkage.py
+++ b/tests/linkage/test_linkage.py
@@ -1345,3 +1345,57 @@ def test_aggregate_given_names_for_linkage():
     assert len(aggregated_data_block) == 3
     assert aggregated_data_block[1][6] == "JOHN TIBERIUS"
     assert aggregated_data_block[2][6] == "MIKE"
+
+
+def test_link_match_missing_address_record():
+    algorithm = DIBBS_BASIC
+    MPI = _init_db()
+
+    patients = [
+        {
+            "resourceType": "Patient",
+            "id": "f6a16ff7-4a31-11eb-be7b-8344edc8f36b",
+            "name": [
+                {
+                    "family": "Neil",
+                    "given": [
+                        "Sean",
+                    ],
+                    "use": "official",
+                }
+            ],
+        },
+        {
+            "resourceType": "Patient",
+            "id": "e0900ce2-7432-4c9f-9f1d-6295996497a4",
+            "name": [
+                {
+                    "family": "Neil",
+                    "given": [
+                        "Sean",
+                    ],
+                    "use": "official",
+                }
+            ],
+        },
+    ]
+
+    # Test various null data values in incoming record
+    matches = []
+    mapped_patients = {}
+    for patient in patients:
+        matched, pid = link_record_against_mpi(
+            patient,
+            algorithm,
+        )
+        print(matched)
+        matches.append(matched)
+        if str(pid) not in mapped_patients:
+            mapped_patients[str(pid)] = 0
+        mapped_patients[str(pid)] += 1
+
+    # First patient inserted into empty MPI, no match
+    assert matches == [False, False]
+    assert sorted(list(mapped_patients.values())) == [1, 1]
+
+    _clean_up(MPI.dal)


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR resolves a TypeError that surfaced when attempting to link to a Patient with no address. Thanks to @ericbuckley for finding the bug and the test that was added.

## Related Issue
Fixes #1542

## Additional Information
Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
