### PR TITLE
[ecr-viewer] fix expand / collapse when multiple labs are available

### DIFF
--- a/containers/ecr-viewer/src/app/view-data/components/AccordionLabResults.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/AccordionLabResults.tsx
@@ -44,10 +44,10 @@ export const AccordionLabResults: React.FC<AccordionLabResultsProps> = ({
           expanded: collapsedByDefault,
           id: title,
           headingLevel: "h5",
-          className: `${organizationId}_acc_item`,
+          className: `acc_item_${organizationId}`,
         },
       ]}
-      className={`accordion-rr ${organizationId}_accordion margin-bottom-3`}
+      className={`accordion-rr accordion_${organizationId} margin-bottom-3`}
     />
   );
 };

--- a/containers/ecr-viewer/src/app/view-data/components/LabInfo.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/LabInfo.tsx
@@ -29,10 +29,10 @@ export const LabInfo = ({ labResults }: LabInfoProps): React.JSX.Element => {
           // the orgId makes it so that when you have multiple, it can distinguish
           // which org it is modifying
           const accordionSelectorClass = labResult.organizationId
-            ? `.${labResult.organizationId}_accordion`
+            ? `.accordion_${labResult.organizationId}`
             : ".accordion-rr";
           const buttonSelectorClass = labResult.organizationId
-            ? `.${labResult.organizationId}_acc_item`
+            ? `.acc_item_${labResult.organizationId}`
             : "h5";
           const labName = `Lab Results from 
                 ${truncateLabNameWholeWord(

--- a/containers/ecr-viewer/src/app/view-data/components/tests/LabInfo.test.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/tests/LabInfo.test.tsx
@@ -48,13 +48,9 @@ describe("LabInfo", () => {
       ]}
     />
   );
-  it("should hide all labs when collapse button is clicked", async () => {
-    const user = userEvent.setup();
+  it("all should be collapsed by default", () => {
     render(labInfoJsx());
-    const collapseButtons = screen.getAllByText("Collapse all labs");
-    for (const button of collapseButtons) {
-      await user.click(button);
-    }
+
     screen
       .getAllByTestId("accordionButton", { exact: false })
       .forEach((button) => {
@@ -63,28 +59,12 @@ describe("LabInfo", () => {
     screen
       .getAllByTestId("accordionItem", { exact: false })
       .forEach((accordion) => {
-        expect(accordion).toHaveAttribute("hidden", "true");
+        expect(accordion).not.toBeVisible();
       });
   });
-  it("should hide all labs when collapse button is clicked", async () => {
+  it("should expand all labs when collapse button is clicked", async () => {
     const user = userEvent.setup();
-
     render(labInfoJsx());
-    const collapseButtons = screen.getAllByText("Collapse all labs");
-    for (const button of collapseButtons) {
-      await user.click(button);
-    }
-    screen
-      .getAllByTestId("accordionButton", { exact: false })
-      .forEach((button) => {
-        expect(button).toHaveAttribute("aria-expanded", "false");
-      });
-    screen
-      .getAllByTestId("accordionItem", { exact: false })
-      .forEach((accordion) => {
-        expect(accordion).toHaveAttribute("hidden", "true");
-      });
-
     const expandButtons = screen.getAllByText("Expand all labs");
     for (const button of expandButtons) {
       await user.click(button);
@@ -97,7 +77,40 @@ describe("LabInfo", () => {
     screen
       .getAllByTestId("accordionItem", { exact: false })
       .forEach((accordion) => {
-        expect(accordion).not.toHaveAttribute("hidden");
+        expect(accordion).toBeVisible();
+      });
+  });
+  it("should hide all labs when collapse button is clicked", async () => {
+    const user = userEvent.setup();
+    render(labInfoJsx());
+    const expandButtons = screen.getAllByText("Expand all labs");
+    for (const button of expandButtons) {
+      await user.click(button);
+    }
+    screen
+      .getAllByTestId("accordionButton", { exact: false })
+      .forEach((button) => {
+        expect(button).toHaveAttribute("aria-expanded", "true");
+      });
+    screen
+      .getAllByTestId("accordionItem", { exact: false })
+      .forEach((accordion) => {
+        expect(accordion).toBeVisible();
+      });
+
+    const collapseButtons = screen.getAllByText("Collapse all labs");
+    for (const button of collapseButtons) {
+      await user.click(button);
+    }
+    screen
+      .getAllByTestId("accordionButton", { exact: false })
+      .forEach((button) => {
+        expect(button).toHaveAttribute("aria-expanded", "false");
+      });
+    screen
+      .getAllByTestId("accordionItem", { exact: false })
+      .forEach((accordion) => {
+        expect(accordion).not.toBeVisible();
       });
   });
 });


### PR DESCRIPTION
# PULL REQUEST

## Summary
- Put the id after the class name 
- Fix tests to replicate what happens actually

## Related Issue
Fixes #1669 

## Additional Information
Example with multiple labs:

https://github.com/CDCgov/phdi/assets/10108172/82235ccf-96c5-4782-bb19-ee815adf9958

Example with only 1 lab:

https://github.com/CDCgov/phdi/assets/10108172/c872e787-0363-4f63-aa50-d64b721db6a2

