### PR TITLE
Store date created in db table when eCRs are saved

### DIFF
--- a/containers/ecr-viewer/seed-scripts/sql/01-init.sql
+++ b/containers/ecr-viewer/seed-scripts/sql/01-init.sql
@@ -3,5 +3,6 @@
 CREATE TABLE IF NOT EXISTS fhir (
   ecr_id VARCHAR NOT NULL,
   data JSONB NOT NULL,
+  date_created TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   PRIMARY KEY (ecr_id)
 );

--- a/containers/ecr-viewer/src/app/api/services/listEcrDataService.ts
+++ b/containers/ecr-viewer/src/app/api/services/listEcrDataService.ts
@@ -44,7 +44,7 @@ export async function listEcrData() {
 const list_postgres = async () => {
   const { ParameterizedQuery: PQ } = pgPromise;
   const listFhir = new PQ({
-    text: "SELECT ecr_id FROM fhir",
+    text: "SELECT ecr_id, date_created FROM fhir",
   });
   try {
     return await database.manyOrNone(listFhir);
@@ -86,7 +86,9 @@ export const processListPostgres = (responseBody: any[]): ListEcr => {
   return responseBody.map((object) => {
     return {
       ecrId: object.ecr_id || "",
-      dateModified: "N/A",
+      dateModified: object.date_created
+        ? formatDateTime(new Date(object.date_created!).toISOString())
+        : "",
     };
   });
 };

--- a/containers/ecr-viewer/src/app/api/tests/listEcrDataService.test.tsx
+++ b/containers/ecr-viewer/src/app/api/tests/listEcrDataService.test.tsx
@@ -47,7 +47,10 @@ describe("listEcrDataService", () => {
     });
 
     it("should map each object in responseBody to the correct output structure", () => {
-      const responseBody: any[] = [{ ecr_id: "ecr1" }, { ecr_id: "ecr2" }];
+      const responseBody: any[] = [
+        { ecr_id: "ecr1", date_created: new Date() },
+        { ecr_id: "ecr2", date_created: new Date() },
+      ];
 
       const expected: ListEcr = [
         { ecrId: "ecr1", dateModified: expect.any(String) },


### PR DESCRIPTION
# PULL REQUEST

## Summary
- Add `date_created` column to `fhir` table, with type `TIMESTAMPTZ` (timestamp with time zone). Column sets default value to `NOW()`
- Adds date value to list eCR viewer when source is Postgres.

## Related Issue
Fixes #1847

## Screenshot: List eCR viewer with Postgres as source
<img width="1511" alt="Screenshot 2024-05-20 at 11 48 53" src="https://github.com/CDCgov/phdi/assets/40042932/d2d519ca-c361-475e-8679-bba8d6499939">

## Additional Information
- Note: Postgres stores `Date Created`, whereas AWS S3 stores "the object creation date OR the last modified date, whichever is the latest"

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
