### PR TITLE
Add Date Formatter to TEFCA Viewer 

### DIFF
--- a/containers/tefca-viewer/src/app/format-service.tsx
+++ b/containers/tefca-viewer/src/app/format-service.tsx
@@ -56,7 +56,6 @@ export const formatDate = (dateString?: string): string | undefined => {
         day: "2-digit",
         timeZone: "UTC",
       }); // UTC, otherwise will have timezone issues
-    } 
-  
+    }
   }
 };

--- a/containers/tefca-viewer/src/app/format-service.tsx
+++ b/containers/tefca-viewer/src/app/format-service.tsx
@@ -49,14 +49,7 @@ export function formatCodeableConcept(concept: CodeableConcept | undefined) {
 export const formatDate = (dateString?: string): string | undefined => {
   if (dateString) {
     let date = new Date(dateString);
-    if (date.toString() == "Invalid Date") {
-      const formattedDate = `${dateString.substring(
-        0,
-        4,
-      )}-${dateString.substring(4, 6)}-${dateString.substring(6, 8)}`; // yyyy-mm-dd
-      date = new Date(formattedDate);
-    }
-    // double check that the reformat actually worked otherwise return nothing
+
     if (date.toString() != "Invalid Date") {
       return date.toLocaleDateString("en-US", {
         year: "numeric",

--- a/containers/tefca-viewer/src/app/format-service.tsx
+++ b/containers/tefca-viewer/src/app/format-service.tsx
@@ -39,3 +39,34 @@ export function formatCodeableConcept(concept: CodeableConcept | undefined) {
     </>
   );
 }
+
+
+/**
+ * Formats the provided date string into a formatted date string with year, month, and day.
+ * @param dateString - The date string to be formatted. formatDate will also be able to take 'yyyymmdd' as input.
+ * @returns - The formatted date string, "" if input date was invalid, or undefined if the input date is falsy.
+ */
+export const formatDate = (dateString?: string): string | undefined => {
+  if (dateString) {
+    let date = new Date(dateString);
+    if (date.toString() == "Invalid Date") {
+      const formattedDate = `${dateString.substring(
+        0,
+        4,
+      )}-${dateString.substring(4, 6)}-${dateString.substring(6, 8)}`; // yyyy-mm-dd
+      date = new Date(formattedDate);
+    }
+    // double check that the reformat actually worked otherwise return nothing
+    if (date.toString() != "Invalid Date") {
+      return date.toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        timeZone: "UTC",
+      }); // UTC, otherwise will have timezone issues
+    }
+    else {
+      return "";
+    }
+  }
+};

--- a/containers/tefca-viewer/src/app/format-service.tsx
+++ b/containers/tefca-viewer/src/app/format-service.tsx
@@ -56,8 +56,7 @@ export const formatDate = (dateString?: string): string | undefined => {
         day: "2-digit",
         timeZone: "UTC",
       }); // UTC, otherwise will have timezone issues
-    } else {
-      return "";
-    }
+    } 
+  
   }
 };

--- a/containers/tefca-viewer/src/app/query/components/ConditionsTable.tsx
+++ b/containers/tefca-viewer/src/app/query/components/ConditionsTable.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Table } from "@trussworks/react-uswds";
 import { Condition } from "fhir/r4";
-import { formatCodeableConcept } from "../../format-service";
+import { formatCodeableConcept, formatDate } from "../../format-service";
 
 /**
  * The props for the ConditionTable component.
@@ -32,8 +32,8 @@ const ConditionsTable: React.FC<ConditionTableProps> = ({ conditions }) => {
           <tr key={condition.id}>
             <td>{formatCodeableConcept(condition.code ?? {})}</td>
             <td>{formatCodeableConcept(condition.clinicalStatus ?? {})}</td>
-            <td>{condition.onsetDateTime}</td>
-            <td>{condition.abatementDateTime}</td>
+            <td>{formatDate(condition.onsetDateTime)}</td>
+            <td>{formatDate(condition.abatementDateTime)}</td>
           </tr>
         ))}
       </tbody>

--- a/containers/tefca-viewer/src/app/query/components/Demographics.tsx
+++ b/containers/tefca-viewer/src/app/query/components/Demographics.tsx
@@ -3,6 +3,7 @@ import { DisplayData } from "@/app/utils";
 import { DataDisplay } from "@/app/utils";
 import * as dateFns from "date-fns";
 import { evaluate } from "fhirpath";
+import { formatDate } from "@/app/format-service";
 
 /**
  * Displays the demographic information of a patient.
@@ -46,7 +47,7 @@ function formatDemographics(patient: Patient): DisplayData[] {
     },
     {
       title: "DOB",
-      value: patient.birthDate ?? "",
+      value: formatDate(patient.birthDate),
     },
     {
       title: "Current Age",

--- a/containers/tefca-viewer/src/app/query/components/DiagnosticReportTable.tsx
+++ b/containers/tefca-viewer/src/app/query/components/DiagnosticReportTable.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Table } from "@trussworks/react-uswds";
 import { DiagnosticReport } from "fhir/r4";
-import { formatCodeableConcept } from "../../format-service";
+import { formatCodeableConcept, formatDate } from "../../format-service";
 
 /**
  * The props for the DiagnosticReportTable component.
@@ -30,7 +30,7 @@ const DiagnosticReportTable: React.FC<DiagnosticReportTableProps> = ({
       <tbody>
         {diagnosticReports.map((diagnosticReport) => (
           <tr key={diagnosticReport.id}>
-            <td>{diagnosticReport?.effectiveDateTime}</td>
+            <td>{formatDate(diagnosticReport?.effectiveDateTime)}</td>
             <td>{formatCodeableConcept(diagnosticReport.code)}</td>
           </tr>
         ))}

--- a/containers/tefca-viewer/src/app/query/components/EncounterTable.tsx
+++ b/containers/tefca-viewer/src/app/query/components/EncounterTable.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Table } from "@trussworks/react-uswds";
 import { Encounter } from "fhir/r4";
-import { formatCodeableConcept } from "../../format-service";
+import { formatCodeableConcept, formatDate } from "../../format-service";
 
 /**
  * The props for the EncounterTable component.
@@ -43,8 +43,8 @@ const EncounterTable: React.FC<EncounterTableProps> = ({
             </td>
             <td>{encounter?.serviceProvider?.display}</td>
             <td>{encounter?.status}</td>
-            <td>{encounter?.period?.start}</td>
-            <td>{encounter?.period?.end}</td>
+            <td>{formatDate(encounter?.period?.start)}</td>
+            <td>{formatDate(encounter?.period?.end)}</td>
           </tr>
         ))}
       </tbody>

--- a/containers/tefca-viewer/src/app/query/components/ObservationTable.tsx
+++ b/containers/tefca-viewer/src/app/query/components/ObservationTable.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Table } from "@trussworks/react-uswds";
 import { Observation } from "fhir/r4";
-import { formatCodeableConcept } from "../../format-service";
+import { formatCodeableConcept, formatDate } from "../../format-service";
 /**
  * The props for the ObservationTable component.
  */
@@ -32,7 +32,8 @@ const ObservationTable: React.FC<ObservationTableProps> = ({
       <tbody>
         {observations.map((obs) => (
           <tr key={obs.id}>
-            <td>{obs?.issued}</td>
+            <td>{formatDate(obs?.issued)}</td>
+            {/* <td>{obs?.issued}</td> */}
             <td>{formatCodeableConcept(obs.code)}</td>
             <td>
               {obs?.interpretation && obs.interpretation.length > 0


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR borrows and slightly alters the `formatDate` function from the eCR Viewer to return all dates as MM/DD/YYYY. We could gather information from users about whether they want to see the timestamps (when available).

## Related Issue
Fixes #1791 

## Additional Information
Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
