### PR TITLE
TEFCA Viewer: Update search results view and header and footer styling 

### DIFF
--- a/containers/tefca-viewer/src/app/footer.tsx
+++ b/containers/tefca-viewer/src/app/footer.tsx
@@ -8,7 +8,7 @@ export default function FooterComponent() {
   return (
     <footer className="usa-footer">
       <div className="usa-footer__secondary-section max-w-full bg-primary-darker">
-        <div className="grid-container usa-nav-container">
+        <div className="header-footer-content grid-container usa-nav-container">
           <div className="grid-row grid-gap">
             <div
               className="

--- a/containers/tefca-viewer/src/app/header.tsx
+++ b/containers/tefca-viewer/src/app/header.tsx
@@ -5,12 +5,12 @@
 export default function HeaderComponent() {
   return (
     <header className="usa-header usa-header--basic bg-primary-darker">
-      <div className="usa-nav-container max-w-full">
+      <div className="header-footer-content usa-nav-container">
         <div className="usa-navbar w-full">
           <div className="usa-logo">
             <em className="usa-logo__text text-base-lightest">
               <a
-                className="text-base-lightest"
+                className="text-base-lightest font-sans-2xl text-bold"
                 href="/tefca-viewer"
                 title="TryTEFCA Viewer"
               >

--- a/containers/tefca-viewer/src/app/query/components/QueryView.tsx
+++ b/containers/tefca-viewer/src/app/query/components/QueryView.tsx
@@ -1,43 +1,57 @@
 import { UseCaseQueryResponse } from "../../query-service";
 import AccordionContainer from "./AccordionContainer";
 import SideNav from "./SideNav";
-import React from "react";
+import React, { useEffect } from "react";
+import { Mode } from "../page";
 
 type QueryViewProps = {
   useCaseQueryResponse: UseCaseQueryResponse;
+  setMode: (mode: Mode) => void;
 };
 
 /**
  * The QueryView component to render the query results.
  * @param props - The props for the QueryView component.
  * @param props.useCaseQueryResponse - The response from the query service.
+ * @param props.setMode - The function to set the mode of the query page.
  * @returns The QueryView component.
  */
-const QueryView: React.FC<QueryViewProps> = ({ useCaseQueryResponse }) => {
+const QueryView: React.FC<QueryViewProps> = ({
+  useCaseQueryResponse,
+  setMode,
+}) => {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
   return (
-    <div>
-      <div>
-        <div className="main-container">
-          <div className="content-wrapper">
-            <div className="nav-wrapper">
-              <nav className="sticky-nav">
-                <SideNav />
-              </nav>
-            </div>
-            <div className={"ecr-viewer-container"}>
-              <div className="ecr-content">
-                <h2 className="margin-bottom-3" id="ecr-summary">
-                  Query Results
-                </h2>
-                <div className="margin-top-6">
-                  <AccordionContainer queryResponse={useCaseQueryResponse} />
-                </div>
+    <>
+      <div className="results-banner">
+        <div className="results-banner-content usa-nav-container">
+          <a href="#" onClick={() => setMode("search")}>
+            Return to search
+          </a>
+        </div>
+      </div>
+      <div className="main-container">
+        <div className="content-wrapper">
+          <div className="nav-wrapper">
+            <nav className="sticky-nav">
+              <SideNav />
+            </nav>
+          </div>
+          <div className={"ecr-viewer-container"}>
+            <div className="ecr-content">
+              <h2 className="margin-bottom-3" id="ecr-summary">
+                Query Results
+              </h2>
+              <div className="margin-top-6">
+                <AccordionContainer queryResponse={useCaseQueryResponse} />
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </>
   );
 };
 export default QueryView;

--- a/containers/tefca-viewer/src/app/query/page.tsx
+++ b/containers/tefca-viewer/src/app/query/page.tsx
@@ -33,13 +33,11 @@ const Query: React.FC = () => {
       {/* Switch the mode to view to show the results of the query */}
       {mode === "results" && (
         <>
-          <button className="usa-button" onClick={() => setMode("search")}>
-            Search for a new patient
-          </button>
-          <LoadingView loading={loading} />
-          {/* TODO: add error view if loading is done and there's no useCaseQueryResponse */}
           {useCaseQueryResponse && (
-            <QueryView useCaseQueryResponse={useCaseQueryResponse} />
+            <QueryView
+              useCaseQueryResponse={useCaseQueryResponse}
+              setMode={setMode}
+            />
           )}
         </>
       )}

--- a/containers/tefca-viewer/src/styles/custom-styles.scss
+++ b/containers/tefca-viewer/src/styles/custom-styles.scss
@@ -293,3 +293,23 @@ body {
   }
   width: 100%;
 }
+.results-banner {
+  background-color: #DFE1E2;
+}
+.results-banner-content {
+  margin-bottom: 1rem;
+  max-width: 90rem;
+  height: 5rem;
+  display: flex;
+  align-items: center;
+  // padding-left: 10rem;
+}
+
+.header-footer-content {
+  max-width: 98rem !important;
+}
+
+.usa-logo {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR ensures that when query results are rendered the app automagically scrolls to the top of the page. We also use this opportunity to make a few styling adjustments:

1. The "Return to search" button has been replaced with a link in a gray banner to more closely align with our designs
2. Horizontal spacing on the header and footer are adjusted to more closely align with the designs

<img width="1903" alt="image" src="https://github.com/CDCgov/phdi/assets/99684231/a3fa8a4c-6b6d-4b4c-9585-9f840b39cded">

<img width="1903" alt="image" src="https://github.com/CDCgov/phdi/assets/99684231/661da462-4427-42cc-9cff-938ea812ab0c">

## Related Issue
Fixes #1798 

## Additional Information
Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
