### PR TITLE
TCRS now finds Conditions on its own.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,19 @@
       "cwd": "${workspaceFolder}/containers/orchestration",
       "justMyCode": false,
       "python": "${workspaceFolder}/containers/orchestration/.venv/bin/python"
+    },
+    {
+      "name": "Python Debugger: Trigger Code Reference",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/containers/trigger-code-reference/app/main.py",
+      "console": "integratedTerminal",
+      "cwd": "${workspaceFolder}/containers/trigger-code-reference",
+      "justMyCode": false,
+      "python": "${workspaceFolder}/containers/trigger-code-reference/.venv/bin/python",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/containers/trigger-code-reference"
+      }
     }
   ]
 }

--- a/containers/orchestration/app/custom_configs/seed-ecr-viewer-config.json
+++ b/containers/orchestration/app/custom_configs/seed-ecr-viewer-config.json
@@ -23,12 +23,7 @@
     {
       "name": "stamped_ecr",
       "service": "trigger_code_reference",
-      "endpoint": "/stamp-condition-extensions",
-      "params": {
-        "conditions": [
-          "840539006"
-        ]
-      }
+      "endpoint": "/stamp-condition-extensions"
     },
     {
       "name": "message_parser_values",

--- a/containers/trigger-code-reference/app/models.py
+++ b/containers/trigger-code-reference/app/models.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from pydantic import BaseModel
 from pydantic import Field
 from pydantic import root_validator
@@ -15,10 +13,6 @@ class InsertConditionInput(BaseModel):
         "to one or more of the conditions in the other supplied parameter will have "
         "an extension added to the resource noting the SNOMED code relating to the "
         "associated condition(s)."
-    )
-    conditions: List[str] = Field(
-        description="The list of SNOMED codes to insert as extensions into any "
-        "associated resources in the supplied FHIR bundle."
     )
 
     @root_validator

--- a/containers/trigger-code-reference/app/models.py
+++ b/containers/trigger-code-reference/app/models.py
@@ -1,6 +1,5 @@
 from pydantic import BaseModel
 from pydantic import Field
-from pydantic import root_validator
 
 
 class InsertConditionInput(BaseModel):
@@ -14,23 +13,3 @@ class InsertConditionInput(BaseModel):
         "an extension added to the resource noting the SNOMED code relating to the "
         "associated condition(s)."
     )
-
-    @root_validator
-    def require_non_empty_condition_list(cls, values):
-        """
-        Ensures that the supplied conditions list parameter is both a list
-        and has at least one element by which to extend the supplied FHIR
-        bundle.
-
-        :param cls: The InsertConditionInput class.
-        :param values: The condition list supplied by the caller.
-        :raises ValueError: Errors when supplied condition list contains no
-          elements, since this can't be used to extend a bundle.
-        :return: The endpoint's values, if the condition list is valid.
-        """
-        if len(values.get("conditions")) == 0:
-            raise ValueError(
-                "Supplied list of SNOMED conditions must contain "
-                "one or more elements; given list was empty."
-            )
-        return values

--- a/containers/trigger-code-reference/app/models.py
+++ b/containers/trigger-code-reference/app/models.py
@@ -9,7 +9,7 @@ class InsertConditionInput(BaseModel):
 
     bundle: dict = Field(
         description="The FHIR bundle to modify. Each resource in the bundle related "
-        "to one or more of the conditions in the other supplied parameter will have "
+        "to one or more of the conditions found in the bundle will have "
         "an extension added to the resource noting the SNOMED code relating to the "
         "associated condition(s)."
     )

--- a/containers/trigger-code-reference/app/utils.py
+++ b/containers/trigger-code-reference/app/utils.py
@@ -209,17 +209,13 @@ def find_conditions(bundle: dict) -> set[str]:
     CONDITION_CODE = "64572001"
     SNOMED_URL = "http://snomed.info/sct"
 
-    # Filter to get observations from the bundle
-    observations = [
-        resource["resource"]
-        for resource in bundle["entry"]
-        if resource["resource"]["resourceType"] == "Observation"
-    ]
+    # Get all resources
+    resources = [resource["resource"] for resource in bundle["entry"]]
 
     # Filter observations that have the SNOMED code for "Condition".
-    observations_with_conditions = [
+    resources_with_conditions = [
         obs
-        for obs in observations
+        for obs in resources
         if "code" in obs
         and any(coding["code"] == CONDITION_CODE for coding in obs["code"]["coding"])
     ]
@@ -227,7 +223,7 @@ def find_conditions(bundle: dict) -> set[str]:
     # Extract unique SNOMED codes from the observations
     snomed_codes = {
         coding["code"]
-        for obs in observations_with_conditions
+        for obs in resources_with_conditions
         for coding in obs.get("valueCodeableConcept", {}).get("coding", [])
         if coding["system"] == SNOMED_URL
     }

--- a/containers/trigger-code-reference/assets/sample_stamp_condition_extensions_requests.json
+++ b/containers/trigger-code-reference/assets/sample_stamp_condition_extensions_requests.json
@@ -3,9 +3,6 @@
     "summary": "Stamping a FHIR bundle consisting of an eICR merged with its RR",
     "description": "This is an example bundle demonstrating condition-stamping on an input eICR that's checking for COVID-related condition codes.",
     "value": {
-      "conditions": [
-        "840539006"
-      ],
       "bundle": {
         "resourceType": "Bundle",
         "type": "batch",

--- a/containers/trigger-code-reference/tests/integration/test_trigger_code_reference.py
+++ b/containers/trigger-code-reference/tests/integration/test_trigger_code_reference.py
@@ -25,7 +25,7 @@ def test_openapi():
 @pytest.mark.integration
 def test_tcr_stamping(setup, fhir_bundle):
     reportable_condition_code = "840539006"
-    request = {"bundle": fhir_bundle, "conditions": [reportable_condition_code]}
+    request = {"bundle": fhir_bundle}
     stamp_response = httpx.post(STAMP_ENDPOINT, json=request)
     assert stamp_response.status_code == 200
 

--- a/containers/trigger-code-reference/tests/test_condition_endpoints.py
+++ b/containers/trigger-code-reference/tests/test_condition_endpoints.py
@@ -77,17 +77,6 @@ def test_get_value_sets_for_condition(mock_db):
     assert response.json() == expected_result
 
 
-def test_stamp_conditions_bad_input():
-    input = {"bundle": {"test_key": "test_val"}, "conditions": []}
-    response = client.post("/stamp-condition-extensions", json=input)
-    assert response.status_code == 422
-    assert (
-        response.json()["detail"][0]["msg"]
-        == "Supplied list of SNOMED conditions "
-        + "must contain one or more elements; given list was empty."
-    )
-
-
 # Note: This function is defined in utils, but we mock it in the namespace
 # coming from main because that's where the endpoint is invoking it from
 @patch("app.main.get_clinical_services_list")

--- a/containers/trigger-code-reference/tests/test_condition_endpoints.py
+++ b/containers/trigger-code-reference/tests/test_condition_endpoints.py
@@ -139,18 +139,18 @@ def test_stamp_condition_extensions(patched_get_services_list):
 
     # Check observation: diagnostic code value came back successful
     found_matching_extension = _check_for_stamped_resource_in_bundle(
-        stamped_message, "99999-9", "Observation"
+        stamped_message, "840539006", "Observation"
     )
     assert found_matching_extension
 
     # Check condition: no value set cross-referenced for this bundle, no stamp
     found_matching_extension = _check_for_stamped_resource_in_bundle(
-        stamped_message, "99999-9", "Condition"
+        stamped_message, "840539006", "Condition"
     )
     assert not found_matching_extension
 
     # Check immunization: we did find a referenced immunization code, so it should be there
     found_matching_extension = _check_for_stamped_resource_in_bundle(
-        stamped_message, "99999-9", "Immunization"
+        stamped_message, "840539006", "Immunization"
     )
     assert found_matching_extension

--- a/containers/trigger-code-reference/tests/test_condition_endpoints.py
+++ b/containers/trigger-code-reference/tests/test_condition_endpoints.py
@@ -132,7 +132,7 @@ def test_stamp_condition_extensions(patched_get_services_list):
         ("dxtc", "8971234987123", "code-sys-2"),
         ("lotc", "72391283|8916394-2|24", "code-sys-1"),
     ]
-    input = {"bundle": message, "conditions": ["99999-9"]}
+    input = {"bundle": message}
     response = client.post("/stamp-condition-extensions", json=input)
     assert response.status_code == 200
     stamped_message = response.json()["extended_bundle"]


### PR DESCRIPTION
# PULL REQUEST

## Summary
What changes are being proposed?
Instead of requiring a given list of SNOMED condition codes the Trigger Code Reference Service now finds all present in the given bundle and stamps additional data for what it found.

## Related Issue
Fixes #2123 

## Additional Information
Anything else the review team should know?

## Checklist
This can be confirmed by:
1) Set up the TCRS following the instructions in it's `description.md`
2) Using your favourite method for making API calls  send a post command to `/stamp-condition-extensions` with the following body:
```
{
    "bundle": <JSON of a FHIR bundle, I used the bundle with ID: "1.2.840.114350.1.13.478.3.7.8.688883.230886">
}
```
3) Compare the returned JSON with the original one. For the bundle I used, three conditions were found: COVID, Hepatitis, and plague.
