### PR TITLE
TEFCA Viewer unit tests for formatContact

### DIFF
--- a/containers/tefca-viewer/src/app/format-service.tsx
+++ b/containers/tefca-viewer/src/app/format-service.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import {
   CodeableConcept,
   HumanName,
@@ -104,18 +105,18 @@ export function formatAddress(address: Address[]): JSX.Element {
 export function formatContact(contacts: ContactPoint[]): JSX.Element {
   return (
     <>
-      {contacts.map((contact) => {
+      {contacts.map((contact, index) => {
         if (contact.system === "phone") {
           return (
-            <>
+            <React.Fragment key={index}>
               {contact.use}: {contact.value} <br />
-            </>
+            </React.Fragment>
           );
         } else if (contact.system === "email") {
           return (
-            <>
+            <React.Fragment key={index}>
               {contact.value} <br />
-            </>
+            </React.Fragment>
           );
         }
         return null;

--- a/containers/tefca-viewer/src/app/tests/format-service.test.tsx
+++ b/containers/tefca-viewer/src/app/tests/format-service.test.tsx
@@ -230,7 +230,7 @@ describe("formatContact", () => {
 
     const { getByText } = render(formatContact(contacts));
     expect(getByText(/home:\s123-456-7890/)).toBeInTheDocument();
-    expect(getByText("test@example.com")).toBeInTheDocument();
+    expect(getByText(/test@example.com/)).toBeInTheDocument();
   });
 
   it("should return null for unsupported contact system", () => {

--- a/containers/tefca-viewer/src/app/tests/format-service.test.tsx
+++ b/containers/tefca-viewer/src/app/tests/format-service.test.tsx
@@ -9,7 +9,6 @@ import {
 } from "@/app/format-service";
 import { Address, HumanName, ContactPoint, Identifier } from "fhir/r4";
 
-
 describe("Format Date", () => {
   it("should return the correct formatted date", () => {
     const inputDate = "2023-01-15";

--- a/containers/tefca-viewer/src/app/tests/format-service.test.tsx
+++ b/containers/tefca-viewer/src/app/tests/format-service.test.tsx
@@ -1,11 +1,12 @@
 import { render } from "@testing-library/react";
 import {
-  formatDate,
   formatAddress,
+  formatContact,
+  formatDate,
   formatName,
   formatString,
 } from "@/app/format-service";
-import { Address, HumanName } from "fhir/r4";
+import { Address, HumanName, ContactPoint } from "fhir/r4";
 
 describe("Format Date", () => {
   it("should return the correct formatted date", () => {
@@ -185,5 +186,69 @@ describe("formatAddress", () => {
     ];
     const { getByText } = render(formatAddress(address));
     expect(getByText("123 Main St")).toBeInTheDocument();
+  });
+});
+
+describe("formatContact", () => {
+  it("should format phone contact correctly", () => {
+    const contacts: ContactPoint[] = [
+      {
+        system: "phone",
+        value: "123-456-7890",
+        use: "home",
+      },
+    ];
+
+    const { getByText } = render(formatContact(contacts));
+    expect(getByText("home: 123-456-7890")).toBeInTheDocument();
+  });
+
+  it("should format email contact correctly", () => {
+    const contacts: ContactPoint[] = [
+      {
+        system: "email",
+        value: "test@example.com",
+      },
+    ];
+
+    const { getByText } = render(formatContact(contacts));
+    expect(getByText("test@example.com")).toBeInTheDocument();
+  });
+
+  it("should handle mixed contact types correctly", () => {
+    const contacts: ContactPoint[] = [
+      {
+        system: "phone",
+        value: "123-456-7890",
+        use: "home",
+      },
+      {
+        system: "email",
+        value: "test@example.com",
+      },
+    ];
+
+    const { getByText } = render(formatContact(contacts));
+    expect(getByText(/home:\s123-456-7890/)).toBeInTheDocument();
+    expect(getByText("test@example.com")).toBeInTheDocument();
+  });
+
+  it("should return null for unsupported contact system", () => {
+    const contacts: ContactPoint[] = [
+      {
+        system: "idk",
+        value: "it was on the form",
+      },
+    ];
+
+    const { container } = render(formatContact(contacts));
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("should handle empty contact array gracefully", () => {
+    const contacts: ContactPoint[] = [];
+
+    const { container } = render(formatContact(contacts));
+    expect(container).toBeEmptyDOMElement();
   });
 });


### PR DESCRIPTION
# PULL REQUEST

## Summary
adds unit tests for formatContact

## Related Issue
Fixes #1993 

## Additional Information
The test got fussy about indices when there were two forms of contact. The change to the `formatContact` function is what I found online as a a way to have the index, but if there's another way we should handle 2+ forms of contact info, happy to discuss.

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
