### PR TITLE
Empty fields in eCR Summary should not be displayed

### DIFF
--- a/containers/ecr-viewer/src/app/services/ecrSummaryService.tsx
+++ b/containers/ecr-viewer/src/app/services/ecrSummaryService.tsx
@@ -1,5 +1,5 @@
 import { Bundle, Condition, Extension, Observation } from "fhir/r4";
-import { PathMappings } from "@/app/utils";
+import { evaluateData, PathMappings } from "@/app/utils";
 import {
   formatDate,
   formatStartEndDateTime,
@@ -52,7 +52,7 @@ export const evaluateEcrSummaryPatientDetails = (
   fhirBundle: Bundle,
   fhirPathMappings: PathMappings,
 ) => {
-  return [
+  return evaluateData([
     {
       title: "Patient Name",
       value: evaluatePatientName(fhirBundle, fhirPathMappings),
@@ -70,7 +70,7 @@ export const evaluateEcrSummaryPatientDetails = (
       title: "Patient Contact",
       value: evaluatePatientContactInfo(fhirBundle, fhirPathMappings),
     },
-  ];
+  ]);
 };
 
 /**
@@ -83,7 +83,7 @@ export const evaluateEcrSummaryEncounterDetails = (
   fhirBundle: Bundle,
   fhirPathMappings: PathMappings,
 ) => {
-  return [
+  return evaluateData([
     {
       title: "Facility Name",
       value: evaluate(fhirBundle, fhirPathMappings.facilityName),
@@ -104,7 +104,7 @@ export const evaluateEcrSummaryEncounterDetails = (
       title: "Encounter Type",
       value: evaluate(fhirBundle, fhirPathMappings.encounterType),
     },
-  ];
+  ]);
 };
 
 /**

--- a/containers/ecr-viewer/src/app/view-data/page.tsx
+++ b/containers/ecr-viewer/src/app/view-data/page.tsx
@@ -116,14 +116,14 @@ const ECRViewerPage: React.FC = () => {
                       eCR Summary
                     </h2>
                     <EcrSummary
-                      patientDetails={evaluateEcrSummaryPatientDetails(
-                        fhirBundle,
-                        mappings,
-                      )}
-                      encounterDetails={evaluateEcrSummaryEncounterDetails(
-                        fhirBundle,
-                        mappings,
-                      )}
+                      patientDetails={
+                        evaluateEcrSummaryPatientDetails(fhirBundle, mappings)
+                          .availableData
+                      }
+                      encounterDetails={
+                        evaluateEcrSummaryEncounterDetails(fhirBundle, mappings)
+                          .availableData
+                      }
                       conditionSummary={evaluateEcrSummaryConditionSummary(
                         fhirBundle,
                         mappings,


### PR DESCRIPTION
# PULL REQUEST

## Summary
Applies `evaluateData` to the **About the Patient** and **About the Encounter** sections in the **eCR Summary**. This filters out empty fields, and only available data is displayed.

## Related Issue
Fixes #2072

## Screenshots
**Before:**
<img width="1512" alt="Screenshot 2024-07-31 at 15 15 32" src="https://github.com/user-attachments/assets/83152eec-5eb3-4662-b877-e0c2e7ed8642">

**After:**
<img width="1496" alt="Screenshot 2024-07-31 at 15 16 35" src="https://github.com/user-attachments/assets/ecd5e476-8bd5-4734-b5ca-675294a8252e">

## Checklist
- [ ] Check example: `61f13d32-b25c-4fb6-998b-73de2dbf87f2`: [Link](http://localhost:3000/view-data?id=1.2.840.114350.1.13.478.3.7.8.688883.230886)
    - eCR Summary → Facility Contact

[//]: # (PR title: Remember to name your PR descriptively!)
