### PR TITLE
[RELEASE]-1.4.10

### DIFF
--- a/.github/workflows/createNewRelease.yaml
+++ b/.github/workflows/createNewRelease.yaml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         container: ${{fromJson(needs.list-containers.outputs.all-containers)}}
-    uses: ./.github/actions/run-container-workflow
+    uses: CDCgov/phdi/.github/actions/run-container-workflow
     with:
       container: ${{ matrix.container }}
     secrets: inherit

--- a/.github/workflows/createNewRelease.yaml
+++ b/.github/workflows/createNewRelease.yaml
@@ -33,18 +33,13 @@ jobs:
       - check-commit-message
       - list-containers
     if: ${{ needs.check-commit-message.outputs.contains_release == 'true' }}
-    runs-on: ubuntu-22.04
     strategy:
       matrix:
         container: ${{fromJson(needs.list-containers.outputs.all-containers)}}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Run container workflow
-        uses: ./.github/actions/run-container-workflow
-        with:
-          container: ${{ matrix.container }}
+    uses: ./.github/actions/run-container-workflow
+      with:
+        container: ${{ matrix.container }}
+      secrets: inherit
 
   tag-release:
     name: Update phdi init version number

--- a/.github/workflows/createNewRelease.yaml
+++ b/.github/workflows/createNewRelease.yaml
@@ -37,9 +37,9 @@ jobs:
       matrix:
         container: ${{fromJson(needs.list-containers.outputs.all-containers)}}
     uses: ./.github/actions/run-container-workflow
-      with:
-        container: ${{ matrix.container }}
-      secrets: inherit
+    with:
+      container: ${{ matrix.container }}
+    secrets: inherit
 
   tag-release:
     name: Update phdi init version number

--- a/.github/workflows/createNewRelease.yaml
+++ b/.github/workflows/createNewRelease.yaml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         container: ${{fromJson(needs.list-containers.outputs.all-containers)}}
-    uses: CDCgov/phdi/.github/actions/run-container-workflow
+    uses: ./.github/workflows/run-container-workflow
     with:
       container: ${{ matrix.container }}
     secrets: inherit

--- a/.github/workflows/createNewRelease.yaml
+++ b/.github/workflows/createNewRelease.yaml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         container: ${{fromJson(needs.list-containers.outputs.all-containers)}}
-    uses: ./.github/workflows/run-container-workflow
+    uses: ./.github/workflows/run-container-workflow.yaml
     with:
       container: ${{ matrix.container }}
     secrets: inherit


### PR DESCRIPTION
# PULL REQUEST

## Summary
Reusable workflows with matrix strategy cannot be run as steps (must be their own [jobs](https://github.com/orgs/community/discussions/27362)) and pointed to the `workflows` directory, not `actions`

## Related Issue
Fixes #1976 

## Additional Information
Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
