### PR TITLE
Fix wrapping in Active Problems table

### DIFF
--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/Clinical.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/Clinical.test.tsx.snap
@@ -71,7 +71,7 @@ exports[`Snapshot test for Clinical Notes should match snapshot for table notes 
           <div>
             <div>
               <div
-                class="grid-col-auto text-pre-line "
+                class="grid-col-auto text-pre-line"
               >
                 <table>
                   <caption>

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/Clinical.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/Clinical.test.tsx.snap
@@ -71,7 +71,7 @@ exports[`Snapshot test for Clinical Notes should match snapshot for table notes 
           <div>
             <div>
               <div
-                class="grid-col-auto text-pre-line"
+                class="grid-col-auto text-pre-line "
               >
                 <table>
                   <caption>

--- a/containers/ecr-viewer/src/app/view-data/components/ClinicalInfo.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/ClinicalInfo.tsx
@@ -4,6 +4,7 @@ import {
   AccordionDiv,
 } from "../component-utils";
 import React from "react";
+import classNames from "classnames";
 import { addCaptionToTable } from "@/app/services/formatService";
 import {
   DataDisplay,
@@ -41,13 +42,15 @@ export const ClinicalInfo = ({
 }: ClinicalProps) => {
   const renderTableDetails = (
     tableDetails: DisplayDataProps[],
-    className: string = "",
+    className?: string,
   ) => {
     return (
       <div>
         {tableDetails.map((item, index) => (
           <div key={index}>
-            <div className={`grid-col-auto text-pre-line ${className}`}>
+            <div
+              className={classNames("grid-col-auto text-pre-line", className)}
+            >
               {item.value}
             </div>
             <div className={"section__line_gray"} />

--- a/containers/ecr-viewer/src/app/view-data/components/ClinicalInfo.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/ClinicalInfo.tsx
@@ -39,12 +39,17 @@ export const ClinicalInfo = ({
   treatmentData,
   clinicalNotes,
 }: ClinicalProps) => {
-  const renderTableDetails = (tableDetails: DisplayDataProps[]) => {
+  const renderTableDetails = (
+    tableDetails: DisplayDataProps[],
+    className: string = "",
+  ) => {
     return (
       <div>
         {tableDetails.map((item, index) => (
           <div key={index}>
-            <div className="grid-col-auto text-pre-line">{item.value}</div>
+            <div className={`grid-col-auto text-pre-line ${className}`}>
+              {item.value}
+            </div>
             <div className={"section__line_gray"} />
           </div>
         ))}
@@ -96,7 +101,10 @@ export const ClinicalInfo = ({
             ))}
           </div>
           <div data-testid="active-problems">
-            {renderTableDetails(activeProblemsDetails)}
+            {renderTableDetails(
+              activeProblemsDetails,
+              "table-clinical-problems",
+            )}
           </div>
         </AccordionDiv>
       </>

--- a/containers/ecr-viewer/src/styles/custom-styles.scss
+++ b/containers/ecr-viewer/src/styles/custom-styles.scss
@@ -129,7 +129,7 @@ h4 {
 }
 
 .usa-table {
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
   thead th {
     background-color: #F0F0F0;
     vertical-align: top;
@@ -148,6 +148,15 @@ h4 {
 
   tbody td:first-child {
     width: 644px;
+  }
+}
+
+.table-clinical-problems {
+  tbody td:nth-child(2) {
+    min-width: 130px;
+  }
+  tbody td:nth-child(3) {
+    min-width: 100px;
   }
 }
 


### PR DESCRIPTION
# PULL REQUEST

## Summary
Fix Active Problems table (Clinical Info section) such that `Onset Date` and `Onset Age` columns are not wrapped (both text and headers)
- sets a minimum width for those columns (130px for `Onset Date` and 100px for `Onset Age`)

## Screenshot (mulitple eCRs)
<img width="1151" alt="Screenshot 2024-07-02 at 10 03 37" src="https://github.com/CDCgov/phdi/assets/40042932/e4ef799f-f48e-4255-a25a-e268b48756fb">
<img width="1171" alt="Screenshot 2024-07-02 at 10 03 47" src="https://github.com/CDCgov/phdi/assets/40042932/ee939fba-554b-422b-9c1d-4cce44a426e4">
<img width="1180" alt="Screenshot 2024-07-02 at 10 04 02" src="https://github.com/CDCgov/phdi/assets/40042932/a7efa70a-4026-4e3b-a72f-9c6275eb1821">

## Related Issue
Fixes #2043 

[//]: # (PR title: Remember to name your PR descriptively!)
