### PR TITLE
Fixing issue with message-parser upload-schema

### DIFF
--- a/containers/message-parser/app/main.py
+++ b/containers/message-parser/app/main.py
@@ -239,7 +239,6 @@ async def upload_schema(
         }
 
     # Convert Pydantic models to dicts so they can be serialized to JSON.
-    # Convert Pydantic models to dicts so they can be serialized to JSON.
     schema_dict = input.dict()
     clean_schema(schema_dict["parsing_schema"])  # remove secondary_schemas
 

--- a/containers/message-parser/app/main.py
+++ b/containers/message-parser/app/main.py
@@ -17,6 +17,7 @@ from app.models import ParseMessageResponse
 from app.models import ParsingSchemaModel
 from app.models import PutSchemaResponse
 from app.phdc.builder import PHDCBuilder
+from app.utils import clean_schema
 from app.utils import convert_to_fhir
 from app.utils import extract_and_apply_parsers
 from app.utils import freeze_parsing_schema
@@ -238,14 +239,12 @@ async def upload_schema(
         }
 
     # Convert Pydantic models to dicts so they can be serialized to JSON.
-    for field in input.parsing_schema:
-        field_dict = input.parsing_schema[field].dict()
-        if "secondary_schema" in field_dict and field_dict["secondary_schema"] is None:
-            del field_dict["secondary_schema"]
-        input.parsing_schema[field] = field_dict
+    # Convert Pydantic models to dicts so they can be serialized to JSON.
+    schema_dict = input.dict()
+    clean_schema(schema_dict["parsing_schema"])  # remove secondary_schemas
 
     with open(file_path, "w") as file:
-        json.dump(input.parsing_schema, file, indent=4)
+        json.dump(schema_dict["parsing_schema"], file, indent=4)
 
     if schema_exists:
         return {"message": "Schema updated successfully!"}

--- a/containers/message-parser/app/utils.py
+++ b/containers/message-parser/app/utils.py
@@ -112,7 +112,10 @@ def get_parsers(extraction_schema: frozendict) -> frozendict:
             ].items():
                 # Base case: secondary field is located on this resource
                 if not secondary_field_definition["fhir_path"].startswith("Bundle"):
-                    if "secondary_schema" in secondary_field_definition:
+                    if (
+                        "secondary_schema" in secondary_field_definition
+                        and secondary_field_definition["secondary_schema"] is not None
+                    ):
                         tertiary_parser = {}
                         tertiary_parsers = {}
                         tertiary_parser["primary_parser"] = fhirpathpy.compile(

--- a/containers/message-parser/app/utils.py
+++ b/containers/message-parser/app/utils.py
@@ -361,6 +361,24 @@ def get_datetime_now() -> datetime.datetime:
     return datetime.datetime.now()
 
 
+def clean_schema(schema: dict):
+    """
+    Recursively remove any 'secondary_schema' fields that are None or empty.
+    :param schema: the parsing schema dictionary to clean out
+    """
+    keys_to_delete = []
+    for key, value in schema.items():
+        if isinstance(value, dict):
+            clean_schema(value)  # Recursively clean nested dictionaries
+            if "secondary_schema" in value and not value["secondary_schema"]:
+                keys_to_delete.append("secondary_schema")
+        elif value is None:
+            keys_to_delete.append(key)
+
+    for key in keys_to_delete:
+        del schema[key]
+
+
 def extract_and_apply_parsers(parsing_schema, message, response):
     """
     Helper function used to pull parsing methods for each field out of the


### PR DESCRIPTION
# PULL REQUEST

## Summary
This fixes an issue where the new secondary schema code would loop through even when `secondary_schema` is None. This adds an exception to prevent this from occurring in the `utils.py` and also fixes what I believe to have been the initial fix that existed in `main.py`.

This can be tested with a `PUT` to `localhost:8080/schemas/<any relevant schema>` then `localhost:8080/parse_message` with the `parsing_schema` set to the new schema.

## Related Issue
Fixes #1743 

## Additional Information
Th fix to utils.py the immediate issue of it erroring, though, I'm not quite sure I understand the core issue. When I `GET` and check for the schema `localhost:8080/schemas/ersd.json`, in this case, it was inserting a bunch of `null` secondary schemas. Example below.

I believe this occurs because of...something here not working correctly:
https://github.com/CDCgov/phdi/blob/main/containers/message-parser/app/main.py#L241-L245

I _think_ the intention of the code is to pop these empty secondary_schemas, but I'm not sure I understand where or why they're added in the first place. @bamader , I know you recently worked on this, so I'm curious if you have ideas for places we might try to remove them? Or rewrite this section to correctly pop them?  Or if it'd be a bad idea to remove them?

The uploaded schemas will still work, they're just slightly bigger with the null secondary schema items. So, we could get away with just the smaller change in utils, but the additional function in utils.py does appear to successfully pop the further nested secondary schemas.


```json
{
	"message": "Schema found!",
	"parsing_schema": {
		"value_set_type": {
			"fhir_path": "entry.resource.where(resourceType='ValueSet' and url.contains('http://ersd.aimsplatform.org/fhir/ValueSet/')",
			"data_type": "string",
			"nullable": false,
			"secondary_schema": {
				"id": {
					"fhir_path": "id",
					"data_type": "string",
					"nullable": false,
					"secondary_schema": null
				},
				"clinical_service_type": {
					"fhir_path": "title",
					"data_type": "string",
					"nullable": false,
					"secondary_schema": null
				}
			}
		},
....
``` 

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
