### PR TITLE
Enforce JSDocs on arrow functions

### DIFF
--- a/containers/ecr-viewer/.eslintrc.json
+++ b/containers/ecr-viewer/.eslintrc.json
@@ -30,7 +30,16 @@
         "argsIgnorePattern": "^_"
       }
     ],
-    "jsdoc/check-tag-names": "off"
+    "jsdoc/check-tag-names": "off",
+    "jsdoc/require-jsdoc": [
+      "error",
+      {
+        "require": {
+          "ArrowFunctionExpression": true
+        },
+        "publicOnly": true
+      }
+    ]
   },
   "overrides": [
     {

--- a/containers/ecr-viewer/src/app/api/fhir-data/fhir-data-service.ts
+++ b/containers/ecr-viewer/src/app/api/fhir-data/fhir-data-service.ts
@@ -6,6 +6,11 @@ import { database } from "@/app/api/fhir-data/db";
 
 const s3Client = new S3Client({ region: process.env.AWS_REGION });
 
+/**
+ * Retrieves FHIR data from PostgreSQL database based on eCR ID.
+ * @param request - The NextRequest object containing the request information.
+ * @returns A promise resolving to a NextResponse object.
+ */
 export const get_postgres = async (request: NextRequest) => {
   const params = request.nextUrl.searchParams;
   const ecr_id = params.get("id") ? params.get("id") : null;
@@ -36,6 +41,11 @@ export const get_postgres = async (request: NextRequest) => {
   }
 };
 
+/**
+ * Retrieves FHIR data from S3 based on eCR ID.
+ * @param request - The NextRequest object containing the request information.
+ * @returns A promise resolving to a NextResponse object.
+ */
 export const get_s3 = async (request: NextRequest) => {
   const params = request.nextUrl.searchParams;
   const ecr_id = params.get("id");

--- a/containers/ecr-viewer/src/app/api/save-fhir-data/save-fhir-data-service.ts
+++ b/containers/ecr-viewer/src/app/api/save-fhir-data/save-fhir-data-service.ts
@@ -13,12 +13,11 @@ const s3Client = new S3Client({ region: process.env.AWS_REGION });
  * Saves a FHIR bundle to a postgres database.
  * @async
  * @function saveToS3
- * @param {Bundle} fhirBundle - The FHIR bundle to be saved.
- * @param {string} ecrId - The unique identifier for the Electronic Case Reporting (ECR) associated with the FHIR bundle.
- * @returns {Promise<void>} A promise that resolves when the FHIR bundle is successfully saved to postgres.
+ * @param fhirBundle - The FHIR bundle to be saved.
+ * @param ecrId - The unique identifier for the Electronic Case Reporting (ECR) associated with the FHIR bundle.
+ * @returns A promise that resolves when the FHIR bundle is successfully saved to postgres.
  * @throws {Error} Throws an error if the FHIR bundle cannot be saved to postgress.
  */
-
 export const saveToPostgres = async (fhirBundle: Bundle, ecrId: string) => {
   const db_url = process.env.DATABASE_URL || "";
   const db = pgPromise();
@@ -50,12 +49,11 @@ export const saveToPostgres = async (fhirBundle: Bundle, ecrId: string) => {
  * Saves a FHIR bundle to an AWS S3 bucket.
  * @async
  * @function saveToS3
- * @param {Bundle} fhirBundle - The FHIR bundle to be saved.
- * @param {string} ecrId - The unique identifier for the Electronic Case Reporting (ECR) associated with the FHIR bundle.
- * @returns {Promise<void>} A promise that resolves when the FHIR bundle is successfully saved to the S3 bucket.
+ * @param fhirBundle - The FHIR bundle to be saved.
+ * @param ecrId - The unique identifier for the Electronic Case Reporting (ECR) associated with the FHIR bundle.
+ * @returns A promise that resolves when the FHIR bundle is successfully saved to the S3 bucket.
  * @throws {Error} Throws an error if the FHIR bundle cannot be saved to the S3 bucket.
  */
-
 export const saveToS3 = async (fhirBundle: Bundle, ecrId: string) => {
   const bucketName = process.env.ECR_BUCKET_NAME;
   const objectKey = `${ecrId}.json`;

--- a/containers/ecr-viewer/src/app/format-service.tsx
+++ b/containers/ecr-viewer/src/app/format-service.tsx
@@ -54,6 +54,15 @@ export const formatName = (
   return nameArray.join(" ").trim();
 };
 
+/**
+ * Formats an address based on its components.
+ * @param streetAddress - An array containing street address lines.
+ * @param city - The city name.
+ * @param state - The state or region name.
+ * @param zipCode - The ZIP code or postal code.
+ * @param country - The country name.
+ * @returns The formatted address string.
+ */
 export const formatAddress = (
   streetAddress: string[],
   city: string,
@@ -112,7 +121,6 @@ export const formatDateTime = (dateTime?: string) => {
  * @param dateString - The date string to be formatted. formatDate will also be able to take 'yyyymmdd' as input
  * @returns - The formatted date string, "Invalid Date" if input date was invalid, or undefined if the input date is falsy.
  */
-
 export const formatDate = (dateString?: string): string | undefined => {
   if (dateString) {
     let date = new Date(dateString);
@@ -135,6 +143,11 @@ export const formatDate = (dateString?: string): string | undefined => {
   }
 };
 
+/**
+ * Formats a phone number into a standard format of XXX-XXX-XXXX.
+ * @param phoneNumber - The phone number to format.
+ * @returns The formatted phone number or undefined if the input is invalid.
+ */
 export const formatPhoneNumber = (phoneNumber: string) => {
   try {
     return phoneNumber
@@ -173,11 +186,20 @@ export const formatStartEndDateTime = (
   return textArray.join("\n");
 };
 
+/**
+ * Formats vital signs information into a single line string with proper units .
+ * @param heightAmount - The amount of height.
+ * @param heightUnit - The measurement type of height (e.g., "[in_i]" for inches, "cm" for centimeters).
+ * @param weightAmount - The amount of weight.
+ * @param weightUnit - The measurement type of weight (e.g., "[lb_av]" for pounds, "kg" for kilograms).
+ * @param bmi - The Body Mass Index (BMI).
+ * @returns The formatted vital signs information.
+ */
 export const formatVitals = (
   heightAmount: string,
-  heightMeasurementType: string,
+  heightUnit: string,
   weightAmount: string,
-  weightMeasurementType: string,
+  weightUnit: string,
   bmi: string,
 ) => {
   let heightString = "";
@@ -186,19 +208,19 @@ export const formatVitals = (
 
   let heightType = "";
   let weightType = "";
-  if (heightAmount && heightMeasurementType) {
-    if (heightMeasurementType === "[in_i]") {
+  if (heightAmount && heightUnit) {
+    if (heightUnit === "[in_i]") {
       heightType = "inches";
-    } else if (heightMeasurementType === "cm") {
+    } else if (heightUnit === "cm") {
       heightType = "cm";
     }
     heightString = `Height: ${heightAmount} ${heightType}\n\n`;
   }
 
-  if (weightAmount && weightMeasurementType) {
-    if (weightMeasurementType === "[lb_av]") {
+  if (weightAmount && weightUnit) {
+    if (weightUnit === "[lb_av]") {
       weightType = "Lbs";
-    } else if (weightMeasurementType === "kg") {
+    } else if (weightUnit === "kg") {
       weightType = "kg";
     }
     weightString = `Weight: ${weightAmount} ${weightType}\n\n`;
@@ -212,6 +234,11 @@ export const formatVitals = (
   return combinedString.trim();
 };
 
+/**
+ * Formats a string by converting it to lowercase, replacing spaces with underscores, and removing special characters except underscores.
+ * @param input - The input string to be formatted.
+ * @returns The formatted string.
+ */
 export const formatString = (input: string): string => {
   // Convert to lowercase
   let result = input.toLowerCase();

--- a/containers/ecr-viewer/src/app/utils.tsx
+++ b/containers/ecr-viewer/src/app/utils.tsx
@@ -64,31 +64,37 @@ export const noData = (
   <span className="no-data text-italic text-base">No data</span>
 );
 
+/**
+ * Evaluates patient name from the FHIR bundle and formats it into structured data for display.
+ * @param fhirBundle - The FHIR bundle containing patient contact info.
+ * @param mappings - The object containing the fhir paths.
+ * @returns The formatted patient name
+ */
 export const evaluatePatientName = (
   fhirBundle: Bundle,
-  fhirPathMappings: PathMappings,
+  mappings: PathMappings,
 ) => {
-  const givenNames = evaluate(
-    fhirBundle,
-    fhirPathMappings.patientGivenName,
-  ).join(" ");
-  const familyName = evaluate(fhirBundle, fhirPathMappings.patientFamilyName);
+  const givenNames = evaluate(fhirBundle, mappings.patientGivenName).join(" ");
+  const familyName = evaluate(fhirBundle, mappings.patientFamilyName);
 
   return `${givenNames} ${familyName}`;
 };
 
+/**
+ * Evaluates patient address from the FHIR bundle and formats it into structured data for display.
+ * @param fhirBundle - The FHIR bundle containing patient contact info.
+ * @param mappings - The object containing the fhir paths.
+ * @returns The formatted patient address
+ */
 export const extractPatientAddress = (
   fhirBundle: Bundle,
-  fhirPathMappings: PathMappings,
+  mappings: PathMappings,
 ) => {
-  const streetAddresses = evaluate(
-    fhirBundle,
-    fhirPathMappings.patientStreetAddress,
-  );
-  const city = evaluate(fhirBundle, fhirPathMappings.patientCity)[0];
-  const state = evaluate(fhirBundle, fhirPathMappings.patientState)[0];
-  const zipCode = evaluate(fhirBundle, fhirPathMappings.patientZipCode)[0];
-  const country = evaluate(fhirBundle, fhirPathMappings.patientCountry)[0];
+  const streetAddresses = evaluate(fhirBundle, mappings.patientStreetAddress);
+  const city = evaluate(fhirBundle, mappings.patientCity)[0];
+  const state = evaluate(fhirBundle, mappings.patientState)[0];
+  const zipCode = evaluate(fhirBundle, mappings.patientZipCode)[0];
+  const country = evaluate(fhirBundle, mappings.patientCountry)[0];
   return formatAddress(streetAddresses, city, state, zipCode, country);
 };
 
@@ -113,14 +119,17 @@ function extractLocationResource(
   return evaluate(fhirBundle, locationExpression)[0];
 }
 
+/**
+ * Evaluates facility address from the FHIR bundle and formats it into structured data for display.
+ * @param fhirBundle - The FHIR bundle containing patient contact info.
+ * @param mappings - The object containing the fhir paths.
+ * @returns The formatted facility address
+ */
 export const extractFacilityAddress = (
   fhirBundle: Bundle,
-  fhirPathMappings: PathMappings,
+  mappings: PathMappings,
 ) => {
-  const locationResource = extractLocationResource(
-    fhirBundle,
-    fhirPathMappings,
-  );
+  const locationResource = extractLocationResource(fhirBundle, mappings);
 
   const streetAddresses = locationResource?.address?.line;
   const city = locationResource?.address?.city;
@@ -131,28 +140,17 @@ export const extractFacilityAddress = (
   return formatAddress(streetAddresses, city, state, zipCode, country);
 };
 
-export const extractFacilityContactInfo = (
-  fhirBundle: Bundle,
-  fhirPathMappings: PathMappings,
-) => {
-  const locationResource = extractLocationResource(
-    fhirBundle,
-    fhirPathMappings,
-  );
-  const phoneNumbers = locationResource.telecom?.filter(
-    (contact: any) => contact.system === "phone",
-  );
-  return phoneNumbers?.[0].value;
-};
-
+/**
+ * Evaluates patient contact info from the FHIR bundle and formats it into structured data for display.
+ * @param fhirBundle - The FHIR bundle containing patient contact info.
+ * @param mappings - The object containing the fhir paths.
+ * @returns All phone numbers and emails seperated by new lines
+ */
 export const evaluatePatientContactInfo = (
   fhirBundle: Bundle,
-  fhirPathMappings: PathMappings,
+  mappings: PathMappings,
 ) => {
-  const phoneNumbers = evaluate(
-    fhirBundle,
-    fhirPathMappings.patientPhoneNumbers,
-  )
+  const phoneNumbers = evaluate(fhirBundle, mappings.patientPhoneNumbers)
     .map(
       (phoneNumber) =>
         `${
@@ -161,20 +159,26 @@ export const evaluatePatientContactInfo = (
         } ${phoneNumber.value}`,
     )
     .join("\n");
-  const emails = evaluate(fhirBundle, fhirPathMappings.patientEmails)
+  const emails = evaluate(fhirBundle, mappings.patientEmails)
     .map((email) => `${email.value}`)
     .join("\n");
 
   return `${phoneNumbers}\n${emails}`;
 };
 
+/**
+ * Evaluates encounter date from the FHIR bundle and formats it into structured data for display.
+ * @param fhirBundle - The FHIR bundle containing encounter date.
+ * @param mappings - The object containing the fhir paths.
+ * @returns A string of start date - end date.
+ */
 export const evaluateEncounterDate = (
   fhirBundle: Bundle,
-  fhirPathMappings: PathMappings,
+  mappings: PathMappings,
 ) => {
   return formatStartEndDateTime(
-    evaluate(fhirBundle, fhirPathMappings.encounterStartDate).join(""),
-    evaluate(fhirBundle, fhirPathMappings.encounterEndDate).join(""),
+    evaluate(fhirBundle, mappings.encounterStartDate).join(""),
+    evaluate(fhirBundle, mappings.encounterEndDate).join(""),
   );
 };
 
@@ -232,6 +236,12 @@ export const calculatePatientAge = (
   }
 };
 
+/**
+ * Evaluates social data from the FHIR bundle and formats it into structured data for display.
+ * @param fhirBundle - The FHIR bundle containing social data.
+ * @param mappings - The object containing the fhir paths.
+ * @returns An array of evaluated and formatted social data.
+ */
 export const evaluateSocialData = (
   fhirBundle: Bundle,
   mappings: PathMappings,
@@ -277,6 +287,12 @@ export const evaluateSocialData = (
   return evaluateData(socialData);
 };
 
+/**
+ * Evaluates demographic data from the FHIR bundle and formats it into structured data for display.
+ * @param fhirBundle - The FHIR bundle containing demographic data.
+ * @param mappings - The object containing the fhir paths.
+ * @returns An array of evaluated and formatted demographic data.
+ */
 export const evaluateDemographicsData = (
   fhirBundle: Bundle,
   mappings: PathMappings,
@@ -335,6 +351,12 @@ export const evaluateDemographicsData = (
   return evaluateData(demographicsData);
 };
 
+/**
+ * Evaluates encounter data from the FHIR bundle and formats it into structured data for display.
+ * @param fhirBundle - The FHIR bundle containing encounter data.
+ * @param mappings - The object containing the fhir paths.
+ * @returns An array of evaluated and formatted encounter data.
+ */
 export const evaluateEncounterData = (
   fhirBundle: Bundle,
   mappings: PathMappings,
@@ -383,6 +405,12 @@ export const evaluateEncounterData = (
   return evaluateData(encounterData);
 };
 
+/**
+ * Evaluates provider data from the FHIR bundle and formats it into structured data for display.
+ * @param fhirBundle - The FHIR bundle containing provider data.
+ * @param mappings - The object containing the fhir paths.
+ * @returns An array of evaluated and formatted provider data.
+ */
 export const evaluateProviderData = (
   fhirBundle: Bundle,
   mappings: PathMappings,
@@ -405,6 +433,12 @@ export const evaluateProviderData = (
   return evaluateData(providerData);
 };
 
+/**
+ * Evaluates eCR metadata from the FHIR bundle and formats it into structured data for display.
+ * @param fhirBundle - The FHIR bundle containing eCR metadata.
+ * @param mappings - The object containing the fhir paths.
+ * @returns An object containing evaluated and formatted eCR metadata.
+ */
 export const evaluateEcrMetadata = (
   fhirBundle: Bundle,
   mappings: PathMappings,
@@ -531,6 +565,12 @@ export const returnProblemsTable = (
   );
 };
 
+/**
+ * Returns a table displaying pending results information.
+ * @param fhirBundle - The FHIR bundle containing care team data.
+ * @param mappings - The object containing the fhir paths.
+ * @returns The JSX element representing the table, or undefined if no pending results are found.
+ */
 export const returnPendingResultsTable = (
   fhirBundle: Bundle,
   mappings: PathMappings,
@@ -590,6 +630,12 @@ export const returnPendingResultsTable = (
   }
 };
 
+/**
+ * Returns a table displaying scheduled order information.
+ * @param fhirBundle - The FHIR bundle containing care team data.
+ * @param mappings - The object containing the fhir paths.
+ * @returns The JSX element representing the table, or undefined if no scheduled orders are found.
+ */
 export const returnScheduledOrdersTable = (
   fhirBundle: Bundle,
   mappings: PathMappings,
@@ -649,6 +695,12 @@ export const returnScheduledOrdersTable = (
   }
 };
 
+/**
+ * Returns a table displaying administered medication information.
+ * @param fhirBundle - The FHIR bundle containing care team data.
+ * @param mappings - The object containing the fhir paths.
+ * @returns The JSX element representing the table, or undefined if no administed medications are found.
+ */
 export const returnAdminMedTable = (
   fhirBundle: Bundle,
   mappings: PathMappings,
@@ -753,6 +805,12 @@ export const returnImmunizations = (
   );
 };
 
+/**
+ * Returns a table displaying care team information.
+ * @param bundle - The FHIR bundle containing care team data.
+ * @param mappings - The object containing the fhir paths.
+ * @returns The JSX element representing the care team table, or undefined if no care team participants are found.
+ */
 export const returnCareTeamTable = (
   bundle: Bundle,
   mappings: PathMappings,
@@ -896,6 +954,18 @@ export const returnPlannedProceduresTable = (
   );
 };
 
+/**
+ * Evaluates clinical data from the FHIR bundle and formats it into structured data for display.
+ * @param fhirBundle - The FHIR bundle containing clinical data.
+ * @param mappings - The object containing the fhir paths.
+ * @returns An object containing evaluated and formatted clinical data.
+ * @property {DisplayData[]} clinicalNotes - Clinical notes data.
+ * @property {DisplayData[]} reasonForVisitDetails - Reason for visit details.
+ * @property {DisplayData[]} activeProblemsDetails - Active problems details.
+ * @property {DisplayData[]} treatmentData - Treatment-related data.
+ * @property {DisplayData[]} vitalData - Vital signs data.
+ * @property {DisplayData[]} immunizationsDetails - Immunization details.
+ */
 export const evaluateClinicalData = (
   fhirBundle: Bundle,
   mappings: PathMappings,
@@ -1090,6 +1160,12 @@ export const DataDisplay: React.FC<{
   );
 };
 
+/**
+ * Functional component for displaying data in a data table.
+ * @param props - Props containing the item to be displayed.
+ * @param props.item - The data item to be displayed.
+ * @returns The JSX element representing the data table display.
+ */
 export const DataTableDisplay: React.FC<{ item: DisplayData }> = ({
   item,
 }): React.JSX.Element => {
@@ -1101,6 +1177,12 @@ export const DataTableDisplay: React.FC<{ item: DisplayData }> = ({
   );
 };
 
+/**
+ * Evaluates emergency contact information from the FHIR bundle and formats it into a readable string.
+ * @param fhirBundle - The FHIR bundle containing patient information.
+ * @param mappings - The object containing the fhir paths.
+ * @returns The formatted emergency contact information.
+ */
 export const evaluateEmergencyContact = (
   fhirBundle: Bundle,
   mappings: PathMappings,

--- a/containers/ecr-viewer/src/app/view-data/component-utils.tsx
+++ b/containers/ecr-viewer/src/app/view-data/component-utils.tsx
@@ -7,6 +7,13 @@ type AccordianSectionProps = {
   id?: string;
 };
 
+/**
+ * Functional component for an accordion section.
+ * @param props - Props containing children and optional className.
+ * @param props.children - The content of the accordion section.
+ * @param [props.className] - Optional additional class name for styling.
+ * @returns The JSX element representing the accordion section.
+ */
 export const AccordianSection: React.FC<AccordianSectionProps> = ({
   children,
   className,
@@ -48,6 +55,13 @@ export const AccordianH4: React.FC<AccordianSectionProps> = ({
   );
 };
 
+/**
+ * Functional component for an accordion div.
+ * @param props - Props containing children and optional className.
+ * @param props.children - The content of the accordion div.
+ * @param [props.className] - Optional additional class name for styling.
+ * @returns The JSX element representing the accordion div.
+ */
 export const AccordianDiv: React.FC<AccordianSectionProps> = ({
   children,
   className,

--- a/containers/ecr-viewer/src/app/view-data/components/AccordionContainer.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/AccordionContainer.tsx
@@ -14,7 +14,7 @@ import UnavailableInfo from "./UnavailableInfo";
 import EcrMetadata from "./EcrMetadata";
 import EncounterDetails from "./Encounter";
 import ClinicalInfo from "./ClinicalInfo";
-import { Bundle, FhirResource } from "fhir/r4";
+import { Bundle } from "fhir/r4";
 import React, { ReactNode } from "react";
 import { Accordion } from "@trussworks/react-uswds";
 import LabInfo from "@/app/view-data/components/LabInfo";
@@ -22,10 +22,17 @@ import { formatString } from "@/app/format-service";
 
 type AccordionContainerProps = {
   children?: ReactNode;
-  fhirBundle: Bundle<FhirResource>;
+  fhirBundle: Bundle;
   fhirPathMappings: PathMappings;
 };
 
+/**
+ * Functional component for an accordion container displaying various sections of eCR information.
+ * @param props - Props containing FHIR bundle and path mappings.
+ * @param props.fhirBundle - The FHIR bundle containing patient information.
+ * @param props.fhirPathMappings - The path mappings used to extract information from the FHIR bundle.
+ * @returns The JSX element representing the accordion container.
+ */
 const AccordianContainer: React.FC<AccordionContainerProps> = ({
   fhirBundle,
   fhirPathMappings,

--- a/containers/ecr-viewer/src/app/view-data/components/ClinicalInfo.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/ClinicalInfo.tsx
@@ -28,6 +28,17 @@ export const clinicalInfoConfig: SectionConfig = new SectionConfig(
   ],
 );
 
+/**
+ * Functional component for displaying clinical information.
+ * @param props - Props containing clinical information.
+ * @param props.reasonForVisitDetails - The details of the reason for visit.
+ * @param props.activeProblemsDetails - The details of active problems.
+ * @param props.immunizationsDetails - The details of immunizations.
+ * @param props.vitalData - The vital signs data.
+ * @param props.treatmentData - The details of treatments.
+ * @param props.clinicalNotes - The clinical notes data.
+ * @returns The JSX element representing the clinical information.
+ */
 export const ClinicalInfo = ({
   reasonForVisitDetails,
   activeProblemsDetails,

--- a/containers/ecr-viewer/src/app/view-data/components/Demographics.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/Demographics.tsx
@@ -13,6 +13,12 @@ interface DemographicsProps {
 
 export const demographicsConfig = new SectionConfig("Demographics");
 
+/**
+ * Functional component for displaying demographic data
+ * @param demographicsData - Props for demographic data
+ * @param demographicsData.demographicsData - The details of fields to be displayed of demographic data
+ * @returns The JSX element representing demographic data
+ */
 const Demographics = ({ demographicsData }: DemographicsProps) => {
   return (
     <AccordianSection>

--- a/containers/ecr-viewer/src/app/view-data/components/EcrMetadata.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrMetadata.tsx
@@ -63,6 +63,14 @@ const convertDictionaryToRows = (dictionary: ReportableConditionsList) => {
   return rows;
 };
 
+/**
+ * Functional component for displaying eCR metadata.
+ * @param props - Props containing eCR metadata.
+ * @param props.rrDetails - The reportable conditions details.
+ * @param props.eicrDetails - The eICR details.
+ * @param props.eCRSenderDetails - The eCR sender details.
+ * @returns The JSX element representing the eCR metadata.
+ */
 const EcrMetadata = ({
   rrDetails,
   eicrDetails,

--- a/containers/ecr-viewer/src/app/view-data/components/EcrSummary.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrSummary.tsx
@@ -12,7 +12,7 @@ import { SectionConfig } from "./SideNav";
 import React, { FC } from "react";
 import { formatDate } from "@/app/format-service";
 
-interface EcrViewerProps {
+interface EcrSummaryProps {
   fhirPathMappings: PathMappings;
   fhirBundle: Bundle;
 }
@@ -58,7 +58,17 @@ const Display: FC<DisplayProps> = ({
   );
 };
 
-const EcrSummary = ({ fhirPathMappings, fhirBundle }: EcrViewerProps) => {
+/**
+ * Functional component for rendering the eCR summary.
+ * @param props - Properties for the ecrSummary.
+ * @param props.fhirPathMappings - The fhir path mappings.
+ * @param props.fhirBundle - The fhir bundle.
+ * @returns The JSX element for eCR summary information.
+ */
+const EcrSummary: React.FC<EcrSummaryProps> = ({
+  fhirPathMappings,
+  fhirBundle,
+}) => {
   return (
     <div className={"info-container"}>
       <div

--- a/containers/ecr-viewer/src/app/view-data/components/Encounter.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/Encounter.tsx
@@ -17,6 +17,13 @@ export const encounterConfig: SectionConfig = new SectionConfig(
   ["Encounter Details", "Provider Details"],
 );
 
+/**
+ * Functional component for displaying encounter details.
+ * @param props - Props containing encounter details.
+ * @param props.encounterData - The encounter data to be displayed.
+ * @param props.providerData - The provider details to be displayed.
+ * @returns The JSX element representing the encounter details.
+ */
 const EncounterDetails = ({ encounterData, providerData }: EncounterProps) => {
   const renderEncounterDetails = () => {
     return (

--- a/containers/ecr-viewer/src/app/view-data/components/ExpandCollapseButtons.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/ExpandCollapseButtons.tsx
@@ -9,6 +9,16 @@ type ExpandCollapseButtonsProps = {
   collapseButtonText: string;
 };
 
+/**
+ * Functional component for a pair of expand and collapse buttons.
+ * @param props - Props containing button configurations.
+ * @param props.id - The ID for the buttons.
+ * @param props.buttonSelector - The CSS selector for the buttons.
+ * @param props.accordionSelector - The CSS selector for the accordions to be hidden.
+ * @param props.expandButtonText - The text for the expand button.
+ * @param props.collapseButtonText - The text for the collapse button.
+ * @returns The JSX element representing the expand and collapse buttons.
+ */
 export const ExpandCollapseButtons: React.FC<ExpandCollapseButtonsProps> = ({
   id,
   buttonSelector,

--- a/containers/ecr-viewer/src/app/view-data/components/SideNav.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/SideNav.tsx
@@ -119,6 +119,10 @@ export const sortHeadings = (headings: HeadingObject[]): SectionConfig[] => {
   return result;
 };
 
+/**
+ * Functional component for the side navigation.
+ * @returns The JSX element representing the side navigation.
+ */
 const SideNav: React.FC = () => {
   const [sectionConfigs, setSectionConfigs] = useState<SectionConfig[]>([]);
   const [activeSection, setActiveSection] = useState<string>("");

--- a/containers/ecr-viewer/src/app/view-data/components/SocialHistory.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/SocialHistory.tsx
@@ -16,7 +16,13 @@ export const socialHistoryConfig: SectionConfig = {
   title: "Social History",
 };
 
-const SocialHistory = ({ socialData }: SocialHistoryProps) => {
+/**
+ * Functional component for displaying social history.
+ * @param props - Props for social history.
+ * @param props.socialData - The fields to be displayed.
+ * @returns The JSX element representing social history.
+ */
+const SocialHistory: React.FC<SocialHistoryProps> = ({ socialData }) => {
   return (
     <AccordianSection>
       <AccordianH4>

--- a/containers/ecr-viewer/src/app/view-data/components/UnavailableInfo.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/UnavailableInfo.tsx
@@ -15,7 +15,22 @@ interface UnavailableInfoProps {
   immunizationsUnavailableData: DisplayData[];
 }
 
-const UnavailableInfo = ({
+/**
+ * Function component for displaying data that is unavailable in the eCR viewer.
+ * @param props The properties for unavailable information
+ * @param props.demographicsUnavailableData The unavailable demographic data
+ * @param props.socialUnavailableData The unavailable social data
+ * @param props.encounterUnavailableData The unavailable encounter data
+ * @param props.providerUnavailableData The unavailable provider data
+ * @param props.reasonForVisitUnavailableData The unavailable reason for visit data
+ * @param props.activeProblemsUnavailableData The unavailable active problems data
+ * @param props.immunizationsUnavailableData The unavailable immunizations data
+ * @param props.vitalUnavailableData The unavailable vital data
+ * @param props.treatmentData The unavailable treatment data
+ * @param props.clinicalNotesData The unavailable clinical notes
+ * @returns The JSX element representing all unavailable data.
+ */
+const UnavailableInfo: React.FC<UnavailableInfoProps> = ({
   demographicsUnavailableData,
   socialUnavailableData,
   encounterUnavailableData,
@@ -26,7 +41,7 @@ const UnavailableInfo = ({
   vitalUnavailableData,
   treatmentData,
   clinicalNotesData,
-}: UnavailableInfoProps) => {
+}) => {
   const renderSection = (sectionTitle: string, data: DisplayData[]) => {
     return (
       <div className="margin-bottom-4">

--- a/containers/ecr-viewer/src/app/view-data/page.tsx
+++ b/containers/ecr-viewer/src/app/view-data/page.tsx
@@ -13,7 +13,11 @@ import { ExpandCollapseButtons } from "@/app/view-data/components/ExpandCollapse
 // string constants to match with possible .env values
 const basePath = process.env.NODE_ENV === "production" ? "/ecr-viewer" : "";
 
-const ECRViewerPage = () => {
+/**
+ * Functional component for rendering the eCR Viewer page.
+ * @returns The main eCR Viewer JSX component.
+ */
+const ECRViewerPage: React.FC = () => {
   const [fhirBundle, setFhirBundle] = useState<Bundle>();
   const [mappings, setMappings] = useState<PathMappings>({});
   const [errors, setErrors] = useState<Error>();


### PR DESCRIPTION
# PULL REQUEST

## Summary
- Enable rule for JSDocs on arrow functions
- Add missing jsdocs

## Related Issue
Fixes #1660

## Additional Information
Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
