### PR TITLE
Make collections endpoint download a file

### DIFF
--- a/containers/message-refiner/app/main.py
+++ b/containers/message-refiner/app/main.py
@@ -88,7 +88,11 @@ async def get_uat_collection() -> FileResponse:
         / "assets"
         / "Message_Refiner_UAT.postman_collection.json"
     )
-    return FileResponse(uat_collection_path)
+    return FileResponse(
+        path=uat_collection_path,
+        media_type="application/json",
+        filename="Message_Refiner_Postman_Samples.json",
+    )
 
 
 @app.post(


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR makes the postman collection JSON file returned by our examples endpoint a downloadable, streamed file rather than just a file object. This means that hitting this endpoint should automatically download the file rather than simply open raw JSON in the browser.