### PR TITLE
Remove old TCRS code from Orchestration

### DIFF
--- a/containers/orchestration/app/default_configs/sample-orchestration-config.json
+++ b/containers/orchestration/app/default_configs/sample-orchestration-config.json
@@ -28,12 +28,7 @@
     },
     {
       "service": "trigger_code_reference",
-      "endpoint": "/stamp-condition-extensions",
-      "params": {
-        "conditions": [
-          "840539006"
-        ]
-      }
+      "endpoint": "/stamp-condition-extensions"
     },
     {
       "service": "save_bundle",

--- a/containers/orchestration/app/handlers.py
+++ b/containers/orchestration/app/handlers.py
@@ -507,16 +507,9 @@ def build_stamp_condition_extensions_request(
             "data_type": orchestration_request.get("data_type"),
             "workflow_params": workflow_params,
         },
-    ) as handler_span:
+    ):
         # Initialize workflow_params as an empty dictionary if it's None
         workflow_params = workflow_params or {}
-
-        handler_span.add_event(
-            "updating stamp conditions extensions request options",
-            attributes={
-                "conditions": workflow_params.get("conditions"),
-            },
-        )
 
         return {
             "bundle": input_msg,


### PR DESCRIPTION
# PULL REQUEST

## Summary
When I updated the trigger code reference service endpoint to no longer take a list of conditions, I did not update `handler.py` in Orchestration to account for that. Everything still works, regardless, but there were a few lines of useless code.

## Related Issue
Fixes #2125 

## Additional Information
Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
