### PR TITLE
ecr viewer: fix duplicate db connections

### DIFF
--- a/containers/ecr-viewer/docker-compose.yml
+++ b/containers/ecr-viewer/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   # PostgreSQL database
   db:

--- a/containers/ecr-viewer/src/app/api/fhir-data/db.ts
+++ b/containers/ecr-viewer/src/app/api/fhir-data/db.ts
@@ -1,0 +1,4 @@
+import pgp from "pg-promise";
+
+const db_url = process.env.DATABASE_URL || "";
+export const database = pgp()(db_url);

--- a/containers/ecr-viewer/src/app/api/fhir-data/fhir-data-service.ts
+++ b/containers/ecr-viewer/src/app/api/fhir-data/fhir-data-service.ts
@@ -2,15 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import pgPromise from "pg-promise";
 import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
 import { loadYamlConfig, streamToJson } from "../utils";
+import { database } from "@/app/api/fhir-data/db";
 
 const s3Client = new S3Client({ region: process.env.AWS_REGION });
 
 export const get_postgres = async (request: NextRequest) => {
   const params = request.nextUrl.searchParams;
   const ecr_id = params.get("id") ? params.get("id") : null;
-  const db_url = process.env.DATABASE_URL || "";
-  const db = pgPromise();
-  const database = db(db_url);
   const mappings = loadYamlConfig();
 
   const { ParameterizedQuery: PQ } = pgPromise;


### PR DESCRIPTION
# PULL REQUEST

## Summary
- Create a global object for the DB connection
  - This is the fix to the warning about creating duplicate database connections. 
  - https://vitaly-t.github.io/pg-promise/Database.html 
- Remove version from docker-compose.yaml since it is deprecated.
  -  https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-and-name-top-level-elements

## Additional Information
- Test locally to ensure works as expected. 