### PR TITLE
Create vocab mapper service stubs

### DIFF
--- a/containers/message-parser/app/models.py
+++ b/containers/message-parser/app/models.py
@@ -104,12 +104,9 @@ class ParseMessageInput(BaseModel):
           message_type has been included with API call
 
         :param cls: the ParseMessageInput class
-
         :param values: the message_format provided by the user
-
         :raises ValueError: errors when message_type is None
           when message_format is not "fhir"
-
         :return values: the message_format provided by the user
         """
         if (
@@ -130,12 +127,9 @@ class ParseMessageInput(BaseModel):
           only one should be provided for message_parser to work correctly.
 
         :param cls: the ParseMessageInput class
-
         :param values: the parsing_schema and parsing_schema_name provided by the user
-
         :raises ValueError: error when both parsing_schema and
           parsing_schema_name are provided in API call.
-
         :return values: the parsing_schema and parsing_schema_name provided by the user
         """
         if (
@@ -156,12 +150,9 @@ class ParseMessageInput(BaseModel):
           one (and only one!) should be provided for message_parser to work correctly.
 
         :param cls: the ParseMessageInput class
-
         :param values: the parsing_schema and parsing_schema_name provided by the user
-
         :raises ValueError: error when both pasing_schema and parsing_schema_name
           are missing from API call.
-
         :return values: the parsing_schema and parsing_schema_name provided by the user
         """
         if (

--- a/containers/vocab-mapper/Dockerfile
+++ b/containers/vocab-mapper/Dockerfile
@@ -1,0 +1,13 @@
+FROM ghcr.io/cdcgov/phdi/dibbs
+
+WORKDIR /code
+
+COPY ./requirements.txt /code/requirements.txt
+RUN pip install -r requirements.txt
+
+COPY ./app /code/app
+COPY ./assets /code/assets
+COPY ./description.md /code/description.md
+
+EXPOSE 8080
+CMD uvicorn app.main:app --host 0.0.0.0 --port 8080

--- a/containers/vocab-mapper/app/main.py
+++ b/containers/vocab-mapper/app/main.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+from dibbs.base_service import BaseService
+from fastapi import Response
+
+from app.models import InsertConditionInput
+from app.models import ValueSetForConditionInput
+
+# Instantiate FastAPI via DIBBs' BaseService class
+app = BaseService(
+    service_name="Vocabulary Mapper",
+    service_path="/vocab-mapper",
+    description_path=Path(__file__).parent.parent / "description.md",
+).start()
+
+
+@app.get("/")
+async def health_check():
+    """
+    Check service status. If an HTTP 200 status code is returned along with
+    '{"status": "OK"}' then the mapper service is available and running
+    properly.
+    """
+    return {"status": "OK"}
+
+
+@app.post("/ersd/insert-condition-extensions/")
+async def insert_condition_extensions(input: InsertConditionInput, response: Response):
+    """
+    Extends the resources of a supplied FHIR bundle with extension tags
+    related to one or more supplied conditions. For each condition in the
+    given list of conditions, each resource in the bundle is appended with
+    an extension structure indicating which snowmed condition code the
+    resource is linked to.
+    """
+    # TODO: This method is a stub.
+    return {"extended_bundle": input.bundle}
+
+
+@app.post("/ersd/get-value-sets/")
+async def get_value_sets_for_condition(
+    input: ValueSetForConditionInput, response: Response
+):
+    """
+    For a given condition, queries and returns the value set of clinical
+    services associated with that condition.
+    """
+    # TODO: This method is a stub.
+    return {"value_set": []}

--- a/containers/vocab-mapper/app/models.py
+++ b/containers/vocab-mapper/app/models.py
@@ -1,0 +1,53 @@
+from typing import List
+
+from pydantic import BaseModel
+from pydantic import Field
+from pydantic import root_validator
+
+
+class InsertConditionInput(BaseModel):
+    """
+    The schema for requests to the /insert-condition-extensions endpoint.
+    """
+
+    bundle: dict = Field(
+        description="The FHIR bundle to modify. Each resource in the bundle related "
+        "to one or more of the conditions in the other supplied parameter will have "
+        "an extension added to the resource noting the snowmed code relating to the "
+        "associated condition(s)."
+    )
+    conditions: List[str] = Field(
+        description="The list of snowmed codes to insert as extensions into any "
+        "associated resources in the supplied FHIR bundle."
+    )
+
+    @root_validator
+    def require_non_empty_condition_list(cls, values):
+        """
+        Ensures that the supplied conditions list parameter is both a list
+        and has at least one element by which to extend the supplied FHIR
+        bundle.
+
+        :param cls: The InsertConditionInput class.
+        :param values: The condition list supplied by the caller.
+        :raises ValueError: Errors when supplied condition list contains no
+          elements, since this can't be used to extend a bundle.
+        :return: The endpoint's values, if the condition list is valid.
+        """
+        if len(values.get("conditions")) == 0:
+            raise ValueError(
+                "Supplied list of snowmed conditions must contain "
+                "one or more elements; given list was empty."
+            )
+        return values
+
+
+class ValueSetForConditionInput(BaseModel):
+    """
+    The schema for requests to the /get-value-sets endpoint.
+    """
+
+    condition: str = Field(
+        description="The snowmed code for a condition of interest, whose value "
+        "sets will be retrieved from the service."
+    )

--- a/containers/vocab-mapper/description.md
+++ b/containers/vocab-mapper/description.md
@@ -1,0 +1,50 @@
+## Getting Started with the DIBBs Vocabulary Mapper Service
+
+### Introduction
+
+The DIBBs vocabulary mapper (vocab-mapper) service offers a REST API devoted to querying and enriching SNOWMED condition code analysis. This service stores condition codes and their associated value sets so that they can be queried by users, as well as inserted into supplied FHIR bundles as tagged extensions for future path parsing.
+
+### Running the eCR Refiner
+
+The vocab mapper can be run using Docker (or any other OCI container runtime e.g., Podman), or directly from the Python source code.
+
+#### Running with Docker (Recommended)
+
+To run the voca mapper with Docker, follow these steps.
+
+1. Confirm that you have Docker installed by running `docker -v`. If you do not see a response similar to what is shown below, follow [these instructions](https://docs.docker.com/get-docker/) to install Docker.
+
+```
+❯ docker -v
+Docker version 20.10.21, build baeda1f
+```
+
+2. Download a copy of the Docker image from the PHDI repository by running `docker pull ghcr.io/cdcgov/phdi/vocab-mapper:latest`.
+3. Run the service with ` docker run -p 8080:8080 vocab-mapper:latest`.
+
+Congratulations, the vocab mapper should now be running on `localhost:8080`!
+
+#### Running from Python Source Code
+
+We recommend running the vocab mapper from a container, but if that is not feasible for a given use-case, it may also be run directly from Python using the steps below.
+
+1. Ensure that both Git and Python 3.10 or higher are installed.
+2. Clone the PHDI repository with `git clone https://github.com/CDCgov/phdi`.
+3. Navigate to `/phdi/containers/vocab-mapper/`.
+4. Make a fresh virtual environment with `python -m venv .venv`.
+5. Activate the virtual environment with `source .venv/bin/activate` (MacOS and Linux), `venv\Scripts\activate` (Windows Command Prompt), or `.venv\Scripts\Activate.ps1` (Windows Power Shell).
+6. Install all of the Python dependencies for the vocab mapper with `pip install -r requirements.txt` into your virtual environment.
+7. Run the vocab mapper on `localhost:8080` with `python -m uvicorn app.main:app --host 0.0.0.0 --port 8080`.
+
+### Building the Docker Image
+
+To build the Docker image for the vocab mapper from source instead of downloading it from the PHDI repository follow these steps.
+
+1. Ensure that both [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) and [Docker](https://docs.docker.com/get-docker/) are installed.
+2. Clone the PHDI repository with `git clone https://github.com/CDCgov/phdi`.
+3. Navigate to `/phdi/containers/vocab-mapper/`.
+4. Run `docker build -t vocab-mapper .`.
+
+### The API
+
+When viewing these docs from the `/redoc` endpoint on a running instance of the vocab-mapper or the PHDI website, detailed documentation on the API will be available below.

--- a/containers/vocab-mapper/dev-requirements.txt
+++ b/containers/vocab-mapper/dev-requirements.txt
@@ -1,0 +1,3 @@
+pytest
+httpx
+testcontainers[compose]==3.7.1

--- a/containers/vocab-mapper/requirements.txt
+++ b/containers/vocab-mapper/requirements.txt
@@ -1,0 +1,4 @@
+../dibbs
+pathlib
+httpx
+requests

--- a/containers/vocab-mapper/tests/conftest.py
+++ b/containers/vocab-mapper/tests/conftest.py
@@ -1,0 +1,72 @@
+import json
+import os
+from pathlib import Path
+
+import pytest
+from testcontainers.compose import DockerCompose
+
+
+@pytest.fixture(scope="session")
+def read_json_from_test_assets():
+    def _read_json(filename: str) -> dict:
+        """
+        Reads a JSON file from the test assets directory.
+        """
+        with open((Path(__file__).parent / "assets" / filename), "r") as file:
+            return json.load(file)
+
+    return _read_json
+
+
+@pytest.fixture(scope="session")
+def read_json_from_phdi_test_assets():
+    def _read_json(filename: str) -> dict:
+        """
+        Reads a JSON file from the test assets directory.
+        """
+        with open(
+            (
+                Path(__file__).parent.parent.parent.parent
+                / "tests"
+                / "assets"
+                / "general"
+                / filename
+            ),
+            "r",
+        ) as file:
+            return json.load(file)
+
+    return _read_json
+
+
+@pytest.fixture(scope="session")
+def read_file_from_test_assets():
+    def _read_file(filename: str) -> str:
+        """
+        Reads a file from the test assets directory.
+        """
+        with open((Path(__file__).parent / "assets" / filename), "r") as file:
+            return file.read()
+
+    return _read_file
+
+
+@pytest.fixture(scope="session")
+def setup(request):
+    print("Setting up tests...")
+    compose_path = os.path.join(os.path.dirname(__file__), "./integration/")
+    compose_file_name = "docker-compose.yaml"
+    vocab_mapper = DockerCompose(compose_path, compose_file_name=compose_file_name)
+    parser_url = "http://0.0.0.0:8080"
+
+    vocab_mapper.start()
+    vocab_mapper.wait_for(parser_url)
+    print("Vocabulary Mapper ready to test!")
+
+    def teardown():
+        print("Service logs...\n")
+        print(vocab_mapper.get_logs())
+        print("Tests finished! Tearing down.")
+        vocab_mapper.stop()
+
+    request.addfinalizer(teardown)

--- a/containers/vocab-mapper/tests/integration/docker-compose.yaml
+++ b/containers/vocab-mapper/tests/integration/docker-compose.yaml
@@ -1,0 +1,8 @@
+version: "3.3"
+
+services:
+  vocab-mapper-service:
+    build:
+      context: ../..
+    ports:
+      - "8080:8080"

--- a/containers/vocab-mapper/tests/integration/test_vocab_mapper.py
+++ b/containers/vocab-mapper/tests/integration/test_vocab_mapper.py
@@ -1,0 +1,10 @@
+import httpx
+import pytest
+
+PARSER_URL = "http://0.0.0.0:8080"
+
+
+@pytest.mark.integration
+def test_health_check(setup):
+    health_check_response = httpx.get(PARSER_URL)
+    assert health_check_response.status_code == 200


### PR DESCRIPTION
# Initialize terminology service

## Summary
This PR sets up the infrastructure and container boilerplate for our terminology service. We follow the same pattern as the message parser, message refiner, and orchestration services, in terms of managing docker files, directory structure, unit and integration tests, and pydantic model inputs. 

Of particular note for team members, this changeset introduces two endpoints that will be used for condition value set purposes (both querying/retrieving and extending). Let's make sure this API structure works for all devs working on this code. I'm able to build and run this container locally (not that it does a whole lot yet) no problem and get responses from the healthcheck, so if the endpoints and model inputs look good, we can move forward with incorporating actual logic into the endpoints.

## Related Issue
Fixes #1665 

## Additional Information
- [x ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)
