### PR TITLE
move tooltips to own file

### DIFF
--- a/containers/ecr-viewer/src/app/DataDisplay.tsx
+++ b/containers/ecr-viewer/src/app/DataDisplay.tsx
@@ -1,7 +1,8 @@
 import React, { ReactNode, useEffect, useState } from "react";
 import { Button } from "@trussworks/react-uswds";
 import classNames from "classnames";
-import { toolTipElement } from "@/app/utils";
+
+import { ToolTipElement } from "@/app/ToolTipElement";
 
 export interface DisplayDataProps {
   title?: string;
@@ -36,7 +37,7 @@ export const DataDisplay: React.FC<{
     <div>
       <div className="grid-row">
         <div className="data-title">
-          {toolTipElement(item.title, item.toolTip)}
+          <ToolTipElement content={item.title} toolTip={item.toolTip} />
         </div>
         <div
           className={classNames(

--- a/containers/ecr-viewer/src/app/DataDisplay.tsx
+++ b/containers/ecr-viewer/src/app/DataDisplay.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode, useEffect, useState } from "react";
 import { Button } from "@trussworks/react-uswds";
 import classNames from "classnames";
-
 import { ToolTipElement } from "@/app/ToolTipElement";
 
 export interface DisplayDataProps {

--- a/containers/ecr-viewer/src/app/ToolTipElement.tsx
+++ b/containers/ecr-viewer/src/app/ToolTipElement.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { Tooltip } from "@trussworks/react-uswds";
+
+type CustomDivProps = React.PropsWithChildren<{
+  className?: string;
+}> &
+  JSX.IntrinsicElements["div"] &
+  React.RefAttributes<HTMLDivElement>;
+/**
+ * `CustomDivForwardRef` is a React forward reference component that renders a div element
+ *  with extended capabilities. This component supports all standard div properties along with
+ *  additional features provided by `tooltipProps`.
+ * @component
+ * @param props - The props for the CustomDiv component.
+ * @param props.className - CSS class to apply to the div element.
+ * @param props.children - Child elements or content to be rendered within the div.
+ * @param props.tooltipProps - Additional props to be spread into the div element, typically used for tooltip logic or styling.
+ * @param ref - Ref forwarded to the div element.
+ * @returns A React element representing a customizable div.
+ */
+const CustomDivForwardRef: React.ForwardRefRenderFunction<
+  HTMLDivElement,
+  CustomDivProps
+> = ({ className, children, ...tooltipProps }: CustomDivProps, ref) => (
+  <div ref={ref} className={className} {...tooltipProps}>
+    {children}
+  </div>
+);
+export const TooltipDiv = React.forwardRef(CustomDivForwardRef);
+
+interface ToolTipProps {
+  content?: string;
+  toolTip?: string;
+}
+
+/**
+ * Creates a tooltip-wrapped element if a tooltip text is provided, or returns the content directly otherwise.
+ * The tooltip is only applied when the `toolTip` parameter is not null or undefined. If the tooltip text
+ * is less than 100 characters, a specific class `short-tooltip` is added to style the tooltip differently.
+ * @param content - The properties object for tooltips.
+ * @param content.content - The content to be displayed, which can be any valid React node or text
+ * @param content.toolTip - The text for the tooltip. If this is provided, the content will be wrapped in a tooltip.
+ * @returns A React JSX element containing either the plain content or content wrapped in a tooltip, depending on the tooltip parameter.
+ */
+export const ToolTipElement = ({
+  content,
+  toolTip,
+}: ToolTipProps): React.JSX.Element => {
+  return toolTip ? (
+    <Tooltip
+      label={toolTip}
+      asCustom={TooltipDiv}
+      className={`usa-tooltip${toolTip.length < 100 ? " short-tooltip" : ""}`}
+    >
+      {content}
+    </Tooltip>
+  ) : (
+    <>{content}</>
+  );
+};

--- a/containers/ecr-viewer/src/app/services/formatService.tsx
+++ b/containers/ecr-viewer/src/app/services/formatService.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-
 import { ToolTipElement } from "@/app/ToolTipElement";
 
 interface Metadata {

--- a/containers/ecr-viewer/src/app/services/formatService.tsx
+++ b/containers/ecr-viewer/src/app/services/formatService.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { toolTipElement } from "@/app/utils";
+
+import { ToolTipElement } from "@/app/ToolTipElement";
 
 interface Metadata {
   [key: string]: string;
@@ -431,7 +432,9 @@ export const addCaptionToTable = (
   if (React.isValidElement(element) && element.type === "table") {
     return React.cloneElement(element, {}, [
       <caption key="caption">
-        <div className="data-title">{toolTipElement(caption, toolTip)}</div>
+        <div className="data-title">
+          <ToolTipElement content={caption} toolTip={toolTip} />
+        </div>
       </caption>,
       ...React.Children.toArray(element.props.children),
     ]);

--- a/containers/ecr-viewer/src/app/tests/utils.test.tsx
+++ b/containers/ecr-viewer/src/app/tests/utils.test.tsx
@@ -1,4 +1,4 @@
-import { isDataAvailable, TooltipDiv, toolTipElement } from "@/app/utils";
+import { isDataAvailable } from "@/app/utils";
 import { loadYamlConfig } from "@/app/api/utils";
 import { Bundle } from "fhir/r4";
 import BundleWithTravelHistory from "./assets/BundleTravelHistory.json";
@@ -26,6 +26,7 @@ import {
   returnProblemsTable,
 } from "../view-data/components/common";
 import { DataDisplay, DisplayDataProps } from "@/app/DataDisplay";
+import { TooltipDiv, ToolTipElement } from "@/app/ToolTipElement";
 
 describe("Utils", () => {
   const mappings = loadYamlConfig();
@@ -446,7 +447,7 @@ describe("Utils", () => {
       expect(tip.textContent).toInclude("Test child");
     });
     it("should make a tooltip", () => {
-      render(toolTipElement("Item Title", "Tooltip"));
+      render(<ToolTipElement content={"Item Title"} toolTip={"Tooltip"} />);
       const tip = screen.getByTestId("triggerElement");
       expect(tip.className).toInclude("short-tooltip");
       expect(tip.textContent).toInclude("Item Title");
@@ -454,7 +455,7 @@ describe("Utils", () => {
     it("should not make the tool tip short if the tip has more than 100 character", () => {
       const toolTip =
         "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890";
-      render(toolTipElement("Item Title", toolTip));
+      render(<ToolTipElement content={"Item Title"} toolTip={toolTip} />);
       const tip = screen.getByTestId("triggerElement");
       expect(tip.className).not.toInclude("short-tooltip");
     });

--- a/containers/ecr-viewer/src/app/utils.tsx
+++ b/containers/ecr-viewer/src/app/utils.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { removeHtmlElements } from "@/app/services/formatService";
-import { Tooltip } from "@trussworks/react-uswds";
 import { DisplayDataProps } from "@/app/DataDisplay";
 
 export interface PathMappings {
@@ -66,58 +65,4 @@ export const isDataAvailable = (item: DisplayDataProps): Boolean => {
     }
   }
   return true;
-};
-
-type CustomDivProps = React.PropsWithChildren<{
-  className?: string;
-}> &
-  JSX.IntrinsicElements["div"] &
-  React.RefAttributes<HTMLDivElement>;
-
-/**
- * `CustomDivForwardRef` is a React forward reference component that renders a div element
- *  with extended capabilities. This component supports all standard div properties along with
- *  additional features provided by `tooltipProps`.
- * @component
- * @param props - The props for the CustomDiv component.
- * @param props.className - CSS class to apply to the div element.
- * @param props.children - Child elements or content to be rendered within the div.
- * @param props.tooltipProps - Additional props to be spread into the div element, typically used for tooltip logic or styling.
- * @param ref - Ref forwarded to the div element.
- * @returns A React element representing a customizable div.
- */
-export const CustomDivForwardRef: React.ForwardRefRenderFunction<
-  HTMLDivElement,
-  CustomDivProps
-> = ({ className, children, ...tooltipProps }: CustomDivProps, ref) => (
-  <div ref={ref} className={className} {...tooltipProps}>
-    {children}
-  </div>
-);
-
-export const TooltipDiv = React.forwardRef(CustomDivForwardRef);
-
-/**
- * Creates a tooltip-wrapped element if a tooltip text is provided, or returns the content directly otherwise.
- * The tooltip is only applied when the `toolTip` parameter is not null or undefined. If the tooltip text
- * is less than 100 characters, a specific class `short-tooltip` is added to style the tooltip differently.
- * @param content - The content to be displayed, which can be any valid React node or text.
- * @param toolTip - The text for the tooltip. If this is provided, the content will be wrapped in a tooltip.
- * @returns A React JSX element containing either the plain content or content wrapped in a tooltip, depending on the tooltip parameter.
- */
-export const toolTipElement = (
-  content: string | undefined | null,
-  toolTip: string | undefined | null,
-): React.JSX.Element => {
-  return toolTip ? (
-    <Tooltip
-      label={toolTip}
-      asCustom={TooltipDiv}
-      className={`usa-tooltip${toolTip.length < 100 ? " short-tooltip" : ""}`}
-    >
-      {content}
-    </Tooltip>
-  ) : (
-    <>{content}</>
-  );
 };

--- a/containers/ecr-viewer/src/app/view-data/components/EcrMetadata.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrMetadata.tsx
@@ -4,7 +4,7 @@ import {
   AccordionDiv,
 } from "../component-utils";
 import { Table } from "@trussworks/react-uswds";
-import { toolTipElement } from "@/app/utils";
+import { ToolTipElement } from "@/app/ToolTipElement";
 import { ReportableConditions } from "../../services/ecrMetadataService";
 import { DataDisplay, DisplayDataProps } from "@/app/DataDisplay";
 import React from "react";
@@ -79,22 +79,28 @@ const EcrMetadata = ({
           <thead>
             <tr>
               <th className="reportability_summary_header">
-                {toolTipElement(
-                  "Reportable Condition",
-                  "List of conditions that caused this eCR to be sent to your jurisdiction based on the rules set up for routing eCRs by your jurisdiction in RCKMS (Reportable Condition Knowledge Management System). Can include multiple Reportable Conditions for one eCR.",
-                )}
+                <ToolTipElement
+                  content={"Reportable Condition"}
+                  toolTip={
+                    "List of conditions that caused this eCR to be sent to your jurisdiction based on the rules set up for routing eCRs by your jurisdiction in RCKMS (Reportable Condition Knowledge Management System). Can include multiple Reportable Conditions for one eCR."
+                  }
+                />
               </th>
               <th>
-                {toolTipElement(
-                  "RCKMS Rule Summary",
-                  "Reason(s) that this eCR was sent for this condition. Corresponds to your jurisdiction's rules for routing eCRs in RCKMS (Reportable Condition Knowledge Management System).",
-                )}
+                <ToolTipElement
+                  content={"RCKMS Rule Summary"}
+                  toolTip={
+                    "Reason(s) that this eCR was sent for this condition. Corresponds to your jurisdiction's rules for routing eCRs in RCKMS (Reportable Condition Knowledge Management System)."
+                  }
+                />
               </th>
               <th className="reportability_summary_header">
-                {toolTipElement(
-                  "Jurisdiction Sent eCR",
-                  "List of jurisdictions this eCR was sent to. Can include multiple jurisdictions depending on provider location, patient address, and jurisdictions onboarded to eCR.",
-                )}
+                <ToolTipElement
+                  content={"Jurisdiction Sent eCR"}
+                  toolTip={
+                    "List of jurisdictions this eCR was sent to. Can include multiple jurisdictions depending on provider location, patient address, and jurisdictions onboarded to eCR."
+                  }
+                />
               </th>
             </tr>
           </thead>


### PR DESCRIPTION
# PULL REQUEST

## Summary
- Move tooltips out of Utils folder and into its own file. 
- Change tooltips to be called as an Element rather than a function

## Related Issue
