### PR TITLE
Build logs into spans

### DIFF
--- a/containers/orchestration/app/handlers.py
+++ b/containers/orchestration/app/handlers.py
@@ -589,7 +589,7 @@ def unpack_parsed_message_response(
                     "Message parser responded with unprocessable entity / bad input parameters"
                 )
                 handler_span.set_status(
-                    StatusCode(2), "Error Message: " + response.json()
+                    StatusCode(2), "Error Message: " + response.json().__str__()
                 )
                 return ServiceHandlerResponse(status_code, response.json(), False)
             case _:
@@ -631,7 +631,7 @@ def unpack_fhir_to_phdc_response(response: Response) -> ServiceHandlerResponse:
                     "Message parser responded with unprocessable entity / bad input parameters"
                 )
                 handler_span.set_status(
-                    StatusCode(2), "Error Message: " + response.json()
+                    StatusCode(2), "Error Message: " + response.json().__str__()
                 )
                 return ServiceHandlerResponse(status_code, response.json(), False)
             case _:
@@ -737,7 +737,7 @@ def unpack_ingestion_standardization(response: Response) -> ServiceHandlerRespon
                     "ingestion service responded with unprocessable entity / bad input params"
                 )
                 handler_span.set_status(
-                    StatusCode(2), "Error Message: " + response.json()
+                    StatusCode(2), "Error Message: " + response.json().__str__()
                 )
                 return ServiceHandlerResponse(status_code, response.json(), False)
             case _:

--- a/containers/orchestration/app/handlers.py
+++ b/containers/orchestration/app/handlers.py
@@ -1,5 +1,7 @@
 import os
 
+from opentelemetry import trace
+from opentelemetry.trace.status import StatusCode
 from requests import Response
 
 from app.models import OrchestrationRequest
@@ -10,6 +12,9 @@ MESSAGE_TO_TEMPLATE_MAP = {
     "elr": "ORU_R01",
     "vxu": "VXU_V04",
 }
+
+# Integrate services tracer with automatic instrumentation context
+tracer = trace.get_tracer("orchestration_handlers.py_tracer")
 
 
 class ServiceHandlerResponse:
@@ -109,15 +114,28 @@ def build_fhir_converter_request(
     :return: A dictionary ready to JSON-serialize as a payload to the
       FHIR converter.
     """
-    # Template will depend on input data formatting and typing
-    input_type = orchestration_request.get("message_type")
-    root_template = MESSAGE_TO_TEMPLATE_MAP[input_type]
-    return {
-        "input_data": input_msg,
-        "input_type": input_type,
-        "root_template": root_template,
-        "rr_data": orchestration_request.get("rr_data"),
-    }
+    with tracer.start_as_current_span(
+        "build_fhir_converter_request",
+        kind=trace.SpanKind(0),
+        attributes={
+            "message_type": orchestration_request.get("message_type"),
+            "data_type": orchestration_request.get("data_type"),
+            "workflow_params": workflow_params,
+        },
+    ) as handler_span:
+        # Template will depend on input data formatting and typing
+        input_type = orchestration_request.get("message_type")
+        root_template = MESSAGE_TO_TEMPLATE_MAP[input_type]
+        handler_span.add_event(
+            "identified root template type for conversion",
+            attributes={"root_template": root_template},
+        )
+        return {
+            "input_data": input_msg,
+            "input_type": input_type,
+            "root_template": root_template,
+            "rr_data": orchestration_request.get("rr_data"),
+        }
 
 
 def build_message_parser_message_request(
@@ -140,17 +158,30 @@ def build_message_parser_message_request(
     :return: A dictionary ready to JSON-serialize as a payload to the
       message parser.
     """
-    # Template format will depend on the data's structure
-    if isinstance(input_msg, dict) and input_msg.get("resourceType", "") == "Bundle":
-        msg_fmt = "fhir"
-    else:
-        msg_fmt = orchestration_request.get("message_type")
-    return {
-        "message": input_msg,
-        "message_format": msg_fmt,
-        "parsing_schema_name": workflow_params.get("parsing_schema_name"),
-        "credential_manager": workflow_params.get("credential_manager"),
-    }
+    with tracer.start_as_current_span(
+        "build_message_parser_parse_message_request",
+        kind=trace.SpanKind(0),
+        attributes={
+            "message_type": orchestration_request.get("message_type"),
+            "data_type": orchestration_request.get("data_type"),
+            "workflow_params": workflow_params,
+        },
+    ) as handler_span:
+        # Template format will depend on the data's structure
+        if (
+            isinstance(input_msg, dict)
+            and input_msg.get("resourceType", "") == "Bundle"
+        ):
+            msg_fmt = "fhir"
+        else:
+            msg_fmt = orchestration_request.get("message_type")
+        handler_span.add_event("using message format " + msg_fmt)
+        return {
+            "message": input_msg,
+            "message_format": msg_fmt,
+            "parsing_schema_name": workflow_params.get("parsing_schema_name"),
+            "credential_manager": workflow_params.get("credential_manager"),
+        }
 
 
 def build_message_parser_phdc_request(
@@ -173,11 +204,19 @@ def build_message_parser_phdc_request(
     :return: A dictionary ready to JSON-serialize as a payload to the
       message parser.
     """
-
-    return {
-        "message": input_msg,
-        "phdc_report_type": workflow_params.get("phdc_report_type"),
-    }
+    with tracer.start_as_current_span(
+        "build_message_parser_phdc_request",
+        kind=trace.SpanKind(0),
+        attributes={
+            "message_type": orchestration_request.get("message_type"),
+            "data_type": orchestration_request.get("data_type"),
+            "workflow_params": workflow_params,
+        },
+    ):
+        return {
+            "message": input_msg,
+            "phdc_report_type": workflow_params.get("phdc_report_type"),
+        }
 
 
 def build_validation_request(
@@ -200,12 +239,21 @@ def build_validation_request(
       included in the workflow config for the validation step of a workflow.
     :return: A dictionary ready to send to the validation service.
     """
-    return {
-        "message_type": orchestration_request.get("message_type"),
-        "include_error_types": workflow_params.get("include_error_types"),
-        "message": orchestration_request.get("message"),
-        "rr_data": orchestration_request.get("rr_data"),
-    }
+    with tracer.start_as_current_span(
+        "build_validation_request",
+        kind=trace.SpanKind(0),
+        attributes={
+            "message_type": orchestration_request.get("message_type"),
+            "data_type": orchestration_request.get("data_type"),
+            "workflow_params": workflow_params,
+        },
+    ):
+        return {
+            "message_type": orchestration_request.get("message_type"),
+            "include_error_types": workflow_params.get("include_error_types"),
+            "message": orchestration_request.get("message"),
+            "rr_data": orchestration_request.get("rr_data"),
+        }
 
 
 def build_ingestion_name_request(
@@ -228,27 +276,46 @@ def build_ingestion_name_request(
     :return: A dictionary ready to JSON-serialize as a payload to the
       message parser.
     """
-    # Default parameter values
-    default_params = {
-        "trim": "true",
-        "overwrite": "true",
-        "case": "upper",
-        "remove_numbers": "true",
-    }
+    with tracer.start_as_current_span(
+        "build_ingestion_name_standardization_request",
+        kind=trace.SpanKind(0),
+        attributes={
+            "message_type": orchestration_request.get("message_type"),
+            "data_type": orchestration_request.get("data_type"),
+            "workflow_params": workflow_params,
+        },
+    ) as handler_span:
+        # Default parameter values
+        default_params = {
+            "trim": "true",
+            "overwrite": "true",
+            "case": "upper",
+            "remove_numbers": "true",
+        }
 
-    # Initialize workflow_params as an empty dictionary if it's None
-    workflow_params = workflow_params or {}
+        # Initialize workflow_params as an empty dictionary if it's None
+        workflow_params = workflow_params or {}
 
-    for key, value in default_params.items():
-        workflow_params.setdefault(key, value)
+        for key, value in default_params.items():
+            workflow_params.setdefault(key, value)
 
-    return {
-        "data": input_msg,
-        "trim": workflow_params.get("trim"),
-        "overwrite": workflow_params.get("overwrite"),
-        "case": workflow_params.get("case"),
-        "remove_numbers": workflow_params.get("remove_numbers"),
-    }
+        handler_span.add_event(
+            "updating standardization options",
+            attributes={
+                "trim": workflow_params.get("trim"),
+                "overwrite": workflow_params.get("overwrite"),
+                "case": workflow_params.get("case"),
+                "remove_numbers": workflow_params.get("remove_numbers"),
+            },
+        )
+
+        return {
+            "data": input_msg,
+            "trim": workflow_params.get("trim"),
+            "overwrite": workflow_params.get("overwrite"),
+            "case": workflow_params.get("case"),
+            "remove_numbers": workflow_params.get("remove_numbers"),
+        }
 
 
 def build_ingestion_phone_request(
@@ -271,14 +338,23 @@ def build_ingestion_phone_request(
     :return: A dictionary ready to JSON-serialize as a payload to the
       message parser.
     """
-    # Since only one param, just adding explicitly
-    if workflow_params is None:
-        workflow_params = {"overwrite": "true"}
+    with tracer.start_as_current_span(
+        "build_ingestion_phone_standardization_request",
+        kind=trace.SpanKind(0),
+        attributes={
+            "message_type": orchestration_request.get("message_type"),
+            "data_type": orchestration_request.get("data_type"),
+            "workflow_params": workflow_params,
+        },
+    ):
+        # Since only one param, just add it explicitly
+        if workflow_params is None:
+            workflow_params = {"overwrite": "true"}
 
-    return {
-        "data": input_msg,
-        "overwrite": workflow_params.get("overwrite"),
-    }
+        return {
+            "data": input_msg,
+            "overwrite": workflow_params.get("overwrite", "true"),
+        }
 
 
 def build_ingestion_dob_request(
@@ -301,20 +377,37 @@ def build_ingestion_dob_request(
     :return: A dictionary ready to JSON-serialize as a payload to the
       message parser.
     """
-    # Default parameter values
-    default_params = {"overwrite": "true", "format": "Y%-m%-d%"}
+    with tracer.start_as_current_span(
+        "build_ingestion_dob_standardization_request",
+        kind=trace.SpanKind(0),
+        attributes={
+            "message_type": orchestration_request.get("message_type"),
+            "data_type": orchestration_request.get("data_type"),
+            "workflow_params": workflow_params,
+        },
+    ) as handler_span:
+        # Default parameter values
+        default_params = {"overwrite": "true", "format": "Y%-m%-d%"}
 
-    # Initialize workflow_params as an empty dictionary if it's None
-    workflow_params = workflow_params or {}
+        # Initialize workflow_params as an empty dictionary if it's None
+        workflow_params = workflow_params or {}
 
-    for key, value in default_params.items():
-        workflow_params.setdefault(key, value)
+        for key, value in default_params.items():
+            workflow_params.setdefault(key, value)
 
-    return {
-        "data": input_msg,
-        "overwrite": workflow_params.get("overwrite"),
-        "format": workflow_params.get("format"),
-    }
+        handler_span.add_event(
+            "updating standardization options",
+            attributes={
+                "overwrite": workflow_params.get("overwrite"),
+                "format": workflow_params.get("format"),
+            },
+        )
+
+        return {
+            "data": input_msg,
+            "overwrite": workflow_params.get("overwrite"),
+            "format": workflow_params.get("format"),
+        }
 
 
 def build_geocoding_request(
@@ -337,29 +430,53 @@ def build_geocoding_request(
     :return: A dictionary ready to JSON-serialize as a payload to the
       message parser.
     """
-    # Default parameter values
-    default_params = {
-        "geocode_method": "smarty",
-        "smarty_auth_id": os.environ.get("SMARTY_AUTH_ID"),
-        "smarty_auth_token": os.environ.get("SMARTY_AUTH_TOKEN"),
-        "license_type": "us-rooftop-geocoding-enterprise-cloud",
-        "overwrite": "true",
-    }
+    with tracer.start_as_current_span(
+        "build_geocoding_request",
+        kind=trace.SpanKind(0),
+        attributes={
+            "message_type": orchestration_request.get("message_type"),
+            "data_type": orchestration_request.get("data_type"),
+            "workflow_params": workflow_params,
+        },
+    ) as handler_span:
+        # Default parameter values
+        default_params = {
+            "geocode_method": "smarty",
+            "smarty_auth_id": os.environ.get("SMARTY_AUTH_ID"),
+            "smarty_auth_token": os.environ.get("SMARTY_AUTH_TOKEN"),
+            "license_type": "us-rooftop-geocoding-enterprise-cloud",
+            "overwrite": "true",
+        }
 
-    # Initialize workflow_params as an empty dictionary if it's None
-    workflow_params = workflow_params or {}
+        # Initialize workflow_params as an empty dictionary if it's None
+        workflow_params = workflow_params or {}
 
-    for key, value in default_params.items():
-        workflow_params.setdefault(key, value)
+        for key, value in default_params.items():
+            workflow_params.setdefault(key, value)
 
-    return {
-        "bundle": input_msg,
-        "geocode_method": workflow_params.get("geocode_method"),
-        "smarty_auth_id": workflow_params.get("smarty_auth_id"),
-        "smarty_auth_token": workflow_params.get("smarty_auth_token"),
-        "license_type": workflow_params.get("license_type"),
-        "overwrite": workflow_params.get("overwrite"),
-    }
+        handler_span.add_event(
+            "updating geocoding function parameters",
+            attributes={
+                "geocode_method": workflow_params.get("geocode_method"),
+                "smarty_auth_id_is_not_null": workflow_params.get("smarty_auth_id")
+                is not None,
+                "smarty_auth_token_is_not_null": workflow_params.get(
+                    "smarty_auth_token"
+                )
+                is not None,
+                "license_type": workflow_params.get("license_type"),
+                "overwrite": workflow_params.get("overwrite"),
+            },
+        )
+
+        return {
+            "bundle": input_msg,
+            "geocode_method": workflow_params.get("geocode_method"),
+            "smarty_auth_id": workflow_params.get("smarty_auth_id"),
+            "smarty_auth_token": workflow_params.get("smarty_auth_token"),
+            "license_type": workflow_params.get("license_type"),
+            "overwrite": workflow_params.get("overwrite"),
+        }
 
 
 def build_save_fhir_data_body(
@@ -381,10 +498,19 @@ def build_save_fhir_data_body(
       included in the workflow config for the validation step of a workflow.
     :return: A dictionary ready to send to the validation service.
     """
-    return {
-        "fhirBundle": input_msg,
-        "saveSource": workflow_params.get("saveSource"),
-    }
+    with tracer.start_as_current_span(
+        "build_save_fhir_data_body_request",
+        kind=trace.SpanKind(0),
+        attributes={
+            "message_type": orchestration_request.get("message_type"),
+            "data_type": orchestration_request.get("data_type"),
+            "workflow_params": workflow_params,
+        },
+    ):
+        return {
+            "fhirBundle": input_msg,
+            "saveSource": workflow_params.get("saveSource"),
+        }
 
 
 def unpack_fhir_converter_response(response: Response) -> ServiceHandlerResponse:
@@ -399,17 +525,29 @@ def unpack_fhir_converter_response(response: Response) -> ServiceHandlerResponse
     :return: A ServiceHandlerResponse with a FHIR bundle and instruction
       to continue, or a failed status code and error messaging.
     """
-    match response.status_code:
-        case 200:
-            converter_response = response.json().get("response")
-            fhir_msg = converter_response.get("FhirResource")
-            return ServiceHandlerResponse(response.status_code, fhir_msg, True)
-        case _:
-            return ServiceHandlerResponse(
-                response.status_code,
-                f"FHIR Converter request failed: {response.text}",
-                False,
-            )
+    with tracer.start_as_current_span(
+        "unpack_fhir_converter_response",
+        kind=trace.SpanKind(0),
+        attributes={"status_code": response.status_code},
+    ) as handler_span:
+        match response.status_code:
+            case 200:
+                handler_span.add_event(
+                    "conversion successful, dumping to JSON response struct"
+                )
+                converter_response = response.json().get("response")
+                fhir_msg = converter_response.get("FhirResource")
+                return ServiceHandlerResponse(response.status_code, fhir_msg, True)
+            case _:
+                handler_span.add_event("conversion failed")
+                handler_span.set_status(
+                    StatusCode(2), "Error Message: " + response.text
+                )
+                return ServiceHandlerResponse(
+                    response.status_code,
+                    f"FHIR Converter request failed: {response.text}",
+                    False,
+                )
 
 
 def unpack_parsed_message_response(
@@ -425,23 +563,45 @@ def unpack_parsed_message_response(
     :return: A ServiceHandlerResponse with a dictionary of parsed values
       and instruction to continue, or a failed status code and error messaging.
     """
-    status_code = response.status_code
+    with tracer.start_as_current_span(
+        "unpack_parsed_message_response",
+        kind=trace.SpanKind(0),
+        attributes={"status_code": response.status_code},
+    ) as handler_span:
+        status_code = response.status_code
 
-    match status_code:
-        case 200:
-            return ServiceHandlerResponse(
-                status_code, response.json().get("parsed_values"), True
-            )
-        case 400:
-            return ServiceHandlerResponse(
-                status_code, response.json().get("message"), False
-            )
-        case 422:
-            return ServiceHandlerResponse(status_code, response.json(), False)
-        case _:
-            return ServiceHandlerResponse(
-                status_code, f"Message Parser request failed: {response.text}", False
-            )
+        match status_code:
+            case 200:
+                handler_span.add_event("Successfully parsed extracted values")
+                return ServiceHandlerResponse(
+                    status_code, response.json().get("parsed_values"), True
+                )
+            case 400:
+                handler_span.add_event("Message parser responded with bad request")
+                handler_span.set_status(
+                    StatusCode(2), "Error Message: " + response.json().get("message")
+                )
+                return ServiceHandlerResponse(
+                    status_code, response.json().get("message"), False
+                )
+            case 422:
+                handler_span.add_event(
+                    "Message parser responded with unprocessable entity / bad input parameters"
+                )
+                handler_span.set_status(
+                    StatusCode(2), "Error Message: " + response.json()
+                )
+                return ServiceHandlerResponse(status_code, response.json(), False)
+            case _:
+                handler_span.add_event("Message parser failed")
+                handler_span.set_status(
+                    StatusCode(2), "Error Message: " + response.text
+                )
+                return ServiceHandlerResponse(
+                    status_code,
+                    f"Message Parser request failed: {response.text}",
+                    False,
+                )
 
 
 def unpack_fhir_to_phdc_response(response: Response) -> ServiceHandlerResponse:
@@ -455,17 +615,35 @@ def unpack_fhir_to_phdc_response(response: Response) -> ServiceHandlerResponse:
     :return: A tuple containing the status code of the response as well as
       parsed message created by the service.
     """
-    status_code = response.status_code
+    with tracer.start_as_current_span(
+        "unpack_fhir_to_phdc_response",
+        kind=trace.SpanKind(0),
+        attributes={"status_code": response.status_code},
+    ) as handler_span:
+        status_code = response.status_code
 
-    match status_code:
-        case 200:
-            return ServiceHandlerResponse(status_code, response.content, True)
-        case 422:
-            return ServiceHandlerResponse(status_code, response.json(), False)
-        case _:
-            return ServiceHandlerResponse(
-                status_code, f"Message Parser request failed: {response.text}", False
-            )
+        match status_code:
+            case 200:
+                handler_span.add_event("Successfully constructed PHDC from bundle")
+                return ServiceHandlerResponse(status_code, response.content, True)
+            case 422:
+                handler_span.add_event(
+                    "Message parser responded with unprocessable entity / bad input parameters"
+                )
+                handler_span.set_status(
+                    StatusCode(2), "Error Message: " + response.json()
+                )
+                return ServiceHandlerResponse(status_code, response.json(), False)
+            case _:
+                handler_span.add_event("PHDC construction failed")
+                handler_span.set_status(
+                    StatusCode(2), "Error Message: " + response.text
+                )
+                return ServiceHandlerResponse(
+                    status_code,
+                    f"Message Parser request failed: {response.text}",
+                    False,
+                )
 
 
 def unpack_validation_response(response: Response) -> ServiceHandlerResponse:
@@ -482,20 +660,40 @@ def unpack_validation_response(response: Response) -> ServiceHandlerResponse:
     :return: A ServiceHandlerResponse with any validation errors the data
       generated, or an instruction to continue to the next service.
     """
-    match response.status_code:
-        case 200:
-            validator_response = response.json()
-            return ServiceHandlerResponse(
-                response.status_code,
-                validator_response.get("validation_results"),
-                validator_response.get("message_valid"),
-            )
-        case _:
-            return ServiceHandlerResponse(
-                response.status_code,
-                f"Validation service failed: {response.text}",
-                False,
-            )
+    with tracer.start_as_current_span(
+        "unpack_validation_response",
+        kind=trace.SpanKind(0),
+        attributes={"status_code": response.status_code},
+    ) as handler_span:
+        match response.status_code:
+            case 200:
+                validator_response = response.json()
+                handler_span.add_event(
+                    "Validation service completed successfully",
+                    attributes={
+                        "validation_results": validator_response.get(
+                            "validation_results"
+                        ),
+                        "message_is_valid": validator_response.get("message_valid"),
+                    },
+                )
+                return ServiceHandlerResponse(
+                    response.status_code,
+                    validator_response.get("validation_results"),
+                    validator_response.get("message_valid"),
+                )
+            case _:
+                handler_span.add_event(
+                    "Validation of message failed, or message contained errors"
+                )
+                handler_span.set_status(
+                    StatusCode(2), "Error Message: " + response.text
+                )
+                return ServiceHandlerResponse(
+                    response.status_code,
+                    f"Validation service failed: {response.text}",
+                    False,
+                )
 
 
 def unpack_ingestion_standardization(response: Response) -> ServiceHandlerResponse:
@@ -511,27 +709,47 @@ def unpack_ingestion_standardization(response: Response) -> ServiceHandlerRespon
     :return: A tuple containing the status code of the response as well as
       parsed message created by the service.
     """
-    status_code = response.status_code
+    with tracer.start_as_current_span(
+        "unpack_ingestion_standardization_response",
+        kind=trace.SpanKind(0),
+        attributes={"status_code": response.status_code},
+    ) as handler_span:
+        status_code = response.status_code
 
-    match status_code:
-        case 200:
-            return ServiceHandlerResponse(
-                status_code,
-                response.json().get("bundle"),
-                True,
-            )
-        case 400:
-            return ServiceHandlerResponse(
-                status_code, response.json().get("message"), False
-            )
-        case 422:
-            return ServiceHandlerResponse(status_code, response.json(), False)
-        case _:
-            return ServiceHandlerResponse(
-                status_code,
-                f"Standardization request failed: {response.text}",
-                False,
-            )
+        match status_code:
+            case 200:
+                handler_span.add_event("ingestion operation successful")
+                return ServiceHandlerResponse(
+                    status_code,
+                    response.json().get("bundle"),
+                    True,
+                )
+            case 400:
+                handler_span.add_event("ingestion service responded with bad request")
+                handler_span.set_status(
+                    StatusCode(2), "Error Message: " + response.json().get("message")
+                )
+                return ServiceHandlerResponse(
+                    status_code, response.json().get("message"), False
+                )
+            case 422:
+                handler_span.add_event(
+                    "ingestion service responded with unprocessable entity / bad input params"
+                )
+                handler_span.set_status(
+                    StatusCode(2), "Error Message: " + response.json()
+                )
+                return ServiceHandlerResponse(status_code, response.json(), False)
+            case _:
+                handler_span.add_event("ingestion service failed")
+                handler_span.set_status(
+                    StatusCode(2), "Error Message: " + response.text
+                )
+                return ServiceHandlerResponse(
+                    status_code,
+                    f"Standardization request failed: {response.text}",
+                    False,
+                )
 
 
 def unpack_save_fhir_data_response(response: Response) -> ServiceHandlerResponse:
@@ -546,22 +764,36 @@ def unpack_save_fhir_data_response(response: Response) -> ServiceHandlerResponse
     :return: A tuple containing the status code of the response as well as
       parsed message created by the service.
     """
-    status_code = response.status_code
+    with tracer.start_as_current_span(
+        "unpack_save_fhir_data_response",
+        kind=trace.SpanKind(0),
+        attributes={"status_code": response.status_code},
+    ) as handler_span:
+        status_code = response.status_code
 
-    match status_code:
-        case 200:
-            return ServiceHandlerResponse(
-                status_code,
-                response.json().get("message"),
-                True,
-            )
-        case 400:
-            return ServiceHandlerResponse(
-                status_code, response.json().get("message"), False
-            )
-        case _:
-            return ServiceHandlerResponse(
-                status_code,
-                f"Saving failed: {response.text}",
-                False,
-            )
+        match status_code:
+            case 200:
+                handler_span.add_event("save fhir data body succeeded")
+                return ServiceHandlerResponse(
+                    status_code,
+                    response.json().get("message"),
+                    True,
+                )
+            case 400:
+                handler_span.add_event("save fhir data responded with bad request")
+                handler_span.set_status(
+                    StatusCode(2), "Error Message: " + response.json().get("message")
+                )
+                return ServiceHandlerResponse(
+                    status_code, response.json().get("message"), False
+                )
+            case _:
+                handler_span.add_event("save fhir data failed")
+                handler_span.set_status(
+                    StatusCode(2), "Error Message: " + response.text
+                )
+                return ServiceHandlerResponse(
+                    status_code,
+                    f"Saving failed: {response.text}",
+                    False,
+                )

--- a/containers/orchestration/app/services.py
+++ b/containers/orchestration/app/services.py
@@ -5,6 +5,8 @@ import requests
 from fastapi import HTTPException
 from fastapi import Response
 from fastapi import WebSocket
+from opentelemetry import trace
+from opentelemetry.trace.status import StatusCode
 
 from app.handlers import build_fhir_converter_request
 from app.handlers import build_geocoding_request
@@ -24,6 +26,9 @@ from app.handlers import unpack_save_fhir_data_response
 from app.handlers import unpack_validation_response
 from app.models import OrchestrationRequest
 from app.utils import format_service_url
+
+# Integrate services tracer with automatic instrumentation context
+tracer = trace.get_tracer("orchestration_services.py_tracer")
 
 # Locations of the various services the service will delegate
 SERVICE_URLS = {
@@ -93,21 +98,38 @@ async def _send_websocket_dump(
     :param websocket: The websocket to stream the data to.
     :return: The updated progress dictionary.
     """
-    status = (
-        "success"
-        if (service_response.status_code == 200 and service_response.should_continue)
-        else "error"
-    )
+    with tracer.start_as_current_span(
+        "send_websocket_dump_to_progress_dict",
+        kind=trace.SpanKind(0),
+        attributes={
+            "endpoint_name": endpoint_name,
+            "socket_client_status": websocket.client_state,
+            "socket_server_status": websocket.application_state,
+        },
+    ) as dump_span:
+        status = (
+            "success"
+            if (
+                service_response.status_code == 200 and service_response.should_continue
+            )
+            else "error"
+        )
 
-    # Write service responses into websocket message
-    progress_dict[endpoint_name] = {
-        "status": status,
-        "status_code": base_response.status_code,
-        "response": base_response.json(),
-    }
+        dump_span.add_event(
+            "determining success logic, preparing to write to progress dict",
+            attributes={"status": status, "status_code": base_response.status_code},
+        )
 
-    await websocket.send_text(json.dumps(progress_dict))
-    return progress_dict
+        # Write service responses into websocket message
+        progress_dict[endpoint_name] = {
+            "status": status,
+            "status_code": base_response.status_code,
+            "response": base_response.json(),
+        }
+
+        dump_span.add_event("dumping JSON to socket's text receiver")
+        await websocket.send_text(json.dumps(progress_dict))
+        return progress_dict
 
 
 async def call_apis(
@@ -128,50 +150,94 @@ async def call_apis(
     :return: A tuple holding the concluding status code of the orchestration
       service, as well as each step's response along the way.
     """
-    workflow = config.get("workflow", [])
-    current_message = input.get("message")
-    response = current_message
-    responses = {}
-    # For websocket json dumps
-    progress_dict = {}
-    for step in workflow:
-        service = step["service"]
-        endpoint = step["endpoint"]
-        endpoint_name = endpoint.split("/")[-1]
-        params = step.get("params", None)
-
-        service_url = format_service_url(SERVICE_URLS[service], endpoint)
-
-        request_body_func = ENDPOINT_TO_REQUEST_BODY[endpoint_name]
-        response_func = ENDPOINT_TO_RESPONSE[endpoint_name]
-        request_body = request_body_func(current_message, input, params)
-        response = post_request(service_url, request_body)
-        service_response = response_func(response)
-
-        if websocket:
-            progress_dict = await _send_websocket_dump(
-                endpoint_name,
-                response,
-                service_response,
-                progress_dict,
-                websocket,
+    with tracer.start_as_current_span(
+        "call-apis",
+        kind=trace.SpanKind(0),
+        attributes={
+            "config": config,
+            "message_type": input.get("message_type"),
+            "data_type": input.get("data_type"),
+        },
+    ) as call_span:
+        call_span.add_event("unpacking input parameters")
+        workflow = config.get("workflow", [])
+        current_message = input.get("message")
+        response = current_message
+        responses = {}
+        # For websocket json dumps
+        progress_dict = {}
+        for step in workflow:
+            service = step["service"]
+            endpoint = step["endpoint"]
+            endpoint_name = endpoint.split("/")[-1]
+            params = step.get("params", None)
+            call_span.add_event(
+                "formatting parameters for service " + service,
+                attributes={
+                    "service": service,
+                    "endpoint": endpoint,
+                    "endpoint_name": endpoint_name,
+                    "config_params": params,
+                },
             )
 
-        if service_response.status_code != 200:
-            raise HTTPException(
-                status_code=service_response.status_code,
-                detail=f"Service {service} failed with error {service_response.msg_content}",  # noqa
-            )
+            service_url = format_service_url(SERVICE_URLS[service], endpoint)
 
-        if not service_response.should_continue:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Service {service} completed, but orchestration cannot continue: "  # noqa
-                + f"{service_response.msg_content}",
+            request_body_func = ENDPOINT_TO_REQUEST_BODY[endpoint_name]
+            response_func = ENDPOINT_TO_RESPONSE[endpoint_name]
+            call_span.add_event(
+                "packaging data to building block handler",
+                attributes={
+                    "request_body_handler": request_body_func.__str__(),
+                    "response_extraction_handler": response_func.__str__(),
+                },
             )
+            request_body = request_body_func(current_message, input, params)
+            call_span.add_event("posting to `service_url` " + service_url)
+            response = post_request(service_url, request_body)
+            call_span.add_event("response received from building block")
+            service_response = response_func(response)
 
-        # Validation and save_bundle do not contain any updates to the data
-        if service not in ["validation", "save_bundle"]:
-            current_message = service_response.msg_content
-        responses[service] = response
-    return (response, responses)
+            if websocket:
+                progress_dict = await _send_websocket_dump(
+                    endpoint_name,
+                    response,
+                    service_response,
+                    progress_dict,
+                    websocket,
+                )
+
+            if service_response.status_code != 200:
+                call_span.record_exception(
+                    HTTPException,
+                    attributes={"status_code": service_response.status_code},
+                )
+                error_detail = f"Service {service} failed with error {service_response.msg_content}"
+                call_span.set_status(StatusCode(2), error_detail)
+                raise HTTPException(
+                    status_code=service_response.status_code, detail=error_detail
+                )
+
+            if not service_response.should_continue:
+                call_span.record_exception(
+                    HTTPException, attributes={"status_code": 400}
+                )
+                error_detail = (
+                    f"Service {service} completed, but orchestration cannot continue "
+                )
+                +f"{service_response.msg_content}"
+                call_span.set_status(StatusCode(2), error_detail)
+                raise HTTPException(
+                    status_code=400,
+                    detail=error_detail,
+                )
+
+            # Validation and save_bundle do not contain any updates to the data
+            if service not in ["validation", "save_bundle"]:
+                call_span.add_event(
+                    "updating input data with building block modifications"
+                )
+                current_message = service_response.msg_content
+            responses[service] = response
+        call_span.set_status(StatusCode(1))
+        return (response, responses)

--- a/containers/orchestration/app/services.py
+++ b/containers/orchestration/app/services.py
@@ -177,7 +177,9 @@ async def call_apis(
                     "service": service,
                     "endpoint": endpoint,
                     "endpoint_name": endpoint_name,
-                    "config_params": params,
+                    "config_params": [f"{k}: {v}" for k, v in params.items()]
+                    if params is not None
+                    else "",
                 },
             )
 
@@ -209,7 +211,10 @@ async def call_apis(
 
             if service_response.status_code != 200:
                 call_span.record_exception(
-                    HTTPException,
+                    HTTPException(
+                        status_code=service_response.status_code,
+                        detail="Received non-200 from unpacked building block response",
+                    ),
                     attributes={"status_code": service_response.status_code},
                 )
                 error_detail = f"Service {service} failed with error {service_response.msg_content}"

--- a/containers/orchestration/tests/integration/test_orchestration.py
+++ b/containers/orchestration/tests/integration/test_orchestration.py
@@ -137,6 +137,7 @@ def test_failed_save_to_ecr_viewer(setup):
     ) as file:
         form_data = {
             "message_type": "ecr",
+            "data_type": "zip",
             "config_file_name": "sample-orchestration-s3-config.json",
         }
         files = {"upload_file": ("file.zip", file)}

--- a/containers/orchestration/tests/test_handlers.py
+++ b/containers/orchestration/tests/test_handlers.py
@@ -96,6 +96,7 @@ def test_unpack_fhir_converter_response():
     converter_result.content = {"fhir_conversion_failed": True}
     response = Mock()
     response.status_code = 400
+    response.text = "conversion failed"
     response.json.return_value = {"response": converter_result}
     result = unpack_fhir_converter_response(response)
     assert result.status_code == 400
@@ -134,6 +135,7 @@ def test_unpack_validation_response():
     validator_result.text = "validation didn't work"
     response = Mock()
     response.status_code = 400
+    response.text = "validation failed"
     response.json.return_value = validator_result
     result = unpack_validation_response(response)
     assert result.status_code == 400
@@ -468,7 +470,7 @@ def test_unpack_ingestion_standardization_name():
     error_message = {"detail": [{"loc": ["string"], "msg": "string", "type": "string"}]}
     response = MagicMock()
     response.status_code = 422
-    response.json.return_value = error_message
+    response.json.return_value = error_message.__str__()
     result = unpack_ingestion_standardization(response)
     assert result.status_code == 422
     assert "detail" in result.msg_content.keys()
@@ -515,7 +517,7 @@ def test_unpack_ingestion_standardization_phone():
     error_message = {"detail": [{"loc": ["string"], "msg": "string", "type": "string"}]}
     response = MagicMock()
     response.status_code = 422
-    response.json.return_value = error_message
+    response.json.return_value = error_message.__str__()
     result = unpack_ingestion_standardization(response)
     assert result.status_code == 422
     assert "detail" in result.msg_content.keys()
@@ -562,7 +564,7 @@ def test_unpack_ingestion_standardization_dob():
     error_message = {"detail": [{"loc": ["string"], "msg": "string", "type": "string"}]}
     response = MagicMock()
     response.status_code = 422
-    response.json.return_value = error_message
+    response.json.return_value = error_message.__str__()
     result = unpack_ingestion_standardization(response)
     assert result.status_code == 422
     assert "detail" in result.msg_content.keys()
@@ -610,7 +612,7 @@ def test_unpack_ingestion_geocoding():
     error_message = {"detail": [{"loc": ["string"], "msg": "string", "type": "string"}]}
     response = MagicMock()
     response.status_code = 422
-    response.json.return_value = error_message
+    response.json.return_value = error_message.__str__()
     result = unpack_ingestion_standardization(response)
     assert result.status_code == 422
     assert "detail" in result.msg_content.keys()

--- a/containers/orchestration/tests/test_handlers.py
+++ b/containers/orchestration/tests/test_handlers.py
@@ -470,7 +470,7 @@ def test_unpack_ingestion_standardization_name():
     error_message = {"detail": [{"loc": ["string"], "msg": "string", "type": "string"}]}
     response = MagicMock()
     response.status_code = 422
-    response.json.return_value = error_message.__str__()
+    response.json.return_value = error_message
     result = unpack_ingestion_standardization(response)
     assert result.status_code == 422
     assert "detail" in result.msg_content.keys()
@@ -517,7 +517,7 @@ def test_unpack_ingestion_standardization_phone():
     error_message = {"detail": [{"loc": ["string"], "msg": "string", "type": "string"}]}
     response = MagicMock()
     response.status_code = 422
-    response.json.return_value = error_message.__str__()
+    response.json.return_value = error_message
     result = unpack_ingestion_standardization(response)
     assert result.status_code == 422
     assert "detail" in result.msg_content.keys()
@@ -564,7 +564,7 @@ def test_unpack_ingestion_standardization_dob():
     error_message = {"detail": [{"loc": ["string"], "msg": "string", "type": "string"}]}
     response = MagicMock()
     response.status_code = 422
-    response.json.return_value = error_message.__str__()
+    response.json.return_value = error_message
     result = unpack_ingestion_standardization(response)
     assert result.status_code == 422
     assert "detail" in result.msg_content.keys()
@@ -612,7 +612,7 @@ def test_unpack_ingestion_geocoding():
     error_message = {"detail": [{"loc": ["string"], "msg": "string", "type": "string"}]}
     response = MagicMock()
     response.status_code = 422
-    response.json.return_value = error_message.__str__()
+    response.json.return_value = error_message
     result = unpack_ingestion_standardization(response)
     assert result.status_code == 422
     assert "detail" in result.msg_content.keys()


### PR DESCRIPTION
# Fully Instrument the Orchestration Service

## Summary
This PR adds full-fledged manual instrumentation to the `process-message` endpoint and all related code. Our goal was to capture relevant logging information about a request moving through the system, in as efficient and effective a way as possible. For OpenTelemetry, this means using traces and the spans they're built on to use structured events to create log output. The changes here document the best practices and design decisions around approaching spans and instrument a set of MVP spans throughout the code.

For one request, you can see one of the views jaeger generates for us below (with various event spans captured in the log output, and important function steps in the call chain each collecting their own span).

## Related Issue
Fixes #1642 

<img width="1668" alt="Screenshot 2024-04-24 at 4 22 32 PM" src="https://github.com/CDCgov/phdi/assets/49412165/f106bd95-8c26-491b-b070-fef08a3e0d04">

