### PR TITLE
Adding unit tests to TEFCA Viewer's GitHub CI

### DIFF
--- a/.github/workflows/container-tefca-viewer.yaml
+++ b/.github/workflows/container-tefca-viewer.yaml
@@ -35,6 +35,27 @@ jobs:
         run: |
           npm ci
           npm run lint
+  test-node-containers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{env.NODE_VERSION}}
+      # - name: Remove symlinks
+      #   working-directory: ./containers/${{env.CONTAINER}}/src/app/shared
+      #   run: rm -rf ./*
+      # - name: Copy shared-resources
+      #   working-directory: ./containers/${{env.CONTAINER}}
+      #   run: cp -r ../../shared-resources/src/ ./src/app/shared/
+      - name: Install dependencies
+        working-directory: ./containers/${{env.CONTAINER}} # Navigate to your Node.js app directory
+        run: npm install
+      - name: Run tests
+        working-directory: ./containers/${{env.CONTAINER}} # Navigate to your Node.js app directory
+        run: npm test
   build-container:
     runs-on: ubuntu-latest
     steps:
@@ -49,6 +70,14 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+
+      # - name: Remove symlinks
+      #   working-directory: ./containers/${{env.CONTAINER}}/src/app/shared
+      #   run: rm -rf ./*
+
+      # - name: Copy shared-resources
+      #   working-directory: ./containers/${{env.CONTAINER}}
+      #   run: cp -r ../../shared-resources/src/ ./src/app/shared/
 
       - name: Build ${{ env.CONTAINER }} Container
         uses: docker/build-push-action@v3

--- a/containers/tefca-viewer/package.json
+++ b/containers/tefca-viewer/package.json
@@ -10,10 +10,9 @@
     "build": "next build && cp -r .next/static .next/standalone/.next && cp -r public .next/standalone/",
     "start": "NODE_TLS_REJECT_UNAUTHORIZED=0 node .next/standalone/server.js",
     "lint": "next lint",
-    "test": "npm run test:unit && npm run test:integration",
+    "test": "npm run test:unit",
     "test:unit": "TZ=America/New_York jest",
     "test:unit:watch": "jest --watch",
-    "test:integration": "mocha --timeout 600000 tests/integration/test_tefca-viewer.js",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run"
   },


### PR DESCRIPTION
# PULL REQUEST

## Summary
This turns on the GitHub CI for TEFCA Viewer. It largely follows the structure of the ecr-viewer's config, with the exception of the cypress e2e testing.

This PR also removes the current, stale integration tests from tefca-viewer's repo to avoid an error. I think next step will need to be to determine if we want to implement cypress e2e and whether we prefer what is done that way to integration tests.

Another note: I don't know if I fully understand the symlink stuff. I thought we had this shared directory so that TEFCA could use it, but if it is, it seems to be used differently to how ecr-viewer has it set up. I've left it commented out for now, but I don't know if we need to update this based on how we use it. I also know we are looking to set up a dibbs-style container for this shared code (I think), so maybe we hold off until that's done then implement.

## Related Issue
Fixes #1731 

## Additional Information
Just some lingering questions noted above. Not sure if they are blockers, but at the least, may be worth chatting about in a short call and/or parking lot.

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
