### PR TITLE
Refactor table elements

### DIFF
--- a/containers/ecr-viewer/src/app/services/labsService.tsx
+++ b/containers/ecr-viewer/src/app/services/labsService.tsx
@@ -290,6 +290,7 @@ export function evaluateObservationTable(
         resources={observations}
         mappings={mappings}
         columns={columnInfo}
+        className={"margin-y-0"}
         outerBorder={false}
       />
     );
@@ -377,6 +378,7 @@ export const evaluateOrganismsReportData = (
       resources={components}
       mappings={mappings}
       columns={columnInfo}
+      className={"margin-y-0"}
       outerBorder={false}
     />
   );

--- a/containers/ecr-viewer/src/app/tests/components/EvaluateTable.test.tsx
+++ b/containers/ecr-viewer/src/app/tests/components/EvaluateTable.test.tsx
@@ -3,8 +3,11 @@ import { render, screen } from "@testing-library/react";
 import { PathMappings } from "@/app/utils";
 import userEvent from "@testing-library/user-event";
 import EvaluateTable, {
+  BuildHeaders,
+  BuildTable,
   ColumnInfoInput,
 } from "@/app/view-data/components/EvaluateTable";
+import { JSX } from "react";
 
 const mappings = loadYamlConfig();
 
@@ -209,5 +212,58 @@ describe("Evaluate table", () => {
         "2",
       );
     });
+  });
+});
+
+describe("BuildHeaders", () => {
+  it("should render headers with correct names and class names", () => {
+    const columns = [
+      { columnName: "Column 1", className: "custom-class-1" },
+      { columnName: "Column 2", className: "custom-class-2" },
+    ];
+
+    const headers = BuildHeaders(columns);
+
+    headers.forEach((header, index) => {
+      expect(header.props.children).toEqual(columns[index].columnName);
+      expect(header.props.className).toContain(columns[index].className);
+    });
+  });
+});
+
+describe("BuildTable", () => {
+  let headers: JSX.Element[], tableRows: JSX.Element[];
+
+  beforeEach(() => {
+    headers = [
+      <th key="column1" className="tableHeader">
+        Column 1
+      </th>,
+      <th key="column2" className="tableHeader">
+        Column 2
+      </th>,
+    ];
+
+    tableRows = [
+      <tr key="row1">
+        <td>Row 1, Col 1</td>
+        <td>Row 1, Col 2</td>
+      </tr>,
+    ];
+  });
+
+  it("should render table with correct class name", () => {
+    const { container } = render(
+      <BuildTable
+        headers={headers}
+        tableRows={tableRows}
+        caption="Table Test"
+        className="custom-class-1 custom-class-2"
+      />,
+    );
+    const tableElement = container.querySelector("table");
+
+    expect(tableElement).toHaveClass("custom-class-1");
+    expect(tableElement).toHaveClass("custom-class-2");
   });
 });

--- a/containers/ecr-viewer/src/app/view-data/components/AdministeredMedication.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/AdministeredMedication.tsx
@@ -44,8 +44,8 @@ export const AdministeredMedication = ({
       headers={headers}
       tableRows={tableRows}
       caption="Administered Medications"
+      className={"margin-y-0"}
       fixed={false}
-      outerBorder={true}
     />
   );
 };

--- a/containers/ecr-viewer/src/app/view-data/components/AdministeredMedication.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/AdministeredMedication.tsx
@@ -1,6 +1,9 @@
 import { noData } from "@/app/utils";
-import { Table } from "@trussworks/react-uswds";
 import { formatDate } from "@/app/services/formatService";
+import {
+  BuildHeaders,
+  BuildTable,
+} from "@/app/view-data/components/EvaluateTable";
 
 type AdministeredMedicationProps = {
   medicationData: AdministeredMedicationTableData[];
@@ -23,36 +26,26 @@ export const AdministeredMedication = ({
     return null;
   }
 
-  const header = ["Medication Name", "Medication Start Date"];
+  const headers = BuildHeaders([
+    { columnName: "Medication Name", className: "bg-gray-5 minw-15" },
+    { columnName: "Medication Start Date", className: "bg-gray-5 minw-15" },
+  ]);
+  const tableRows = medicationData.map((entry, index: number) => {
+    return (
+      <tr key={`table-row-${index}`}>
+        <td>{entry?.name ?? noData}</td>
+        <td>{formatDate(entry?.date) ?? noData}</td>
+      </tr>
+    );
+  });
+
   return (
-    <Table
-      bordered={false}
-      fullWidth={true}
+    <BuildTable
+      headers={headers}
+      tableRows={tableRows}
       caption="Administered Medications"
-      className={
-        "table-caption-margin margin-y-0 border-top border-left border-right"
-      }
-      data-testid="table"
-    >
-      <thead>
-        <tr>
-          {header.map((column) => (
-            <th key={`${column}`} scope="col" className="bg-gray-5 minw-15">
-              {column}
-            </th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {medicationData.map((entry, index: number) => {
-          return (
-            <tr key={`table-row-${index}`}>
-              <td>{entry?.name ?? noData}</td>
-              <td>{formatDate(entry?.date) ?? noData}</td>
-            </tr>
-          );
-        })}
-      </tbody>
-    </Table>
+      fixed={false}
+      outerBorder={true}
+    />
   );
 };

--- a/containers/ecr-viewer/src/app/view-data/components/EvaluateTable.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EvaluateTable.tsx
@@ -62,14 +62,16 @@ const EvaluateTable = ({
     );
   });
 
-  return BuildTable({
-    headers: headers,
-    tableRows: tableRows,
-    caption: caption,
-    className: className,
-    fixed: fixed,
-    outerBorder: outerBorder,
-  });
+  return (
+    <BuildTable
+      headers={headers}
+      tableRows={tableRows}
+      caption={caption}
+      className={className}
+      fixed={fixed}
+      outerBorder={outerBorder}
+    />
+  );
 };
 
 /**

--- a/containers/ecr-viewer/src/app/view-data/components/EvaluateTable.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/EvaluateTable.tsx
@@ -24,16 +24,18 @@ interface TableProps {
   mappings: PathMappings;
   columns: ColumnInfoInput[];
   caption?: string;
+  className?: string;
   fixed?: boolean;
   outerBorder?: boolean;
 }
 /**
  * Formats a table based on the provided resources, mappings, columns, and caption.
  * @param props - The properties for configuring the table.
- * @param props.resources - An array of FHIR Resources representing the data entries.
+ * @param props.resources - An array of FHIR Resources representing the data entries. Data for each table row is collected from each resource.
  * @param props.mappings - An object containing the FHIR path mappings.
  * @param props.columns - An array of objects representing column information. The order of columns in the array determines the order of appearance.
  * @param props.caption - The caption for the table.
+ * @param props.className - (Optional) Classnames to be applied to table.
  * @param props.fixed - Determines whether to fix the width of the table columns. Default is true.
  * @param props.outerBorder - Determines whether to include an outer border for the table. Default is true
  * @returns - A formatted table React element.
@@ -43,18 +45,11 @@ const EvaluateTable = ({
   mappings,
   columns,
   caption,
+  className,
   fixed = true,
   outerBorder = true,
 }: TableProps): React.JSX.Element => {
-  let headers = columns.map((column, index) => (
-    <th
-      key={`${column.columnName}${index}`}
-      scope="col"
-      className="tableHeader"
-    >
-      {column.columnName}
-    </th>
-  ));
+  let headers = BuildHeaders(columns);
 
   let tableRows = resources.map((entry, index) => {
     return (
@@ -67,13 +62,68 @@ const EvaluateTable = ({
     );
   });
 
+  return BuildTable({
+    headers: headers,
+    tableRows: tableRows,
+    caption: caption,
+    className: className,
+    fixed: fixed,
+    outerBorder: outerBorder,
+  });
+};
+
+/**
+ * Builds table headers from the given columns.
+ * @param columns - The column info to build headers from.
+ * @returns An array of table header elements.
+ */
+export const BuildHeaders = (
+  columns: ColumnInfoInput[],
+): React.JSX.Element[] => {
+  return columns.map((column, index) => (
+    <th
+      key={`${column.columnName}${index}`}
+      scope="col"
+      className={classNames("tableHeader", column.className)}
+    >
+      {column.columnName}
+    </th>
+  ));
+};
+
+/**
+ * Builds a table component with the provided headers, rows, and configurations.
+ * @param props - The parameters for building the table.
+ * @param props.headers - JSX Element of the table headers.
+ * @param props.tableRows - The rows of the table.
+ * @param props.caption - The caption for the table.
+ * @param props.className - (Optional) Classnames to be applied to table.
+ * @param props.fixed (default=true) - Whether the table forces equal width columns.
+ * @param props.outerBorder (default=true) - Whether the table has an outer border.
+ * @returns JSX Element representing the table component.
+ */
+export const BuildTable = ({
+  headers,
+  tableRows,
+  caption,
+  className,
+  fixed = true,
+  outerBorder = true,
+}: {
+  headers: React.JSX.Element[];
+  tableRows: React.JSX.Element[];
+  caption?: string;
+  className?: string;
+  fixed?: boolean;
+  outerBorder?: boolean;
+}) => {
   return (
     <Table
       fixed={fixed}
       bordered={false}
       fullWidth={true}
       caption={caption}
-      className={classNames("table-caption-margin margin-y-0", {
+      className={classNames("table-caption-margin", className, {
         "border-top border-left border-right": outerBorder,
       })}
       data-testid="table"

--- a/containers/ecr-viewer/src/app/view-data/components/common.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/common.tsx
@@ -3,6 +3,8 @@ import {
   evaluateReference,
 } from "@/app/services/evaluateFhirDataService";
 import EvaluateTable, {
+  BuildHeaders,
+  BuildTable,
   ColumnInfoInput,
 } from "@/app/view-data/components/EvaluateTable";
 import {
@@ -14,7 +16,6 @@ import {
   formatDate,
 } from "@/app/services/formatService";
 import { PathMappings, evaluateData, noData } from "@/app/utils";
-import { Table } from "@trussworks/react-uswds";
 import {
   Bundle,
   CarePlanActivity,
@@ -109,6 +110,7 @@ export const returnCareTeamTable = (
       mappings={mappings}
       columns={columnInfo}
       caption={"Care Team"}
+      className={"margin-y-0"}
       fixed={false}
     />
   );
@@ -165,6 +167,7 @@ export const returnImmunizations = (
       mappings={mappings}
       columns={columnInfo}
       caption={"Immunization History"}
+      className={"margin-y-0"}
     />
   );
 };
@@ -193,7 +196,6 @@ export const returnProblemsTable = (
     {
       columnName: "Active Problem",
       infoPath: "activeProblemsDisplay",
-      className: "width-mobile-lg",
     },
     { columnName: "Onset Date", infoPath: "activeProblemsOnsetDate" },
     { columnName: "Onset Age", infoPath: "activeProblemsOnsetAge" },
@@ -227,6 +229,7 @@ export const returnProblemsTable = (
       mappings={mappings}
       columns={columnInfo}
       caption={"Problems List"}
+      className={"margin-y-0"}
       fixed={false}
     />
   );
@@ -250,49 +253,35 @@ export const returnPendingResultsTable = (
   );
 
   if (pendingResultsTableJson?.tables?.[0]) {
-    const header = [
-      "Name",
-      "Type",
-      "Priority",
-      "Associated Diagnoses",
-      "Date/Time",
-    ];
+    const headers = BuildHeaders([
+      { columnName: "Name", className: "bg-gray-5 minw-15" },
+      { columnName: "Type", className: "bg-gray-5 minw-15" },
+      { columnName: "Priority", className: "bg-gray-5 minw-15" },
+      { columnName: "Associated Diagnoses", className: "bg-gray-5 minw-15" },
+      { columnName: "Date/Time", className: "bg-gray-5 minw-15" },
+    ]);
+    const tableRows = pendingResultsTableJson.tables[0].map(
+      (entry: TableRow, index: number) => {
+        return (
+          <tr key={`table-row-${index}`}>
+            <td>{entry.Name?.value ?? noData}</td>
+            <td>{entry.Type?.value ?? noData}</td>
+            <td>{entry.Priority?.value ?? noData}</td>
+            <td>{entry.AssociatedDiagnoses?.value ?? noData}</td>
+            <td>{entry["Date/Time"]?.value ?? noData}</td>
+          </tr>
+        );
+      },
+    );
 
     return (
-      <Table
-        bordered={false}
-        fullWidth={true}
-        className={
-          "table-caption-margin caption-normal-weight margin-top-0 border-top border-left border-right margin-bottom-2"
-        }
-        data-testid="table"
-        caption={"Pending Results"}
-      >
-        <thead>
-          <tr>
-            {header.map((column) => (
-              <th key={`${column}`} scope="col" className="bg-gray-5 minw-15">
-                {column}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {pendingResultsTableJson.tables[0].map(
-            (entry: TableRow, index: number) => {
-              return (
-                <tr key={`table-row-${index}`}>
-                  <td>{entry.Name?.value ?? noData}</td>
-                  <td>{entry.Type?.value ?? noData}</td>
-                  <td>{entry.Priority?.value ?? noData}</td>
-                  <td>{entry.AssociatedDiagnoses?.value ?? noData}</td>
-                  <td>{entry["Date/Time"]?.value ?? noData}</td>
-                </tr>
-              );
-            },
-          )}
-        </tbody>
-      </Table>
+      <BuildTable
+        headers={headers}
+        tableRows={tableRows}
+        caption="Pending Results"
+        className={"caption-normal-weight margin-top-0 margin-bottom-2"}
+        fixed={false}
+      />
     );
   }
 };
@@ -315,49 +304,38 @@ export const returnScheduledOrdersTable = (
   );
 
   if (scheduledOrdersTableJson?.tables?.[0]) {
-    const header = [
-      "Name",
-      "Type",
-      "Priority",
-      "Associated Diagnoses",
-      "Date/Time",
-    ];
+    const headers = BuildHeaders([
+      { columnName: "Name", className: "bg-gray-5 minw-15" },
+      { columnName: "Type", className: "bg-gray-5 minw-15" },
+      { columnName: "Priority", className: "bg-gray-5 minw-15" },
+      {
+        columnName: "Associated Diagnoses",
+        className: "bg-gray-5 minw-15",
+      },
+      { columnName: "Date/Time", className: "bg-gray-5 minw-15" },
+    ]);
+    const tableRows = scheduledOrdersTableJson.tables?.[0].map(
+      (entry: TableRow, index: number) => {
+        return (
+          <tr key={`table-row-${index}`}>
+            <td>{entry.Name?.value ?? noData}</td>
+            <td>{entry.Type?.value ?? noData}</td>
+            <td>{entry.Priority?.value ?? noData}</td>
+            <td>{entry.AssociatedDiagnoses?.value ?? noData}</td>
+            <td>{entry["Order Schedule"]?.value ?? noData}</td>
+          </tr>
+        );
+      },
+    );
 
     return (
-      <Table
-        bordered={false}
-        fullWidth={true}
-        className={
-          "table-caption-margin margin-top-1 caption-normal-weight margin-y-0 border-top border-left border-right"
-        }
-        data-testid="table"
-        caption={"Scheduled Orders"}
-      >
-        <thead>
-          <tr>
-            {header.map((column) => (
-              <th key={`${column}`} scope="col" className="bg-gray-5 minw-15">
-                {column}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {scheduledOrdersTableJson.tables?.[0].map(
-            (entry: TableRow, index: number) => {
-              return (
-                <tr key={`table-row-${index}`}>
-                  <td>{entry.Name?.value ?? noData}</td>
-                  <td>{entry.Type?.value ?? noData}</td>
-                  <td>{entry.Priority?.value ?? noData}</td>
-                  <td>{entry.AssociatedDiagnoses?.value ?? noData}</td>
-                  <td>{entry["Order Schedule"]?.value ?? noData}</td>
-                </tr>
-              );
-            },
-          )}
-        </tbody>
-      </Table>
+      <BuildTable
+        headers={headers}
+        tableRows={tableRows}
+        caption="Scheduled Orders"
+        className={"margin-top-1 caption-normal-weight margin-y-0"}
+        fixed={false}
+      />
     );
   }
 };
@@ -398,6 +376,7 @@ export const returnProceduresTable = (
       mappings={mappings}
       columns={columnInfo}
       caption={"Procedures"}
+      className={"margin-y-0"}
     />
   );
 };
@@ -440,6 +419,7 @@ export const returnPlannedProceduresTable = (
       mappings={mappings}
       columns={columnInfo}
       caption={"Planned Procedures"}
+      className={"margin-y-0"}
     />
   );
 };


### PR DESCRIPTION
# PULL REQUEST

## Summary
Quick refactor of table elements
- Create reusable elements to build tables/headers (i.e. when `EvaluateTable` can't be used)
- Add (optional) className specification that can be applied to table and header elements

## Related Issue
NA - refactor work I wanted to apply before working on adding vital signs table (#2096)

## Additional Information
Anything else the review team should know?

[//]: # (PR title: Remember to name your PR descriptively!)
