### PR TITLE
Add relevant lab results to eCR Summary section

### DIFF
--- a/containers/ecr-viewer/src/app/DataDisplay.tsx
+++ b/containers/ecr-viewer/src/app/DataDisplay.tsx
@@ -52,6 +52,28 @@ export const DataDisplay: React.FC<{
     </div>
   );
 };
+
+/**
+ * Functional component for displaying (a list of) data tables.
+ * @param props - Props containing the item to be displayed.
+ * @param props.item - The data item to be displayed.
+ * @returns The JSX element representing the data table display.
+ */
+export const DataTableDisplay: React.FC<{
+  item: DisplayDataProps;
+}> = ({ item }): React.JSX.Element => {
+  item.dividerLine =
+    item.dividerLine == null || item.dividerLine == undefined
+      ? true
+      : item.dividerLine;
+  return (
+    <div>
+      <div className="grid-col-auto width-full text-pre-line">{item.value}</div>
+      {item.dividerLine ? <div className={"section__line_gray"} /> : ""}
+    </div>
+  );
+};
+
 /**
  * Functional component for displaying a value. If the value has a length greater than 500 characters, it will be split after 300 characters with a view more button to view the entire value.
  * @param value - props for the component

--- a/containers/ecr-viewer/src/app/api/fhirPath.yml
+++ b/containers/ecr-viewer/src/app/api/fhirPath.yml
@@ -115,6 +115,7 @@ procedureReason: "Procedure.reason.display"
 
 # Lab Info
 diagnosticReports: "Bundle.entry.resource.where(resourceType = 'DiagnosticReport')"
+observations: "Bundle.entry.resource.where(resourceType = 'Observation')"
 labResultDiv: "Bundle.entry.resource.section.where(code.coding[0].code = '30954-2').text"
 specimenCollectionTime: "Observation.extension[0].extension.where(url = 'specimen collection time').valueDateTime"
 specimenReceivedTime: "Observation.extension[0].extension.where(url = 'specimen receive time').valueDateTime"

--- a/containers/ecr-viewer/src/app/services/ecrSummaryService.ts
+++ b/containers/ecr-viewer/src/app/services/ecrSummaryService.ts
@@ -11,6 +11,7 @@ import {
   evaluatePatientAddress,
   evaluateFacilityAddress,
 } from "./evaluateFhirDataService";
+import { DisplayDataProps } from "../DataDisplay";
 
 /**
  * Evaluates and retrieves patient details from the FHIR bundle using the provided path mappings.
@@ -101,6 +102,37 @@ export const evaluateEcrSummaryAboutTheConditionDetails = (
       value: evaluate(fhirBundle, fhirPathMappings.rckmsTriggerSummaries)[0],
     },
   ];
+};
+
+/**
+ * Evaluates and retrieves relevant lab results from the FHIR bundle using the provided SNOMED code and path mappings.
+ * @param fhirBundle - The FHIR bundle containing patient data.
+ * @param fhirPathMappings - Object containing fhir path mappings.
+ * @param snomedCode - String containing the SNOMED code search parameter.
+ * @returns An array of lab result details objects containing title and value pairs.
+ */
+export const evaluateEcrSummaryRelevantLabResults = (
+  fhirBundle: Bundle,
+  fhirPathMappings: PathMappings,
+  snomedCode: string,
+) => {
+  const noData: string = "No matching lab results found in this eCR";
+  let resultsArray: DisplayDataProps[] = [];
+
+  if (!snomedCode) {
+    resultsArray.push({ value: noData, dividerLine: true });
+    return resultsArray;
+  }
+
+  // * Lab Results
+
+  // * If no data matches snomed code, return noData
+  if (resultsArray.length === 0) {
+    resultsArray.push({ value: noData, dividerLine: false });
+  }
+
+  resultsArray.push({ dividerLine: true });
+  return resultsArray;
 };
 
 /**

--- a/containers/ecr-viewer/src/app/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/services/labsService.tsx
@@ -384,14 +384,15 @@ export const evaluateOrganismsReportData = (
 /**
  * Evaluates lab information and RR data from the provided FHIR bundle and mappings.
  * @param fhirBundle - The FHIR bundle containing lab and RR data.
+ * @param labReports - An array of DiagnosticReport objects
  * @param mappings - An object containing the FHIR path mappings.
  * @returns An array of the Diagnostic reports Elements and Organization Display Data
  */
 export const evaluateLabInfoData = (
   fhirBundle: Bundle,
+  labReports: any[],
   mappings: PathMappings,
 ): LabReportElementData[] => {
-  const labReports = evaluate(fhirBundle, mappings["diagnosticReports"]);
   // the keys are the organization id, the value is an array of jsx elements of diagnsotic reports
   let organizationElements: ResultObject = {};
 

--- a/containers/ecr-viewer/src/app/tests/assets/BundleLab.json
+++ b/containers/ecr-viewer/src/app/tests/assets/BundleLab.json
@@ -447,6 +447,15 @@
                 "valueString": "#Result.1.2.840.114350.1.13.297.3.7.2.798268.1670844.Comp1"
               }
             ]
+          },
+          {
+            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/condition-code",
+            "coding": [
+              {
+                "code": "test-snomed",
+                "system": "http://snomed.info/sct"
+              }
+            ]
           }
         ],
         "subject": {
@@ -781,6 +790,15 @@
               {
                 "url": "observation entry reference value",
                 "valueString": "#Result.1.2.840.114350.1.13.478.3.7.2.798268.2061347.Narrative"
+              }
+            ]
+          },
+          {
+            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/condition-code",
+            "coding": [
+              {
+                "code": "test-snomed",
+                "system": "http://snomed.info/sct"
               }
             ]
           }

--- a/containers/ecr-viewer/src/app/tests/components/LabInfo.test.tsx
+++ b/containers/ecr-viewer/src/app/tests/components/LabInfo.test.tsx
@@ -6,12 +6,14 @@ import BundleLab from "@/app/tests/assets/BundleLab.json";
 import { loadYamlConfig } from "@/app/api/utils";
 import { Bundle } from "fhir/r4";
 import { evaluateLabInfoData } from "@/app/services/labsService";
+import { evaluate } from "@/app/view-data/utils/evaluate";
 
 const mappings = loadYamlConfig();
 
 describe("LabInfo", () => {
   const labinfoOrg = evaluateLabInfoData(
     BundleLab as unknown as Bundle,
+    evaluate(BundleLab, mappings["diagnosticReports"]),
     mappings,
   );
   const labInfoJsx = <LabInfo labResults={labinfoOrg} />;

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/EcrSummary.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/EcrSummary.test.tsx.snap
@@ -264,6 +264,12 @@ End: 05/13/2022 9:57 AM UTC
               class="section__line_gray"
             />
           </div>
+          <div
+            class="ecr-summary-title-long"
+            id="relevant-labs"
+          >
+            Lab Results Relevant to Reportable Condition
+          </div>
         </div>
       </div>
     </div>

--- a/containers/ecr-viewer/src/app/tests/services/ecrSummaryService.test.ts
+++ b/containers/ecr-viewer/src/app/tests/services/ecrSummaryService.test.ts
@@ -1,0 +1,52 @@
+import { loadYamlConfig } from "@/app/api/utils";
+import { evaluateEcrSummaryRelevantLabResults } from "@/app/services/ecrSummaryService";
+import BundleLab from "@/app/tests/assets/BundleLab.json";
+import { Bundle } from "fhir/r4";
+import { render, screen } from "@testing-library/react";
+
+const mappings = loadYamlConfig();
+
+describe("Evaluate eCR Summary Relevant Lab Results", () => {
+  it("should return 'No Data' string when no SNOMED code is provided", () => {
+    const expectedValue = "No matching lab results found in this eCR";
+    const actual = evaluateEcrSummaryRelevantLabResults(
+      BundleLab as unknown as Bundle,
+      mappings,
+      "",
+    );
+
+    expect(actual).toHaveLength(1);
+    expect(actual[0]["value"]).toEqual(expectedValue);
+  });
+
+  it("should return 'No Data' string when the provided SNOMED code has no matches", () => {
+    const expectedValue = "No matching lab results found in this eCR";
+    const actual = evaluateEcrSummaryRelevantLabResults(
+      BundleLab as unknown as Bundle,
+      mappings,
+      "invalid-snomed-code",
+    );
+
+    expect(actual).toHaveLength(1);
+    expect(actual[0]["value"]).toEqual(expectedValue);
+  });
+
+  it("should return the correct lab result(s) when the provided SNOMED code matches", () => {
+    const result = evaluateEcrSummaryRelevantLabResults(
+      BundleLab as unknown as Bundle,
+      mappings,
+      "test-snomed",
+    );
+    expect(result).toHaveLength(3); // 2 results, plus last item is divider line
+
+    render(result[0].value);
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(
+      screen.getByText("STOOL PATHOGENS, NAAT, 12 TO 25 TARGETS"),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("09/28/2022 8:51 PM UTC")).toHaveLength(2);
+
+    render(result[1].value);
+    expect(screen.getByText("Cytogenomic SNP microarray")).toBeInTheDocument();
+  });
+});

--- a/containers/ecr-viewer/src/app/tests/services/labsService.test.tsx
+++ b/containers/ecr-viewer/src/app/tests/services/labsService.test.tsx
@@ -460,6 +460,7 @@ describe("Evaluate the lab info section", () => {
   it("should return a list of objects", () => {
     const result = evaluateLabInfoData(
       BundleLab as unknown as Bundle,
+      evaluate(BundleLab, mappings["diagnosticReports"]),
       mappings,
     );
     expect(result[0]).toHaveProperty("diagnosticReportDataElements");
@@ -468,6 +469,7 @@ describe("Evaluate the lab info section", () => {
   it("should properly count the number of labs", () => {
     const result = evaluateLabInfoData(
       BundleLab as unknown as Bundle,
+      evaluate(BundleLab, mappings["diagnosticReports"]),
       mappings,
     );
     expect(result[0].organizationDisplayDataProps[3].title).toEqual(

--- a/containers/ecr-viewer/src/app/view-data/components/AccordionContent.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/AccordionContent.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/app/services/evaluateFhirDataService";
 import { evaluateClinicalData } from "./common";
 import AccordionContainer from "@/app/shared/src/accordion/AccordionContainer";
+import { evaluate } from "@/app/view-data/utils/evaluate";
 
 type AccordionContainerProps = {
   children?: ReactNode;
@@ -45,7 +46,11 @@ const AccordionContent: React.FC<AccordionContainerProps> = ({
   const providerData = evaluateProviderData(fhirBundle, fhirPathMappings);
   const clinicalData = evaluateClinicalData(fhirBundle, fhirPathMappings);
   const ecrMetadata = evaluateEcrMetadata(fhirBundle, fhirPathMappings);
-  const labInfoData = evaluateLabInfoData(fhirBundle, fhirPathMappings);
+  const labInfoData = evaluateLabInfoData(
+    fhirBundle,
+    evaluate(fhirBundle, fhirPathMappings["diagnosticReports"]),
+    fhirPathMappings,
+  );
   const accordionItems: any[] = [
     {
       title: "Patient Info",

--- a/containers/ecr-viewer/src/app/view-data/components/EcrSummary.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EcrSummary.tsx
@@ -1,10 +1,15 @@
 import React from "react";
-import { DataDisplay, DisplayDataProps } from "@/app/DataDisplay";
+import {
+  DataDisplay,
+  DataTableDisplay,
+  DisplayDataProps,
+} from "@/app/DataDisplay";
 
 interface EcrSummaryProps {
   patientDetails: DisplayDataProps[];
   encounterDetails: DisplayDataProps[];
   aboutTheCondition: DisplayDataProps[];
+  relevantLabs: DisplayDataProps[];
 }
 
 /**
@@ -12,13 +17,15 @@ interface EcrSummaryProps {
  * @param props - Properties for the eCR Viewer Summary section
  * @param props.patientDetails - Array of title and values to be displayed in patient details section
  * @param props.encounterDetails - Array of title and values to be displayed in encounter details section
- * @param props.aboutTheCondition - Array of title and values to be displayed in about the condition section
+ * @param props.aboutTheCondition - Array of title and values to be displayed about the condition section
+ * @param props.relevantLabs - Array of title and tables to be displayed about the relevant lab results
  * @returns a react element for ECR Summary
  */
 const EcrSummary: React.FC<EcrSummaryProps> = ({
   patientDetails,
   encounterDetails,
   aboutTheCondition,
+  relevantLabs,
 }) => {
   return (
     <div className={"info-container"}>
@@ -63,6 +70,12 @@ const EcrSummary: React.FC<EcrSummaryProps> = ({
             {aboutTheCondition.map((item) => (
               <DataDisplay item={item} key={item.title} />
             ))}
+            <div className="ecr-summary-title-long" id={"relevant-labs"}>
+              {"Lab Results Relevant to Reportable Condition"}
+            </div>
+            {relevantLabs &&
+              relevantLabs.length > 0 &&
+              relevantLabs.map((item) => <DataTableDisplay item={item} />)}
           </div>
         </div>
       </div>

--- a/containers/ecr-viewer/src/app/view-data/page.tsx
+++ b/containers/ecr-viewer/src/app/view-data/page.tsx
@@ -13,6 +13,7 @@ import {
   evaluateEcrSummaryPatientDetails,
   evaluateEcrSummaryEncounterDetails,
   evaluateEcrSummaryAboutTheConditionDetails,
+  evaluateEcrSummaryRelevantLabResults,
 } from "../services/ecrSummaryService";
 import { metrics } from "./component-utils";
 
@@ -107,6 +108,11 @@ const ECRViewerPage: React.FC = () => {
                     aboutTheCondition={evaluateEcrSummaryAboutTheConditionDetails(
                       fhirBundle,
                       mappings,
+                    )}
+                    relevantLabs={evaluateEcrSummaryRelevantLabResults(
+                      fhirBundle,
+                      mappings,
+                      snomedCode,
                     )}
                   />
                   <div className="margin-top-10">

--- a/containers/ecr-viewer/src/styles/custom-styles.scss
+++ b/containers/ecr-viewer/src/styles/custom-styles.scss
@@ -63,6 +63,11 @@ h4 {
   font-weight: bold;
 }
 
+.ecr-summary-title-long {
+  font-weight: bold;
+  margin-bottom: 8px;
+}
+
 .info-container > .usa-accordion__heading > .usa-accordion__button {
   font-size: 2rem;
   background-size: 2.25rem;


### PR DESCRIPTION
# PULL REQUEST

## Summary
Adds relevant lab results to the eCR Summary section
- Adds `evaluateEcrSummaryRelevantLabResults`: which filters for the relevant lab results given a SNOMED code and returns the relevant labs element(s).
- Adds relevant tests

## Related Issue
Fixes #1157

## Screenshots
**Given a valid SNOMED code**
![Screenshot 2024-06-21 at 14 37 57](https://github.com/CDCgov/phdi/assets/40042932/cec4afe3-a561-4296-8609-e8abdf56a974)

**Loom of relevant labs**
https://github.com/CDCgov/phdi/assets/40042932/4d3fdaf4-8985-4ba2-8ad7-8abee4523ac8

**Given an absent or invalid SNOMED code**
![Screenshot 2024-06-21 at 14 37 34](https://github.com/CDCgov/phdi/assets/40042932/26913fa8-1c18-4898-b2a4-e796688ed967)

## Checklist
Note: No seed data has been stamped yet with condition codes via the trigger-code-reference service. You can test this by:
- [ ] Running the `trigger-code-reference` service on an eICR
    - eICR to try:`61f13d32-b25c-4fb6-998b-73de2dbf87f2`. This particular eCR should stamp 10 resources: 1 Condition and 9 Observations
    - Check `/containers/trigger-code-reference/description.md` for running the service from Python
- [ ] Add the output FHIR bundle to your local db
- [ ] Check the resulting eCR viewer of the bundle, and add `&snomed-code=840539006` (COVID) as a URL search param. This should bubble up relevant COVID labs to the eCR summary.
    - For `61f13d32-b25c-4fb6-998b-73de2dbf87f2`, it should bubble up 6 lab reports labeled `SARS-CoV-2 PCR`

[//]: # (PR title: Remember to name your PR descriptively!)
