### PR TITLE
Allow spaces in first and last names

### DIFF
--- a/containers/tefca-viewer/src/app/query/components/SearchForm.tsx
+++ b/containers/tefca-viewer/src/app/query/components/SearchForm.tsx
@@ -83,7 +83,7 @@ const SearchForm: React.FC<SearchFormProps> = ({
                 id="firstName"
                 name="first_name"
                 type="text"
-                pattern="^[A-Za-z]+$"
+                pattern="^[A-Za-z ]+$"
                 value={firstName}
                 onChange={(event) => {
                   setFirstName(event.target.value);
@@ -96,7 +96,7 @@ const SearchForm: React.FC<SearchFormProps> = ({
                 id="lastName"
                 name="last_name"
                 type="text"
-                pattern="^[A-Za-z]+$"
+                pattern="^[A-Za-z ]+$"
                 value={lastName}
                 onChange={(event) => {
                   setLastName(event.target.value);


### PR DESCRIPTION
# PULL REQUEST

## Summary
This is a very small PR that relaxes the form validation on values for First and Last name to allow for spaces. I'm not sure if this is the correct move long term, but several of the synthetic patients we will use at the connectathon from JMC have spaces in their first names e.g. "GC ONE".

## Related Issue
Fixes #1858 

## Additional Information
Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
