### PR TITLE
Handle multiple phone number formats in search

### DIFF
--- a/containers/tefca-viewer/e2e/query_workflow.spec.ts
+++ b/containers/tefca-viewer/e2e/query_workflow.spec.ts
@@ -76,7 +76,7 @@ test.describe("querying with the TryTEFCA viewer", () => {
 
     await page.getByLabel("First Name").fill("Ellie");
     await page.getByLabel("Last Name").fill("Williams");
-    await page.getByLabel("Date of Birth").fill("2030-07-07");
+    await page.getByLabel("Date of Birth").fill("2019-07-07");
     await page.getByLabel("Medical Record Number").fill("TLOU1TLOU2");
     await page
       .getByLabel("Use case", { exact: true })
@@ -93,5 +93,32 @@ test.describe("querying with the TryTEFCA viewer", () => {
     await expect(
       page.getByRole("heading", { name: "Search for a Patient" }),
     ).toBeVisible();
+  });
+
+  test("query using form-fillable demo patient by phone number", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Get Started" }).click();
+
+    await page
+      .getByLabel("Select from the following use cases to")
+      .selectOption("demo-sti-syphilis");
+    await page.getByRole("button", { name: "Fill fields" }).click();
+
+    // Delete last name and MRN to force phone number as one of the 3 fields
+    await page.getByLabel("Last Name").clear();
+    await page.getByLabel("Medical Record Number").clear();
+
+    // Among verification, make sure phone number is right
+    await page.getByRole("button", { name: "Search for patient" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Query Results" }),
+    ).toBeVisible();
+    await expect(page.getByText("Patient Name")).toBeVisible();
+    await expect(page.getByText("Veronica Anne Blackstone")).toBeVisible();
+    await expect(page.getByText("Contact")).toBeVisible();
+    await expect(page.getByText("937-379-3497")).toBeVisible();
+    await expect(page.getByText("Patient Identifiers")).toBeVisible();
+    await expect(page.getByText("34972316")).toBeVisible();
   });
 });

--- a/containers/tefca-viewer/src/app/page.tsx
+++ b/containers/tefca-viewer/src/app/page.tsx
@@ -44,7 +44,7 @@ export default function LandingPage() {
           Framework and Common Agreement (TEFCA). This tool demonstrates how
           public health jurisdictions can leverage TEFCA to quickly retrieve
           patient records and relevant case information from HCOs without
-          requiring direct connection and onboarding. 
+          requiring direct connection and onboarding.
         </h2>
         <h3 className="font-sans-l text-bold margin-top-5">
           How does it work?

--- a/containers/tefca-viewer/src/app/query-service.ts
+++ b/containers/tefca-viewer/src/app/query-service.ts
@@ -38,6 +38,7 @@ export type UseCaseQueryRequest = {
   last_name?: string;
   dob?: string;
   mrn?: string;
+  phone?: string;
 };
 
 const UseCaseQueryMap: {
@@ -57,6 +58,41 @@ const UseCaseQueryMap: {
 
 // Expected responses from the FHIR server
 export type UseCaseQueryResponse = Awaited<ReturnType<typeof UseCaseQuery>>;
+
+const FORMATS_TO_SEARCH: string[] = [
+  "$1$2$3",
+  "$1-$2-$3",
+  "$1+$2+$3",
+  "($1)+$2+$3",
+  "($1)-$2-$3",
+  "($1)$2-$3",
+  "1($1)$2-$3",
+];
+
+/**
+ * @todo Once the country code box is created on the search form, we'll
+ * need to use that value to act as a kind of switch logic here to figure
+ * out which formats we should be using.
+ * Helper function to transform a cleaned, digit-only representation of
+ * a phone number into multiple possible formatting options of that phone
+ * number. If the given number has fewer than 10 digits, or contains any
+ * delimiters, no formatting is performed and only the given number is
+ * used.
+ * @param phone A digit-only representation of a phone number.
+ * @returns An array of formatted phone numbers.
+ */
+export async function GetPhoneQueryFormats(phone: string) {
+  // Digit-only phone numbers will resolve as actual numbers
+  if (isNaN(Number(phone)) || phone.length != 10) {
+    const strippedPhone = phone.replace(" ", "+");
+    return [strippedPhone];
+  }
+  // Map the phone number into each format we want to check
+  const possibleFormats: string[] = FORMATS_TO_SEARCH.map((fmt) => {
+    return phone.replace(/(\d{3})(\d{3})(\d{4})/gi, fmt);
+  });
+  return possibleFormats;
+}
 
 /**
  * Query a FHIR server for a patient based on demographics provided in the request. If
@@ -84,6 +120,10 @@ async function patientQuery(
   }
   if (request.mrn) {
     query += `identifier=${request.mrn}&`;
+  }
+  if (request.phone) {
+    const phonePossibilities = await GetPhoneQueryFormats(request.phone);
+    query += `phone=${phonePossibilities.join(",")}&`;
   }
 
   const response = await fhirClient.get(query);

--- a/containers/tefca-viewer/src/app/query/components/SearchForm.tsx
+++ b/containers/tefca-viewer/src/app/query/components/SearchForm.tsx
@@ -20,6 +20,28 @@ import {
 } from "../../query-service";
 import { Mode } from "../page";
 
+/**
+ * @todo Add country code form box on search form
+ * @todo Update documentation here once that's done to reflect switch
+ * logic of country code
+ *
+ * Helper function to strip out non-digit characters from a phone number
+ * entered into the search tool. Right now, we're not going to worry about
+ * country code or international numbers, so we'll just make an MVP
+ * assumption of 10 regular digits.
+ * @param givenPhone The original phone number the user typed.
+ * @returns The phone number as a pure digit string. If the cleaned number
+ * is fewer than 10 digits, just return the original.
+ */
+export function FormatPhoneAsDigits(givenPhone: string) {
+  // Start by getting rid of all existing separators for a clean slate
+  const newPhone: string = givenPhone.replace(/\D/g, "");
+  if (newPhone.length != 10) {
+    return givenPhone;
+  }
+  return newPhone;
+}
+
 interface SearchFormProps {
   setOriginalRequest: (originalRequest: UseCaseQueryRequest) => void;
   setUseCaseQueryResponse: (UseCaseQueryResponse: UseCaseQueryResponse) => void;
@@ -73,6 +95,7 @@ const SearchForm: React.FC<SearchFormProps> = ({
     }
     event.preventDefault();
     setLoading(true);
+
     const originalRequest = {
       first_name: firstName,
       last_name: lastName,
@@ -80,6 +103,7 @@ const SearchForm: React.FC<SearchFormProps> = ({
       mrn: mrn,
       fhir_server: fhirServer,
       use_case: useCase,
+      phone: FormatPhoneAsDigits(phone),
     };
     setOriginalRequest(originalRequest);
     const queryResponse = await UseCaseQuery(originalRequest);

--- a/containers/tefca-viewer/src/app/tests/unit/SearchForm.test.tsx
+++ b/containers/tefca-viewer/src/app/tests/unit/SearchForm.test.tsx
@@ -1,0 +1,38 @@
+import { FormatPhoneAsDigits } from "@/app/query/components/SearchForm";
+
+describe("FormatPhoneAsDigits", () => {
+  it("should handle dashes, spacecs, and dot delimiters", () => {
+    const dashInput = "123-456-7890";
+    const expectedResult = "1234567890";
+    expect(FormatPhoneAsDigits(dashInput)).toEqual(expectedResult);
+
+    const spaceInput = "123 456 7890";
+    expect(FormatPhoneAsDigits(spaceInput)).toEqual(expectedResult);
+
+    const dotInput = "123.456.7890";
+    expect(FormatPhoneAsDigits(dotInput)).toEqual(expectedResult);
+  });
+  it("should handle parentheticals around area codes", () => {
+    const expectedResult = "1234567890";
+    let parentheticalInput = "(123) 456 7890";
+    expect(FormatPhoneAsDigits(parentheticalInput)).toEqual(expectedResult);
+
+    parentheticalInput = "(123)456-7890";
+    expect(FormatPhoneAsDigits(parentheticalInput)).toEqual(expectedResult);
+  });
+  it("should handle extraneous white spaces regardless of position", () => {
+    const expectedResult = "1234567890";
+    const weirdSpaceNumber = "  123  - 456 7 8 9 0  ";
+    expect(FormatPhoneAsDigits(weirdSpaceNumber)).toEqual(expectedResult);
+  });
+  it("should gracefully fail if provided a partial number", () => {
+    const givenPhone = "456-7890";
+    const expectedResult = "456-7890";
+    expect(FormatPhoneAsDigits(givenPhone)).toEqual(expectedResult);
+  });
+  it("should gracefully fail if given a country code", () => {
+    const givenPhone = "+44 202 555 8736";
+    const expectedResult = "+44 202 555 8736";
+    expect(FormatPhoneAsDigits(givenPhone)).toEqual(expectedResult);
+  });
+});

--- a/containers/tefca-viewer/src/app/tests/unit/query-service.test.tsx
+++ b/containers/tefca-viewer/src/app/tests/unit/query-service.test.tsx
@@ -1,0 +1,27 @@
+import { GetPhoneQueryFormats } from "@/app/query-service";
+
+describe("GetPhoneQueryFormats", () => {
+  it("should fail gracefully on partial phone number inputs", async () => {
+    const partialPhone = "456 7890";
+    const expectedResult = ["456+7890"];
+    expect(await GetPhoneQueryFormats(partialPhone)).toEqual(expectedResult);
+  });
+  it("should fail gracefully on given phones with separators remaining", async () => {
+    const phoneWithStuff = "+44.202.456.7890";
+    const expectedResult = ["+44.202.456.7890"];
+    expect(await GetPhoneQueryFormats(phoneWithStuff)).toEqual(expectedResult);
+  });
+  it("should fully process ten-digit input strings", async () => {
+    const inputPhone = "1234567890";
+    const expectedResult = [
+      "1234567890",
+      "123-456-7890",
+      "123+456+7890",
+      "(123)+456+7890",
+      "(123)-456-7890",
+      "(123)456-7890",
+      "1(123)456-7890",
+    ];
+    expect(await GetPhoneQueryFormats(inputPhone)).toEqual(expectedResult);
+  });
+});


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR handles the MVP of phone number formatting for our query search; the phone number passed in the search field gets stripped to just be digits, and then based on some profiling of the most common formatting schemes present in HAPI, Epic, and Cerner, we spit back out an array of possible formattings with some combinations of spaces, dashes, and parentheticals. These all get logically `OR`'ed in the query URL search proper.

## Related Issue
Fixes #1840 

## Additional Information
The idea for this approach came out of some conversations with Dan, but the idea is to basically take a much wider shotgun-style approach to hitting phone numbers, since the big FHIR servers all enforce _exact only_ matching on the telecom field (that means we need to perfectly hit how they distribute all their delimiters, parentheses, etc.). We're making the choice right now to kind of ignore country code parsing--eventually, we'll want to have a separate country code field that starts off with a default value of 1 (for US numbers) because then we can more explicitly handle country digits. If we tried to handle it now, we run into some very hairy and not-worth-it-to-sort-out cases. For example, there's no way to tell if a number with 10 digits includes a country code and omits local-area routing, or if it's some other partial phone number, etc. So we're just gonna ignore it for this PR. Later on though, we can also use the country code text input field for switch-statement logic to check different formatting options more common to international numbers. That code will just have to come after we have a country code box.
