### PR TITLE
TEFCA Viewer: Log an error on failed patient searches instead of raising an exception.

### DIFF
--- a/containers/tefca-viewer/src/app/query-service.ts
+++ b/containers/tefca-viewer/src/app/query-service.ts
@@ -76,10 +76,10 @@ async function patientQuery(
 
   // Check for errors
   if (response.status !== 200) {
-    throw new Error(
+    console.error(
       `Patient search failed. Status: ${
         response.status
-      } \n ${await response.text()} \n Headers: ${JSON.stringify(
+      } \n Body: ${JSON.stringify(await response.body)} \n Headers: ${JSON.stringify(
         response.headers.raw(),
       )}`,
     );

--- a/containers/tefca-viewer/src/app/query-service.ts
+++ b/containers/tefca-viewer/src/app/query-service.ts
@@ -79,7 +79,7 @@ async function patientQuery(
     console.error(
       `Patient search failed. Status: ${
         response.status
-      } \n Body: ${JSON.stringify(await response.body)} \n Headers: ${JSON.stringify(
+      } \n Body: ${await response.text} \n Headers: ${JSON.stringify(
         response.headers.raw(),
       )}`,
     );


### PR DESCRIPTION
# PULL REQUEST

## Summary
When a non 200 status code is returned for a patient search we log the error instead of raising an error. This allows for processing to continuing and ultimately results in the user being guided to the "No patients found" page. This is a more graceful failure state when make queries with names that contain spaces to eHX instead of hanging on our loading screen.

## Related Issue
Fixes #

## Additional Information
Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
