### PR TITLE
If matching org exists, copy telecom over

### DIFF
--- a/containers/ecr-viewer/src/app/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/services/labsService.tsx
@@ -606,7 +606,7 @@ const findIdenticalOrg = (
   orgMappings = orgMappings.filter(
     (organization) => organization?.id !== matchedOrg?.id,
   );
-  orgMappings.filter((organization) => {
+  orgMappings.forEach((organization) => {
     if (
       organization?.address?.[0]?.line?.[0] ===
         matchedOrg?.address?.[0]?.line?.[0] &&

--- a/containers/ecr-viewer/src/app/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/services/labsService.tsx
@@ -593,7 +593,7 @@ export const evaluateLabOrganizationData = (
 /**
  * Finds an identical organization based on address and assigns the telecom to the matched organization
  * First filters out matchedOrg from orgMappings to avoid comparing to itself
- * Checks if addrress line 0, address line 1, city, state, and postal code are the same, if so
+ * Checks if address line 0, address line 1, city, state, and postal code are the same, if so
  * it assigns the telecom to the matchedOrg
  * @param orgMappings all the organizations found in the fhir bundle
  * @param matchedOrg the org that matches the id of the lab

--- a/containers/ecr-viewer/src/app/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/services/labsService.tsx
@@ -559,9 +559,12 @@ export const evaluateLabOrganizationData = (
   labReportCount: number,
 ) => {
   const orgMappings = evaluate(fhirBundle, mappings["organizations"]);
-  const matchingOrg: Organization = orgMappings.filter(
+  let matchingOrg: Organization = orgMappings.filter(
     (organization) => organization.id === id,
   )[0];
+  if (matchingOrg) {
+    matchingOrg = findIdenticalOrg(orgMappings, matchingOrg);
+  }
   const orgAddress = matchingOrg?.address?.[0];
   const streetAddress = orgAddress?.line ?? [];
   const city = orgAddress?.city ?? "";
@@ -585,6 +588,41 @@ export const evaluateLabOrganizationData = (
     { title: "Number of Results", value: labReportCount },
   ];
   return matchingOrgData;
+};
+
+/**
+ * Finds an identical organization based on address and assigns the telecom to the matched organization
+ * First filters out matchedOrg from orgMappings to avoid comparing to itself
+ * Checks if addrress line 0, address line 1, city, state, and postal code are the same, if so
+ * it assigns the telecom to the matchedOrg
+ * @param orgMappings all the organizations found in the fhir bundle
+ * @param matchedOrg the org that matches the id of the lab
+ * @returns the matchedOrg with the telecom assigned if applicable
+ */
+const findIdenticalOrg = (
+  orgMappings: any[],
+  matchedOrg: Organization,
+): Organization => {
+  orgMappings = orgMappings.filter(
+    (organization) => organization?.id !== matchedOrg?.id,
+  );
+  orgMappings.filter((organization) => {
+    if (
+      organization?.address?.[0]?.line?.[0] ===
+        matchedOrg?.address?.[0]?.line?.[0] &&
+      organization?.address?.[0]?.line?.[1] ===
+        matchedOrg?.address?.[0]?.line?.[1] &&
+      organization?.address?.[0]?.city === matchedOrg?.address?.[0]?.city &&
+      organization?.address?.[0]?.state === matchedOrg?.address?.[0]?.state &&
+      organization?.address?.[0]?.postalCode ===
+        matchedOrg?.address?.[0]?.postalCode
+    ) {
+      Object.assign(matchedOrg, {
+        telecom: organization.telecom,
+      });
+    }
+  });
+  return matchedOrg;
 };
 
 /**

--- a/containers/ecr-viewer/src/app/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/services/labsService.tsx
@@ -592,22 +592,19 @@ export const evaluateLabOrganizationData = (
 
 /**
  * Finds an identical organization based on address and assigns the telecom to the matched organization
- * First filters out matchedOrg from orgMappings to avoid comparing to itself
- * Checks if address line 0, address line 1, city, state, and postal code are the same, if so
- * it assigns the telecom to the matchedOrg
+ * Checks if id is not the same to avoid comparing to itself as well as address line 0, address line 1,
+ * city, state, and postal code are the same, if so it assigns the telecom to the matchedOrg
  * @param orgMappings all the organizations found in the fhir bundle
  * @param matchedOrg the org that matches the id of the lab
  * @returns the matchedOrg with the telecom assigned if applicable
  */
-const findIdenticalOrg = (
+export const findIdenticalOrg = (
   orgMappings: any[],
   matchedOrg: Organization,
 ): Organization => {
-  orgMappings = orgMappings.filter(
-    (organization) => organization?.id !== matchedOrg?.id,
-  );
   orgMappings.forEach((organization) => {
     if (
+      organization?.id !== matchedOrg?.id &&
       organization?.address?.[0]?.line?.[0] ===
         matchedOrg?.address?.[0]?.line?.[0] &&
       organization?.address?.[0]?.line?.[1] ===


### PR DESCRIPTION
# PULL REQUEST
### Before 
<img width="1673" alt="Screen Shot 2024-07-10 at 4 59 34 PM" src="https://github.com/CDCgov/phdi/assets/21372324/06450d41-9bfe-4e8c-8398-cf2b378e2175">

### After
<img width="1087" alt="Screen Shot 2024-07-10 at 4 32 57 PM" src="https://github.com/CDCgov/phdi/assets/21372324/6d5db30d-37c7-414e-84da-2729de319589">

## Summary
- It appears that Orgs that match DiagnosticReports sometimes don't have telecom. But the Organization of those Observations of those Diagnostic Report does. Check to see if an Org has a matching org in fhir bundle and if so, copy telecom
- Added function findIdenticalOrg() 
- Checks if address line 0, address line 1, city, state, and postal code are the same, if so it assigns the telecom to the matchedOrg

## Related Issue
Fixes #2080 

## Additional Information
Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
