### PR TITLE
Update algorithms in containerized linkage service

### DIFF
--- a/containers/record-linkage/app/linkage/algorithms.py
+++ b/containers/record-linkage/app/linkage/algorithms.py
@@ -1,82 +1,96 @@
-# Pre-computed log-odds points values for each of the DIBBs MPI
-# supported columns (derived from representative synthetic data)
-LOG_ODDS_SCORES = {
-    "birthdate": 9.944142836217619,
-    "first_name": 8.009121400325398,
-    "last_name": 5.327681398982514,
-    "sex": 0.6964525713514773,
-    "address": 5.769942276960749,
-    "city": 1.8002552875091014,
-    "state": 0.0,
-    "zip": 4.909466232098861,
-    "mrn": 1.464232660081324,
-}
+# DEFAULT DIBBS ALGORITHMS
+# These algorithms and log odds scores are the updated values developed after
+# substantial statistical tuning.
 
+LOG_ODDS_SCORES = {
+    "address": 8.438284928858774,
+    "birthdate": 10.126641103800338,
+    "city": 2.438553006137189,
+    "first_name": 6.849475906891162,
+    "last_name": 6.350720397426025,
+    "mrn": 0.3051262572525359,
+    "sex": 0.7510419059643679,
+    "state": 0.022376768992488694,
+    "zip": 4.975031471124867,
+}
+FUZZY_THRESHOLDS = {
+    "first_name": 0.9,
+    "last_name": 0.9,
+    "birthdate": 0.95,
+    "address": 0.9,
+    "city": 0.92,
+    "zip": 0.95,
+}
 
 DIBBS_BASIC = [
     {
         "funcs": {
             "first_name": "feature_match_fuzzy_string",
-            "last_name": "feature_match_fuzzy_string",
-            "birthdate": "feature_match_fuzzy_string",
+            "last_name": "feature_match_exact",
         },
         "blocks": [
+            {"value": "birthdate"},
             {"value": "mrn", "transformation": "last4"},
-            {"value": "address", "transformation": "first4"},
+            {"value": "sex"},
         ],
         "matching_rule": "eval_perfect_match",
         "cluster_ratio": 0.9,
+        "kwargs": {"thresholds": FUZZY_THRESHOLDS},
     },
     {
         "funcs": {
             "address": "feature_match_fuzzy_string",
-            "city": "feature_match_fuzzy_string",
+            "birthdate": "feature_match_exact",
         },
         "blocks": [
+            {"value": "zip"},
             {"value": "first_name", "transformation": "first4"},
             {"value": "last_name", "transformation": "first4"},
+            {"value": "sex"},
         ],
         "matching_rule": "eval_perfect_match",
         "cluster_ratio": 0.9,
+        "kwargs": {"thresholds": FUZZY_THRESHOLDS},
     },
 ]
-
 
 DIBBS_ENHANCED = [
     {
         "funcs": {
-            "birthdate": "feature_match_log_odds_fuzzy_compare",
             "first_name": "feature_match_log_odds_fuzzy_compare",
             "last_name": "feature_match_log_odds_fuzzy_compare",
         },
         "blocks": [
+            {"value": "birthdate"},
             {"value": "mrn", "transformation": "last4"},
-            {"value": "address", "transformation": "first4"},
+            {"value": "sex"},
         ],
         "matching_rule": "eval_log_odds_cutoff",
         "cluster_ratio": 0.9,
         "kwargs": {
             "similarity_measure": "JaroWinkler",
-            "threshold": 0.7,
-            "true_match_threshold": 16.5,
+            "thresholds": FUZZY_THRESHOLDS,
+            "true_match_threshold": 12.2,
             "log_odds": LOG_ODDS_SCORES,
         },
     },
     {
         "funcs": {
             "address": "feature_match_log_odds_fuzzy_compare",
-            "city": "feature_match_log_odds_fuzzy_compare",
+            "birthdate": "feature_match_log_odds_fuzzy_compare",
         },
         "blocks": [
+            {"value": "zip"},
             {"value": "first_name", "transformation": "first4"},
             {"value": "last_name", "transformation": "first4"},
+            {"value": "sex"},
         ],
         "matching_rule": "eval_log_odds_cutoff",
         "cluster_ratio": 0.9,
         "kwargs": {
             "similarity_measure": "JaroWinkler",
-            "threshold": 0.7,
-            "true_match_threshold": 7.0,
+            "thresholds": FUZZY_THRESHOLDS,
+            "true_match_threshold": 17.0,
             "log_odds": LOG_ODDS_SCORES,
         },
     },

--- a/containers/record-linkage/app/linkage/link.py
+++ b/containers/record-linkage/app/linkage/link.py
@@ -641,12 +641,6 @@ def read_linkage_config(config_file: pathlib.Path) -> List[dict]:
     try:
         with open(config_file) as f:
             algo_config = json.load(f)
-            # Need to convert function keys back to column indices, since
-            # JSON serializes dict keys as strings
-            for rl_pass in algo_config.get("algorithm"):
-                rl_pass["funcs"] = {
-                    int(col): f for (col, f) in rl_pass["funcs"].items()
-                }
             return algo_config.get("algorithm", [])
     except FileNotFoundError:
         raise FileNotFoundError(f"No file exists at path {config_file}.")
@@ -746,7 +740,7 @@ def write_linkage_config(linkage_algo: List[dict], file_to_write: pathlib.Path) 
     and optionally `"cluster_ratio"` and `"kwargs"`) and whose values are
     as follows:
 
-    - `"funcs"` should map to a dictionary mapping column index to the
+    - `"funcs"` should map to a dictionary mapping column name to the
     name of a function in the DIBBS linkage module (such as
     `feature_match_fuzzy_string`)--note that these are the actual
     functions, not string names of the functions
@@ -757,27 +751,6 @@ def write_linkage_config(linkage_algo: List[dict], file_to_write: pathlib.Path) 
     - `"cluster_ratio"` should map to a float, if provided
     - `"kwargs"` should map to a dictionary of keyword arguments and their
     associated values, if provided
-
-    Here's an example of a simple single-pass linkage algorithm that blocks
-    on zip code, then matches on exact first name, exact last name, and
-    fuzzy date of birth (using, say, Levenshtein similarity with a score
-    threshold of 0.8) in dictionary descriptor form (for the sake of the
-    example, let's assume the data has the column order first, last, DOB):
-
-    [{
-        "funcs": {
-            0: feature_match_exact,
-            1: feature_match_exact,
-            2: feature_match_fuzzy_string,
-            3: feature_match_fuzzy_string,
-        },
-        "blocks": ["ZIP"],
-        "matching_rule": eval_perfect_match,
-        "kwargs": {
-            "similarity-measure": "Levenshtein",
-            "threshold": 0.8
-        }
-    }]
 
     :param linkage_algo: A list of dictionaries whose key-value pairs correspond
       to the rules above.

--- a/containers/record-linkage/assets/linkage/dibbs_basic_algorithm.json
+++ b/containers/record-linkage/assets/linkage/dibbs_basic_algorithm.json
@@ -2,29 +2,43 @@
   "algorithm": [
     {
       "funcs": {
-        "1": "feature_match_fuzzy_string",
-        "3": "feature_match_fuzzy_string",
-        "4": "feature_match_fuzzy_string"
+        "first_name": "feature_match_fuzzy_string",
+        "last_name": "feature_match_exact"
       },
       "blocks": [
+        {
+          "value": "birthdate"
+        },
         {
           "value": "mrn",
           "transformation": "last4"
         },
         {
-          "value": "address",
-          "transformation": "first4"
+          "value": "sex"
         }
       ],
       "matching_rule": "eval_perfect_match",
-      "cluster_ratio": 0.9
+      "cluster_ratio": 0.9,
+      "kwargs": {
+        "thresholds": {
+          "first_name": 0.9,
+          "last_name": 0.9,
+          "birthdate": 0.95,
+          "address": 0.9,
+          "city": 0.92,
+          "zip": 0.95
+        }
+      }
     },
     {
       "funcs": {
-        "0": "feature_match_fuzzy_string",
-        "2": "feature_match_fuzzy_string"
+        "address": "feature_match_fuzzy_string",
+        "birthdate": "feature_match_exact"
       },
       "blocks": [
+        {
+          "value": "zip"
+        },
         {
           "value": "first_name",
           "transformation": "first4"
@@ -32,10 +46,23 @@
         {
           "value": "last_name",
           "transformation": "first4"
+        },
+        {
+          "value": "sex"
         }
       ],
       "matching_rule": "eval_perfect_match",
-      "cluster_ratio": 0.9
+      "cluster_ratio": 0.9,
+      "kwargs": {
+        "thresholds": {
+          "first_name": 0.9,
+          "last_name": 0.9,
+          "birthdate": 0.95,
+          "address": 0.9,
+          "city": 0.92,
+          "zip": 0.95
+        }
+      }
     }
   ]
 }

--- a/containers/record-linkage/assets/linkage/dibbs_enhanced_algorithm.json
+++ b/containers/record-linkage/assets/linkage/dibbs_enhanced_algorithm.json
@@ -2,34 +2,56 @@
   "algorithm": [
     {
       "funcs": {
-        "1": "feature_match_log_odds_fuzzy_compare",
-        "3": "feature_match_log_odds_fuzzy_compare",
-        "4": "feature_match_log_odds_fuzzy_compare"
+        "first_name": "feature_match_log_odds_fuzzy_compare",
+        "last_name": "feature_match_log_odds_fuzzy_compare"
       },
       "blocks": [
+        {
+          "value": "birthdate"
+        },
         {
           "value": "mrn",
           "transformation": "last4"
         },
         {
-          "value": "address",
-          "transformation": "first4"
+          "value": "sex"
         }
       ],
       "matching_rule": "eval_log_odds_cutoff",
       "cluster_ratio": 0.9,
       "kwargs": {
         "similarity_measure": "JaroWinkler",
-        "threshold": 0.7,
-        "true_match_threshold": 16.5
+        "thresholds": {
+          "first_name": 0.9,
+          "last_name": 0.9,
+          "birthdate": 0.95,
+          "address": 0.9,
+          "city": 0.92,
+          "zip": 0.95
+        },
+        "true_match_threshold": 12.2,
+        "log_odds": {
+          "address": 8.438284928858774,
+          "birthdate": 10.126641103800338,
+          "city": 2.438553006137189,
+          "first_name": 6.849475906891162,
+          "last_name": 6.350720397426025,
+          "mrn": 0.3051262572525359,
+          "sex": 0.7510419059643679,
+          "state": 0.022376768992488694,
+          "zip": 4.975031471124867
+        }
       }
     },
     {
       "funcs": {
-        "0": "feature_match_log_odds_fuzzy_compare",
-        "2": "feature_match_log_odds_fuzzy_compare"
+        "address": "feature_match_log_odds_fuzzy_compare",
+        "birthdate": "feature_match_log_odds_fuzzy_compare"
       },
       "blocks": [
+        {
+          "value": "zip"
+        },
         {
           "value": "first_name",
           "transformation": "first4"
@@ -37,14 +59,35 @@
         {
           "value": "last_name",
           "transformation": "first4"
+        },
+        {
+          "value": "sex"
         }
       ],
       "matching_rule": "eval_log_odds_cutoff",
       "cluster_ratio": 0.9,
       "kwargs": {
         "similarity_measure": "JaroWinkler",
-        "threshold": 0.7,
-        "true_match_threshold": 7.0
+        "thresholds": {
+          "first_name": 0.9,
+          "last_name": 0.9,
+          "birthdate": 0.95,
+          "address": 0.9,
+          "city": 0.92,
+          "zip": 0.95
+        },
+        "true_match_threshold": 17.0,
+        "log_odds": {
+          "address": 8.438284928858774,
+          "birthdate": 10.126641103800338,
+          "city": 2.438553006137189,
+          "first_name": 6.849475906891162,
+          "last_name": 6.350720397426025,
+          "mrn": 0.3051262572525359,
+          "sex": 0.7510419059643679,
+          "state": 0.022376768992488694,
+          "zip": 4.975031471124867
+        }
       }
     }
   ]

--- a/containers/record-linkage/assets/linkage/patient_bundle_to_link_with_mpi.json
+++ b/containers/record-linkage/assets/linkage/patient_bundle_to_link_with_mpi.json
@@ -75,7 +75,7 @@
         ],
         "name": [
           {
-            "family": "Sheperd",
+            "family": "Shepard",
             "given": [
               "Jon",
               "Tiberius"

--- a/containers/record-linkage/tests/assets/patient_bundle_to_link_with_mpi.json
+++ b/containers/record-linkage/tests/assets/patient_bundle_to_link_with_mpi.json
@@ -74,7 +74,7 @@
         ],
         "name": [
           {
-            "family": "Sheperd",
+            "family": "Shepard",
             "given": [
               "Jon"
             ],

--- a/containers/record-linkage/tests/test_linkage.py
+++ b/containers/record-linkage/tests/test_linkage.py
@@ -455,28 +455,50 @@ def test_algo_read():
     assert dibbs_basic_algo == [
         {
             "funcs": {
-                1: "feature_match_fuzzy_string",
-                3: "feature_match_fuzzy_string",
-                4: "feature_match_fuzzy_string",
+                "first_name": "feature_match_fuzzy_string",
+                "last_name": "feature_match_exact",
             },
             "blocks": [
+                {"value": "birthdate"},
                 {"value": "mrn", "transformation": "last4"},
-                {"value": "address", "transformation": "first4"},
+                {"value": "sex"},
             ],
             "matching_rule": "eval_perfect_match",
             "cluster_ratio": 0.9,
+            "kwargs": {
+                "thresholds": {
+                    "first_name": 0.9,
+                    "last_name": 0.9,
+                    "birthdate": 0.95,
+                    "address": 0.9,
+                    "city": 0.92,
+                    "zip": 0.95,
+                }
+            },
         },
         {
             "funcs": {
-                0: "feature_match_fuzzy_string",
-                2: "feature_match_fuzzy_string",
+                "address": "feature_match_fuzzy_string",
+                "birthdate": "feature_match_exact",
             },
             "blocks": [
+                {"value": "zip"},
                 {"value": "first_name", "transformation": "first4"},
                 {"value": "last_name", "transformation": "first4"},
+                {"value": "sex"},
             ],
             "matching_rule": "eval_perfect_match",
             "cluster_ratio": 0.9,
+            "kwargs": {
+                "thresholds": {
+                    "first_name": 0.9,
+                    "last_name": 0.9,
+                    "birthdate": 0.95,
+                    "address": 0.9,
+                    "city": 0.92,
+                    "zip": 0.95,
+                }
+            },
         },
     ]
 
@@ -489,37 +511,75 @@ def test_algo_read():
     assert dibbs_enhanced_algo == [
         {
             "funcs": {
-                1: "feature_match_log_odds_fuzzy_compare",
-                3: "feature_match_log_odds_fuzzy_compare",
-                4: "feature_match_log_odds_fuzzy_compare",
+                "first_name": "feature_match_log_odds_fuzzy_compare",
+                "last_name": "feature_match_log_odds_fuzzy_compare",
             },
             "blocks": [
+                {"value": "birthdate"},
                 {"value": "mrn", "transformation": "last4"},
-                {"value": "address", "transformation": "first4"},
+                {"value": "sex"},
             ],
             "matching_rule": "eval_log_odds_cutoff",
             "cluster_ratio": 0.9,
             "kwargs": {
                 "similarity_measure": "JaroWinkler",
-                "threshold": 0.7,
-                "true_match_threshold": 16.5,
+                "thresholds": {
+                    "first_name": 0.9,
+                    "last_name": 0.9,
+                    "birthdate": 0.95,
+                    "address": 0.9,
+                    "city": 0.92,
+                    "zip": 0.95,
+                },
+                "true_match_threshold": 12.2,
+                "log_odds": {
+                    "address": 8.438284928858774,
+                    "birthdate": 10.126641103800338,
+                    "city": 2.438553006137189,
+                    "first_name": 6.849475906891162,
+                    "last_name": 6.350720397426025,
+                    "mrn": 0.3051262572525359,
+                    "sex": 0.7510419059643679,
+                    "state": 0.022376768992488694,
+                    "zip": 4.975031471124867,
+                },
             },
         },
         {
             "funcs": {
-                0: "feature_match_log_odds_fuzzy_compare",
-                2: "feature_match_log_odds_fuzzy_compare",
+                "address": "feature_match_log_odds_fuzzy_compare",
+                "birthdate": "feature_match_log_odds_fuzzy_compare",
             },
             "blocks": [
+                {"value": "zip"},
                 {"value": "first_name", "transformation": "first4"},
                 {"value": "last_name", "transformation": "first4"},
+                {"value": "sex"},
             ],
             "matching_rule": "eval_log_odds_cutoff",
             "cluster_ratio": 0.9,
             "kwargs": {
                 "similarity_measure": "JaroWinkler",
-                "threshold": 0.7,
-                "true_match_threshold": 7.0,
+                "thresholds": {
+                    "first_name": 0.9,
+                    "last_name": 0.9,
+                    "birthdate": 0.95,
+                    "address": 0.9,
+                    "city": 0.92,
+                    "zip": 0.95,
+                },
+                "true_match_threshold": 17.0,
+                "log_odds": {
+                    "address": 8.438284928858774,
+                    "birthdate": 10.126641103800338,
+                    "city": 2.438553006137189,
+                    "first_name": 6.849475906891162,
+                    "last_name": 6.350720397426025,
+                    "mrn": 0.3051262572525359,
+                    "sex": 0.7510419059643679,
+                    "state": 0.022376768992488694,
+                    "zip": 4.975031471124867,
+                },
             },
         },
     ]
@@ -541,17 +601,17 @@ def test_algo_write():
     sample_algo = [
         {
             "funcs": {
-                8: feature_match_fuzzy_string,
-                12: feature_match_exact,
+                "first_name": feature_match_fuzzy_string,
+                "last_name": feature_match_exact,
             },
             "blocks": ["MRN4", "ADDRESS4"],
             "matching_rule": eval_perfect_match,
         },
         {
             "funcs": {
-                10: feature_match_four_char,
-                16: feature_match_log_odds_exact,
-                22: feature_match_log_odds_fuzzy_compare,
+                "last_name": feature_match_four_char,
+                "sex": feature_match_log_odds_exact,
+                "address": feature_match_log_odds_fuzzy_compare,
             },
             "blocks": ["ZIP", "BIRTH_YEAR"],
             "matching_rule": eval_log_odds_cutoff,
@@ -568,17 +628,17 @@ def test_algo_write():
     assert loaded_algo == [
         {
             "funcs": {
-                8: "feature_match_fuzzy_string",
-                12: "feature_match_exact",
+                "first_name": "feature_match_fuzzy_string",
+                "last_name": "feature_match_exact",
             },
             "blocks": ["MRN4", "ADDRESS4"],
             "matching_rule": "eval_perfect_match",
         },
         {
             "funcs": {
-                10: "feature_match_four_char",
-                16: "feature_match_log_odds_exact",
-                22: "feature_match_log_odds_fuzzy_compare",
+                "last_name": "feature_match_four_char",
+                "sex": "feature_match_log_odds_exact",
+                "address": "feature_match_log_odds_fuzzy_compare",
             },
             "blocks": ["ZIP", "BIRTH_YEAR"],
             "matching_rule": "eval_log_odds_cutoff",
@@ -610,8 +670,8 @@ def test_link_record_against_mpi_none_record():
     ][:2]
 
     # Test various null data values in incoming record
-    patients[1]["name"][0]["given"] = None
-    patients[1]["birthDate"] = None
+    patients[1]["gender"] = None
+    patients[1]["zip"] = None
     matches = []
     mapped_patients = {}
     for patient in patients:
@@ -666,15 +726,14 @@ def test_link_record_against_mpi():
     # First patient inserted into empty MPI, no match
     # Second patient blocks with first patient in first pass, then fuzzy matches name
     # Third patient is entirely new individual, no match
-    # Fourth patient fails blocking with first pass but catches on second, fuzzy
-    # matches
+    # Fourth patient fails blocking with first pass then fails on second
     # Fifth patient: in first pass MRN blocks with one cluster but fails name,
     # in second pass name blocks with different cluster but fails address, no match
     # Sixth patient: in first pass, MRN blocks with one cluster and name matches in it,
     # in second pass name blocks on different cluster and address matches it,
     # finds greatest strength match and correctly assigns to larger cluster
-    assert matches == [False, True, False, True, False, True]
-    assert sorted(list(mapped_patients.values())) == [1, 1, 4]
+    assert matches == [False, True, False, False, False, False]
+    assert sorted(list(mapped_patients.values())) == [1, 1, 1, 1, 2]
 
     # Re-open connection to check for all insertions
     patient_records = MPI.dal.select_results(select(MPI.dal.PATIENT_TABLE))
@@ -761,8 +820,8 @@ def test_link_record_against_mpi_enhanced_algo():
     # Sixth patient: in first pass, MRN blocks with one cluster and name matches in it,
     # in second pass name blocks on different cluster and address matches it,
     #  finds greatest strength match and correctly assigns to larger cluster
-    assert matches == [False, True, False, True, False, True, True]
-    assert sorted(list(mapped_patients.values())) == [1, 1, 5]
+    assert matches == [False, True, False, True, False, False, True]
+    assert sorted(list(mapped_patients.values())) == [1, 1, 1, 4]
 
     # Re-open connection to check for all insertions
     patient_records = MPI.dal.select_results(select(MPI.dal.PATIENT_TABLE))

--- a/containers/record-linkage/tests/test_record_linkage.py
+++ b/containers/record-linkage/tests/test_record_linkage.py
@@ -122,6 +122,7 @@ def test_linkage_success():
     resp_3 = client.post("/link-record", json={"bundle": bundle_3})
     assert not resp_3.json()["found_match"]
 
+    # Cluster membership failure--justified non-match
     bundle_4 = test_bundle
     bundle_4["entry"] = [entry_list[3]]
     resp_4 = client.post("/link-record", json={"bundle": bundle_4})
@@ -131,8 +132,7 @@ def test_linkage_success():
         for r in new_bundle["entry"]
         if r.get("resource").get("resourceType") == "Person"
     ][0]
-    assert resp_4.json()["found_match"]
-    assert person_4.get("id") == person_1.get("id")
+    assert not resp_4.json()["found_match"]
 
     bundle_5 = test_bundle
     bundle_5["entry"] = [entry_list[4]]
@@ -148,8 +148,7 @@ def test_linkage_success():
         for r in new_bundle["entry"]
         if r.get("resource").get("resourceType") == "Person"
     ][0]
-    assert resp_6.json()["found_match"]
-    assert person_6.get("id") == person_1.get("id")
+    assert not resp_6.json()["found_match"]
 
 
 def test_use_enhanced_algo():
@@ -222,5 +221,4 @@ def test_use_enhanced_algo():
         for r in new_bundle["entry"]
         if r.get("resource").get("resourceType") == "Person"
     ][0]
-    assert resp_6.json()["found_match"]
-    assert person_6.get("id") == person_1.get("id")
+    assert not resp_6.json()["found_match"]


### PR DESCRIPTION
# Switch to prod-tested algos

## Summary
So it turns out that even though we updated our algorithms in the evaluation notebook with all these sweet new values, our actual linkage service was still using old and outdated algorithm parameters. This PR integrates the values we determined in our spark evaluation into our DIBBs defaults, finally aligning our production testing with our service offering. As part of this update, a number of tests needed updating to reflect new parameter values, and our new utils' ability to use column names rather than column indices.

## Related Issue
No linked issue, caught as part of a RL resource collation