### PR TITLE
Create TEFCA Viewer FormatString Unit Tests

### DIFF
--- a/containers/tefca-viewer/src/app/format-service.tsx
+++ b/containers/tefca-viewer/src/app/format-service.tsx
@@ -14,10 +14,10 @@ export const formatString = (input: string): string => {
   // Convert to lowercase
   let result = input.toLowerCase();
 
-  // Replace spaces with underscores
+  // Replace spaces with dashes
   result = result.replace(/\s+/g, "-");
 
-  // Remove all special characters except underscores
+  // Remove all special characters except dashes
   result = result.replace(/[^a-z0-9\-]/g, "");
 
   return result;

--- a/containers/tefca-viewer/src/app/tests/format-service.test.tsx
+++ b/containers/tefca-viewer/src/app/tests/format-service.test.tsx
@@ -1,7 +1,7 @@
-import { formatDate, formatName } from "@/app/format-service";
+import { formatDate, formatName, formatString } from "@/app/format-service";
 import { HumanName } from "fhir/r4";
 
-describe("Format Date", () => {
+describe.only("Format Date", () => {
   it("should return the correct formatted date", () => {
     const inputDate = "2023-01-15";
     const expectedDate = "01/15/2023";
@@ -84,5 +84,28 @@ describe.only("formatName", () => {
     ];
     const result = formatName(names);
     expect(result).toBe("");
+  });
+});
+
+describe.only("Format String", () => {
+  it("should convert all character to lower case", () => {
+    const inputString = "TestOfSomeCAPITALS";
+    const expectedString = "testofsomecapitals";
+    const result = formatString(inputString);
+    expect(result).toEqual(expectedString);
+  });
+
+  it("should also replace all spaces with underscores", () => {
+    const inputString = "JoHn ShEpArD";
+    const expectedString = "john-shepard";
+    const result = formatString(inputString);
+    expect(result).toEqual(expectedString);
+  });
+
+  it("should remove all non alpha-numeric characters", () => {
+    const inputString = "*C0MPL3X_$TR!NG*";
+    const expectedString = "c0mpl3xtrng";
+    const result = formatString(inputString);
+    expect(result).toEqual(expectedString);
   });
 });

--- a/containers/tefca-viewer/src/app/tests/format-service.test.tsx
+++ b/containers/tefca-viewer/src/app/tests/format-service.test.tsx
@@ -1,5 +1,10 @@
 import { render } from "@testing-library/react";
-import { formatDate, formatAddress, formatName, formatString } from "@/app/format-service";
+import {
+  formatDate,
+  formatAddress,
+  formatName,
+  formatString,
+} from "@/app/format-service";
 import { Address, HumanName } from "fhir/r4";
 
 describe("Format Date", () => {

--- a/containers/tefca-viewer/src/app/tests/format-service.test.tsx
+++ b/containers/tefca-viewer/src/app/tests/format-service.test.tsx
@@ -1,7 +1,7 @@
 import { formatDate, formatName, formatString } from "@/app/format-service";
 import { HumanName } from "fhir/r4";
 
-describe.only("Format Date", () => {
+describe("Format Date", () => {
   it("should return the correct formatted date", () => {
     const inputDate = "2023-01-15";
     const expectedDate = "01/15/2023";
@@ -32,7 +32,7 @@ describe.only("Format Date", () => {
   });
 });
 
-describe.only("formatName", () => {
+describe("formatName", () => {
   it("should format a single HumanName correctly", () => {
     const names: HumanName[] = [
       {
@@ -87,7 +87,7 @@ describe.only("formatName", () => {
   });
 });
 
-describe.only("Format String", () => {
+describe("Format String", () => {
   it("should convert all character to lower case", () => {
     const inputString = "TestOfSomeCAPITALS";
     const expectedString = "testofsomecapitals";


### PR DESCRIPTION
# PULL REQUEST

## Summary
This test creates some unit tests for the format string function in our format-services.tsx file. Each condition of the function is given a test case. It also corrects an absolutely egregious comment that refers to hypens/dashes as underscores 🤣 (which made me stare at my output and failing tests for longer than I care to admit).

## Related Issue
Fixes #1738 
