### PR TITLE
fix ecr-viewer seed script volume mapping to the correct folder name

### DIFF
--- a/containers/ecr-viewer/seed-scripts/Dockerfile
+++ b/containers/ecr-viewer/seed-scripts/Dockerfile
@@ -12,7 +12,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy the script into the container
 COPY create-seed-data.py /code/create-seed-data.py
 COPY ./baseECR /code/baseECR
-COPY sql /code/sql
 
 # Command to run the script
 CMD ["python", "./create-seed-data.py"]

--- a/containers/ecr-viewer/seed-scripts/docker-compose.yml
+++ b/containers/ecr-viewer/seed-scripts/docker-compose.yml
@@ -17,5 +17,4 @@ services:
     ports:
       - "8081:8081"
     volumes:
-      - ./sql-init/:/code/sql-init
-      - ./baseECR/:/code/baseECR
+      - ./sql:/code/sql


### PR DESCRIPTION
# PULL REQUEST

## Summary
- Fix volume being mapped in docker-compose to be `./sql:/code/sql` rather than `sql-init`