### PR TITLE
Add OperationOutcomes to error handling

### DIFF
--- a/containers/tefca-viewer/src/app/api/query/error-handling-service.ts
+++ b/containers/tefca-viewer/src/app/api/query/error-handling-service.ts
@@ -1,5 +1,11 @@
 import { OperationOutcome } from "fhir/r4";
 
+/**
+ * Handles a request error by returning an OperationOutcome with a diagnostics message.
+ * @param diagnostics_message - The message to be included in the `diagnostics` section
+ * of the OperationOutcome.
+ * @returns OperationOutcome with the included error message.
+ */
 export async function handleRequestError(
   diagnostics_message: string
 ): Promise<OperationOutcome> {

--- a/containers/tefca-viewer/src/app/api/query/error-handling-service.ts
+++ b/containers/tefca-viewer/src/app/api/query/error-handling-service.ts
@@ -7,7 +7,7 @@ import { OperationOutcome } from "fhir/r4";
  * @returns OperationOutcome with the included error message.
  */
 export async function handleRequestError(
-  diagnostics_message: string
+  diagnostics_message: string,
 ): Promise<OperationOutcome> {
   const OperationOutcome: OperationOutcome = {
     resourceType: "OperationOutcome",

--- a/containers/tefca-viewer/src/app/api/query/error-handling-service.ts
+++ b/containers/tefca-viewer/src/app/api/query/error-handling-service.ts
@@ -1,0 +1,17 @@
+import { OperationOutcome } from "fhir/r4";
+
+export async function handleRequestError(
+  diagnostics_message: string
+): Promise<OperationOutcome> {
+  const OperationOutcome: OperationOutcome = {
+    resourceType: "OperationOutcome",
+    issue: [
+      {
+        severity: "error",
+        code: "invalid",
+        diagnostics: diagnostics_message,
+      },
+    ],
+  };
+  return OperationOutcome;
+}

--- a/containers/tefca-viewer/src/app/api/query/route.ts
+++ b/containers/tefca-viewer/src/app/api/query/route.ts
@@ -14,7 +14,7 @@ import {
   UseCases,
 } from "../../constants";
 
-import { OperationOutcome } from "fhir/r4";
+import { handleRequestError } from "./error-handling-service";
 
 /**
  * Health check for TEFCA Viewer
@@ -39,16 +39,8 @@ export async function POST(request: NextRequest) {
   try {
     requestBody = await request.json();
   } catch (error: any) {
-    const OperationOutcome: OperationOutcome = {
-      resourceType: "OperationOutcome",
-      issue: [
-        {
-          severity: "error",
-          code: "invalid",
-          diagnostics: `Error reading request body. ${error.message}`,
-        },
-      ],
-    };
+    const diagnostics_message = `Error reading request body. ${error.message}`;
+    const OperationOutcome = await handleRequestError(diagnostics_message);
     return NextResponse.json(OperationOutcome);
   }
 
@@ -56,16 +48,9 @@ export async function POST(request: NextRequest) {
   try {
     PatientIdentifiers = await parsePatientDemographics(requestBody);
   } catch (error: any) {
-    const OperationOutcome: OperationOutcome = {
-      resourceType: "OperationOutcome",
-      issue: [
-        {
-          severity: "error",
-          code: "invalid",
-          diagnostics: "Error parsing patient identifiers from requestBody.",
-        },
-      ],
-    };
+    const diagnostics_message =
+      "Error parsing patient identifiers from requestBody.";
+    const OperationOutcome = await handleRequestError(diagnostics_message);
     return NextResponse.json(OperationOutcome);
   }
 
@@ -75,43 +60,18 @@ export async function POST(request: NextRequest) {
   const fhir_server = params.get("fhir_server");
 
   if (!use_case || !fhir_server) {
-    const OperationOutcome: OperationOutcome = {
-      resourceType: "OperationOutcome",
-      issue: [
-        {
-          severity: "error",
-          code: "invalid",
-          diagnostics: "Invalid use_case or fhir_server.",
-        },
-      ],
-    };
+    const diagnostics_message = "Missing use_case or fhir_server.";
+    const OperationOutcome = await handleRequestError(diagnostics_message);
     return NextResponse.json(OperationOutcome);
   } else if (!Object.values(UseCases).includes(use_case as USE_CASES)) {
-    const OperationOutcome: OperationOutcome = {
-      resourceType: "OperationOutcome",
-      issue: [
-        {
-          severity: "error",
-          code: "invalid",
-          diagnostics: `Invalid use_case. Please provide a valid use_case. Valid use_cases include ${UseCases}.`,
-        },
-      ],
-    };
-
+    const diagnostics_message = `Invalid use_case. Please provide a valid use_case. Valid use_cases include ${UseCases}.`;
+    const OperationOutcome = await handleRequestError(diagnostics_message);
     return NextResponse.json(OperationOutcome);
   } else if (
     !Object.values(FhirServers).includes(fhir_server as FHIR_SERVERS)
   ) {
-    const OperationOutcome: OperationOutcome = {
-      resourceType: "OperationOutcome",
-      issue: [
-        {
-          severity: "error",
-          code: "invalid",
-          diagnostics: `Invalid fhir_server. Please provide a valid fhir_server. Valid fhir_servers include ${FhirServers}.`,
-        },
-      ],
-    };
+    const diagnostics_message = `Invalid fhir_server. Please provide a valid fhir_server. Valid fhir_servers include ${FhirServers}.`;
+    const OperationOutcome = await handleRequestError(diagnostics_message);
     return NextResponse.json(OperationOutcome);
   }
 

--- a/containers/tefca-viewer/src/app/api/query/route.ts
+++ b/containers/tefca-viewer/src/app/api/query/route.ts
@@ -39,11 +39,17 @@ export async function POST(request: NextRequest) {
   try {
     requestBody = await request.json();
   } catch (error: any) {
-    console.error("Error reading request body:", error);
-    return NextResponse.json(
-      { message: "Error reading request body. " + error.message },
-      { status: error.status }
-    );
+    const OperationOutcome: OperationOutcome = {
+      resourceType: "OperationOutcome",
+      issue: [
+        {
+          severity: "error",
+          code: "invalid",
+          diagnostics: `Error reading request body. ${error.message}`,
+        },
+      ],
+    };
+    return NextResponse.json(OperationOutcome);
   }
 
   // Parse patient identifiers from requestBody


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR updates the error messages for validation steps in the the POST request to use OperationOutcome resources to better conform to FHIR API standards.

For each error, a const `OperationOutcome` is created with the specifics of the error included in the `diagnostics` section. The `OperationOutcome` is a fhir/r4 `OperationOutcome` type.


## Related Issue
Fixes #2036 

## Additional Information
Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
