### PR TITLE
Adding eRSD config to message-parser and initializing seed-db.

### DIFF
--- a/containers/message-parser/app/default_schemas/ersd.json
+++ b/containers/message-parser/app/default_schemas/ersd.json
@@ -1,0 +1,78 @@
+{
+  "value_set_type": {
+    "fhir_path": "entry.resource.where(resourceType='ValueSet' and url.contains('http://ersd.aimsplatform.org/fhir/ValueSet/')",
+    "data_type": "string",
+    "nullable": false,
+    "secondary_schema": {
+      "id": {
+        "fhir_path": "id",
+        "data_type": "string",
+        "nullable": false
+      },
+      "clinical_service_type": {
+        "fhir_path": "title",
+        "data_type": "string",
+        "nullable": false
+      }
+    }
+  },
+  "clincal_services": {
+    "fhir_path": "entry.resource.where(resourceType='ValueSet' and url.contains('http://cts.nlm.nih.gov/fhir/ValueSet/')",
+    "data_type": "string",
+    "nullable": false,
+    "secondary_schema": {
+      "value_set_id": {
+        "fhir_path": "id",
+        "data_type": "string",
+        "nullable": false
+      },
+      "display": {
+        "fhir_path": "title",
+        "data_type": "string",
+        "nullable": false
+      },
+      "valueable_codes": {
+        "fhir_path": "useContext.valueCodeableConcept.where(coding.system!='http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context')",
+        "data_type": "array",
+        "nullable": false
+      },
+      "compose_codes": {
+        "fhir_path": "compose.include",
+        "data_type": "string",
+        "nullable": false
+      },
+      "expansion_codes": {
+        "fhir_path": "expansion.contains",
+        "data_type": "string",
+        "nullable": false
+      }
+    }
+  },
+  "value_sets": {
+    "fhir_path": "entry.resource.where(resourceType='ValueSet' and url.contains('http://ersd.aimsplatform.org/fhir/ValueSet/')",
+    "data_type": "string",
+    "nullable": false,
+    "secondary_schema": {
+      "clinical_service_type_id": {
+        "fhir_path": "id",
+        "data_type": "string",
+        "nullable": false
+      },
+      "version": {
+        "fhir_path": "version",
+        "data_type": "string",
+        "nullable": false
+      },
+      "compose_codes": {
+        "fhir_path": "compose.include.valueSet",
+        "data_type": "string",
+        "nullable": false
+      },
+      "expansion_codes": {
+        "fhir_path": "expansion.contains",
+        "data_type": "array",
+        "nullable": false
+      }
+    }
+  }
+}


### PR DESCRIPTION
# PULL REQUEST

## Summary
This adds a new config file to the message-parser that can take a eRSD file and transform it to a flatter file for the purposes of transforming it and loading it for the new `vocab-mapper` service.

This will require `seed.py` to:
1. Download the JSON from the API endpoint.
2. Start up the `message-parser` service.
3. Run the data through `message-parser`.
4. Take the returned JSON to do additional parsing to 3 tables in this format: https://drive.google.com/file/d/1nxm0HpiJsONizM5NzvSIH2dbUCcDif6f/view
5. Load tables to sqlite DB.
6. Spin down `message-parser`.

## Related Issue
Fixes #1663, partially.

## Additional Information
There's currently some limitations in how far we can pare down just via the message parser. The structure of it is quite nested, so ideally we would have a tertiary schema. I'm also not entirely sure if there is a way to use `#REF` in the `value_sets` portion to try to turn the compose codes into references to the actual ValueSets.

The data within each section (value_sets, compose_codes, expansion_codes) all follow a predictable pattern, so I don't think it should be too necessary to implement tertiary anytime soon.

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
