### PR TITLE
Skip middleware re-route for openapi

### DIFF
--- a/containers/dibbs/dibbs/base_service.py
+++ b/containers/dibbs/dibbs/base_service.py
@@ -92,7 +92,10 @@ class BaseService:
 
         @self.app.middleware("http")
         async def rewrite_path(request: Request, call_next: callable) -> Response:
-            if request.url.path.startswith(self.service_path):
+            if (
+                request.url.path.startswith(self.service_path)
+                and "openapi.json" not in request.url.path
+            ):
                 request.scope["path"] = request.scope["path"].replace(
                     self.service_path, ""
                 )


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR adds a bypass to the DIBBs `BaseService` middleware, which is what we use in deployed environments to gateway route requests to the appropriate service. Terraform needs to prepend paths with service names, but to locate the `openapi.json` file that FastAPI uses to programmatically generate an openAPI schema for our apps, we need to be able to bypass this rerouting.

## Related Issue
Fix 1 of 3 for redoc issues