### PR TITLE
Centralize testing utils

### DIFF
--- a/containers/record-linkage/app/linkage/mpi.py
+++ b/containers/record-linkage/app/linkage/mpi.py
@@ -5,7 +5,7 @@ import uuid
 from functools import cache
 from typing import Dict
 from typing import List
-from typing import Literal
+from typing import Union
 
 from app.linkage.core import BaseMPIConnectorClient
 from app.linkage.dal import DataAccessLayer
@@ -603,7 +603,7 @@ class DIBBsMPIConnectorClient(BaseMPIConnectorClient):
                 )
 
     @cache
-    def _get_external_source_id(self, external_source_name: str) -> Literal[str, None]:
+    def _get_external_source_id(self, external_source_name: str) -> Union[str, None]:
         """
         Gets the external source id for the external source name provided.
         :param external_source_name: The external source name.

--- a/containers/record-linkage/app/utils.py
+++ b/containers/record-linkage/app/utils.py
@@ -1,24 +1,14 @@
 import json
 import logging
+import os
 import pathlib
 import subprocess
 from typing import Literal
 
 from app.config import get_settings
 from app.linkage.dal import DataAccessLayer
+from app.linkage.mpi import DIBBsMPIConnectorClient
 from sqlalchemy import text
-
-
-def load_mpi_env_vars_os():
-    """
-    Simple helper function to load some of the environment variables
-    needed to make a database connection as part of the DB migrations.
-    """
-    dbname = get_settings().get("mpi_dbname")
-    user = get_settings().get("mpi_user")
-    password = get_settings().get("mpi_password")
-    host = get_settings().get("mpi_host")
-    return dbname, user, password, host
 
 
 def read_json_from_assets(filename: str):
@@ -112,7 +102,45 @@ def run_migrations():
         raise Exception(validation_response.stderr.decode("utf-8"))
 
 
-def _clean_up(dal: DataAccessLayer):
+def set_mpi_env_vars():
+    """
+    Utility function for testing purposes that sets the environment variables
+    of the testing suite to prespecified valid values, and clears out any
+    old values from the DB Settings cache.
+    """
+    os.environ["mpi_db_type"] = "postgres"
+    os.environ["mpi_dbname"] = "testdb"
+    os.environ["mpi_user"] = "postgres"
+    os.environ["mpi_password"] = "pw"
+    os.environ["mpi_host"] = "localhost"
+    os.environ["mpi_port"] = "5432"
+    get_settings.cache_clear()
+
+
+def pop_mpi_env_vars():
+    """
+    Utility function for testing purposes that removes the environment variables
+    used for database access from the testing environment.
+    """
+    os.environ.pop("mpi_db_type", None)
+    os.environ.pop("mpi_dbname", None)
+    os.environ.pop("mpi_user", None)
+    os.environ.pop("mpi_password", None)
+    os.environ.pop("mpi_host", None)
+    os.environ.pop("mpi_port", None)
+
+
+def _clean_up(dal: DataAccessLayer | None = None) -> None:
+    """
+    Utility function for testing purposes that makes tests idempotent by cleaning up
+    database state after each test run.
+
+    :param dal: Optionally, a DataAccessLayer currently connected to an instantiated
+      MPI database. If not provided, the default DIBBsMPIConnectorClient is used
+      to perform cleanup operations.
+    """
+    if dal is None:
+        dal = DIBBsMPIConnectorClient().dal
     with dal.engine.connect() as pg_connection:
         pg_connection.execute(text("""DROP TABLE IF EXISTS external_person CASCADE;"""))
         pg_connection.execute(text("""DROP TABLE IF EXISTS external_source CASCADE;"""))

--- a/containers/record-linkage/seed_testdb.py
+++ b/containers/record-linkage/seed_testdb.py
@@ -2,27 +2,17 @@
 # fmt: off
 import os
 
-from app.config import get_settings
-
-def set_mpi_env_vars():
-    os.environ["mpi_db_type"] = "postgres"
-    os.environ["mpi_dbname"] = "testdb"
-    os.environ["mpi_user"] = "postgres"
-    os.environ["mpi_password"] = "pw"
-    os.environ["mpi_host"] = "localhost"
-    os.environ["mpi_port"] = "5432"
-    get_settings.cache_clear()
+from app.utils import set_mpi_env_vars
 
 
 set_mpi_env_vars()
 
-from fastapi import status
 from fastapi.testclient import TestClient
 from app.main import app, run_migrations
-from sqlalchemy import text
+from app.utils import _clean_up
+from app.utils import pop_mpi_env_vars
 import json
 import pathlib
-from app.linkage.mpi import DIBBsMPIConnectorClient
 # fmt: on
 client = TestClient(app)
 
@@ -37,34 +27,6 @@ def load_test_bundle():
         )
     )
     return test_bundle
-
-
-def pop_mpi_env_vars():
-    os.environ.pop("mpi_db_type", None)
-    os.environ.pop("mpi_dbname", None)
-    os.environ.pop("mpi_user", None)
-    os.environ.pop("mpi_password", None)
-    os.environ.pop("mpi_host", None)
-    os.environ.pop("mpi_port", None)
-
-
-def _clean_up():
-    MPI = DIBBsMPIConnectorClient()
-
-    with MPI.dal.engine.connect() as pg_connection:
-        pg_connection.execute(text("""DROP TABLE IF EXISTS external_person CASCADE;"""))
-        pg_connection.execute(text("""DROP TABLE IF EXISTS external_source CASCADE;"""))
-        pg_connection.execute(text("""DROP TABLE IF EXISTS address CASCADE;"""))
-        pg_connection.execute(text("""DROP TABLE IF EXISTS phone_number CASCADE;"""))
-        pg_connection.execute(text("""DROP TABLE IF EXISTS identifier CASCADE;"""))
-        pg_connection.execute(text("""DROP TABLE IF EXISTS give_name CASCADE;"""))
-        pg_connection.execute(text("""DROP TABLE IF EXISTS given_name CASCADE;"""))
-        pg_connection.execute(text("""DROP TABLE IF EXISTS name CASCADE;"""))
-        pg_connection.execute(text("""DROP TABLE IF EXISTS patient CASCADE;"""))
-        pg_connection.execute(text("""DROP TABLE IF EXISTS person CASCADE;"""))
-        pg_connection.execute(text("""DROP TABLE IF EXISTS public.pyway;"""))
-        pg_connection.commit()
-        pg_connection.close()
 
 
 def seed_testdb():

--- a/containers/record-linkage/tests/test_record_linkage.py
+++ b/containers/record-linkage/tests/test_record_linkage.py
@@ -5,28 +5,20 @@ import json
 import os
 import pathlib
 
+import pytest
 from app.config import get_settings
-
-def set_mpi_env_vars():
-    os.environ["mpi_db_type"] = "postgres"
-    os.environ["mpi_dbname"] = "testdb"
-    os.environ["mpi_user"] = "postgres"
-    os.environ["mpi_password"] = "pw"
-    os.environ["mpi_host"] = "localhost"
-    os.environ["mpi_port"] = "5432"
-    get_settings.cache_clear()
-
+from app.utils import pop_mpi_env_vars
+from app.utils import set_mpi_env_vars
 
 set_mpi_env_vars()
 
 from fastapi import status
 from fastapi.testclient import TestClient
 from app.main import app, run_migrations
-from sqlalchemy import text
+from app.utils import _clean_up
 import copy
 import json
 import pathlib
-from app.linkage.mpi import DIBBsMPIConnectorClient
 # fmt: on
 client = TestClient(app)
 
@@ -42,47 +34,29 @@ def load_test_bundle():
     return test_bundle
 
 
-def pop_mpi_env_vars():
-    os.environ.pop("mpi_db_type", None)
-    os.environ.pop("mpi_dbname", None)
-    os.environ.pop("mpi_user", None)
-    os.environ.pop("mpi_password", None)
-    os.environ.pop("mpi_host", None)
-    os.environ.pop("mpi_port", None)
-
-
-def _clean_up():
-    MPI = DIBBsMPIConnectorClient()
-
-    with MPI.dal.engine.connect() as pg_connection:
-        pg_connection.execute(text("""DROP TABLE IF EXISTS external_person CASCADE;"""))
-        pg_connection.execute(text("""DROP TABLE IF EXISTS external_source CASCADE;"""))
-        pg_connection.execute(text("""DROP TABLE IF EXISTS address CASCADE;"""))
-        pg_connection.execute(text("""DROP TABLE IF EXISTS phone_number CASCADE;"""))
-        pg_connection.execute(text("""DROP TABLE IF EXISTS identifier CASCADE;"""))
-        pg_connection.execute(text("""DROP TABLE IF EXISTS give_name CASCADE;"""))
-        pg_connection.execute(text("""DROP TABLE IF EXISTS given_name CASCADE;"""))
-        pg_connection.execute(text("""DROP TABLE IF EXISTS name CASCADE;"""))
-        pg_connection.execute(text("""DROP TABLE IF EXISTS patient CASCADE;"""))
-        pg_connection.execute(text("""DROP TABLE IF EXISTS person CASCADE;"""))
-        pg_connection.execute(text("""DROP TABLE IF EXISTS public.pyway CASCADE;"""))
-        pg_connection.commit()
-
-
-def test_health_check():
+@pytest.fixture(autouse=True)
+def setup_and_clean_tests():
+    # This code will always run before every test in this file
+    # We want it to set up env variables and run migrations
     set_mpi_env_vars()
     run_migrations()
 
-    actual_response = client.get("/")
-    assert actual_response.status_code == 200
-    # assert actual_response.json() == {"status": "OK", "mpi_connection_status": "OK"}
+    # pytest will automatically plug each test in this scoped file
+    # in place of this yield
+    yield
+
+    # This code will run at the end of the test plugged into the yield
     _clean_up()
     pop_mpi_env_vars()
 
 
+def test_health_check():
+    actual_response = client.get("/")
+    assert actual_response.status_code == 200
+    assert actual_response.json() == {"status": "OK", "mpi_connection_status": "OK"}
+
+
 def test_linkage_bundle_with_no_patient():
-    set_mpi_env_vars()
-    run_migrations()
     bad_bundle = {"entry": []}
     expected_response = {
         "message": "Supplied bundle contains no Patient resource to link on.",
@@ -95,13 +69,9 @@ def test_linkage_bundle_with_no_patient():
     )
     assert actual_response.json() == expected_response
     assert actual_response.status_code == status.HTTP_400_BAD_REQUEST
-    _clean_up()
-    pop_mpi_env_vars()
 
 
 def test_linkage_invalid_db_type():
-    set_mpi_env_vars()
-    run_migrations()
     invalid_db_type = "mssql"
     os.environ["mpi_db_type"] = invalid_db_type
     get_settings.cache_clear()
@@ -119,14 +89,8 @@ def test_linkage_invalid_db_type():
     assert actual_response.json() == expected_response
     assert actual_response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
-    _clean_up()
-    pop_mpi_env_vars()
-    os.environ.pop("mpi_db_type", None)
-
 
 def test_linkage_success():
-    set_mpi_env_vars()
-    run_migrations()
     test_bundle = load_test_bundle()
     entry_list = copy.deepcopy(test_bundle["entry"])
 
@@ -186,14 +150,9 @@ def test_linkage_success():
     ][0]
     assert resp_6.json()["found_match"]
     assert person_6.get("id") == person_1.get("id")
-    _clean_up()
-    pop_mpi_env_vars()
 
 
 def test_use_enhanced_algo():
-    # Start with fresh tables to make tests atomic
-    set_mpi_env_vars()
-    run_migrations()
     test_bundle = load_test_bundle()
     entry_list = copy.deepcopy(test_bundle["entry"])
 
@@ -265,6 +224,3 @@ def test_use_enhanced_algo():
     ][0]
     assert resp_6.json()["found_match"]
     assert person_6.get("id") == person_1.get("id")
-
-    _clean_up()
-    pop_mpi_env_vars()


### PR DESCRIPTION
# Making our RL tests (at least a little bit) less brittle

## Summary
This PR introduces a couple of refactoring cleanup changes designed to make the record linkage tests more robust in the face of our DB and CI/CD woes. There are a couple of main changes here:
- removing duplicate copies of `_clean_up`, `set_env_variables`, and `pop_env_variables`; previously, there were three different versions of most of these functions with either minor variations or no variations at all. These have now all been centrally located in the `app.utils` file for sharing across all tests. In particular, with the `_clean_up` function, we've now made it more flexible for testing purposes because the `dal` parameter is optional.
- wrapping migrations, DB setup, and env variable teardown in the testing suite in an `autouse` `pytest.fixture`. Instead of manually defining and calling these functions with every test, we can create an automation point that tells pytest to run setup and teardown functions for us around every test in a scoped file. Importantly, this gives us the benefit of a `try/finally` flow in that pytest is now responsible for both creating and removing the environment variables used in the testing suite (i.e. if we encounter some issue down the line with the pyway migrations command, all tables should still get removed from the testing MPI so we better achieve idempotency).

## Related Issue
No zenhub issue, but makes some strides on cleaning up some of the most brittle testing offenders, and I said I'd make a fast follow to address the duplications that Robert found

## Additional Information
There is one more area of duplication that I didn't touch here, the doubling up config sets in `app/config.py` and `app/linkage/utils.py`. While I'm 80ish percent sure we could delete either one of these and wire all config through the other, I know cache performance on the DB had a massive performance impact when seeding in LAC's environment, so I'm hesitant to mess with anything that involves LRU cache settings since I don't know which part of the cache being defined was part of that speed up.
