### PR TITLE
Add design review script for eCR Viewer

### DIFF
--- a/containers/ecr-viewer/design-review/README.MD
+++ b/containers/ecr-viewer/design-review/README.MD
@@ -1,0 +1,22 @@
+# Design Review Script
+
+A bash script intended to allow designers and members of the team to easily spin up an instance of the eCR Viewer on their local machines for UI/UX review. Currently only MacOS is supported.
+
+## Initial Setup
+
+In order to use this script a copy must be downloaded onto your computer from GitHub. To do this follow these instructions.
+1. Open the Terminal application.
+2. Copy and paste `curl https://raw.githubusercontent.com/CDCgov/phdi/main/containers/ecr-viewer/design-review/design-review.sh -O` into the Terminal prompt and press enter. This command uses the wget program to download a copy the `design-review.sh` file from this directory to the root level of your user directory e.g. `Users/johndoe`.
+3. Copy and paste `chmod +x design-review.sh` into Terminal and press enter. This command assigns executable permissions to `design-review.sh` allowing it to be run.
+
+
+## Usage
+
+Follow these steps to run script and spin up a local instance of the eCR Viewer.
+
+1. Ensure you have completed the initial setup instructions.
+2. Open the Terminal application.
+3. Copy and paste `./design-review.sh <MY-BRANCH>` into the Terminal prompt.
+4. Replace `<MY-BRANCH>` with the name of the GitHub branch you would like to conduct a review on. For example, `./design-review.sh main` will spin up an instance of the eCR Viewer based on the current state of the `main` branch of repository.
+5. Press enter. The script will now ensure that all required dependencies are installed on your machine, build and run the eCR Viewer, and finally navigate to the landing page in your system's default browser. Please note that because certain dependencies may need to be installed the script make take a few minutes the first time it is run on a machine. Additionally, depending on what needs to be installed you may be prompted at points during installation of dependencies to provide a password or click through some installation screens.
+6. When you are done with your review to shut the eCR Viewer down return to Terminal and press enter.

--- a/containers/ecr-viewer/design-review/README.MD
+++ b/containers/ecr-viewer/design-review/README.MD
@@ -6,8 +6,12 @@ A bash script intended to allow designers and members of the team to easily spin
 
 In order to use this script a copy must be downloaded onto your computer from GitHub. To do this follow these instructions.
 1. Open the Terminal application.
-2. Copy and paste `curl https://raw.githubusercontent.com/CDCgov/phdi/main/containers/ecr-viewer/design-review/design-review.sh -O` into the Terminal prompt and press enter. This command uses the wget program to download a copy the `design-review.sh` file from this directory to the root level of your user directory e.g. `Users/johndoe`.
-3. Copy and paste `chmod +x design-review.sh` into Terminal and press enter. This command assigns executable permissions to `design-review.sh` allowing it to be run.
+2. Copy and paste the following command into the Terminal prompt and press enter.
+```
+curl https://raw.githubusercontent.com/CDCgov/phdi/main/containers/ecr-viewer/design-review/design-review.sh -O && chmod +x design-review.sh
+```
+- The first command uses the wget program to download a copy the `design-review.sh` file from this directory to the root level of your user directory e.g. `Users/johndoe`.
+- The second command (`chmod +x design-review.sh`) assigns executable permissions to `design-review.sh` allowing it to be run.
 
 
 ## Usage
@@ -17,8 +21,11 @@ Follow these steps to run script and spin up a local instance of the eCR Viewer.
 1. Ensure you have completed the initial setup instructions.
 2. Open the Terminal application.
 3. Copy and paste `./design-review.sh <MY-BRANCH> <IS_NON_INTEGRATED>` into the Terminal prompt.
-4. Replace `<MY-BRANCH>` with the name of the GitHub branch you would like to conduct a review on. For example, `./design-review.sh main` will spin up an instance of the eCR Viewer based on the current state of the `main` branch of repository.
-5. Replace `<IS_NON_INTEGRATED>` with either `true` or `false`. Setting it to `true` will show the non-integrated version of the eCR Viewer, while setting it to `false` will show the integrated version. If any other text is used for this second argument, an error message will be displayed: `Invalid value for IS_NON_INTEGRATED. It must be 'true' or 'false'`.
+4. Replace `<MY-BRANCH>` with the name of the GitHub branch you would like to conduct a review on. 
+    - For example, `./design-review.sh main` will spin up an instance of the eCR Viewer based on the current state of the `main` branch of repository.
+5. Replace `<IS_NON_INTEGRATED>` with either `true` or `false`. 
+    - Setting it to `true` will show the non-integrated version of the eCR Viewer, while setting it to `false` will show the integrated version. 
+    - If any other text is used for this second argument, an error message will be displayed: `Invalid value for IS_NON_INTEGRATED. It must be 'true' or 'false'`.
 6. Press enter. The script will now ensure that all required dependencies are installed on your machine, build and run the eCR Viewer, and finally navigate to the landing page in your system's default browser. Please note that because certain dependencies may need to be installed the script make take a few minutes the first time it is run on a machine. Additionally, depending on what needs to be installed you may be prompted at points during installation of dependencies to provide a password or click through some installation screens.
     - Note: If the landing page of the eCR Viewer displays `Something went wrong!`, try reloading the page to resolve the error.
 7. When you are done with your review to shut the eCR Viewer down return to Terminal and press enter.

--- a/containers/ecr-viewer/design-review/README.MD
+++ b/containers/ecr-viewer/design-review/README.MD
@@ -16,7 +16,9 @@ Follow these steps to run script and spin up a local instance of the eCR Viewer.
 
 1. Ensure you have completed the initial setup instructions.
 2. Open the Terminal application.
-3. Copy and paste `./design-review.sh <MY-BRANCH>` into the Terminal prompt.
+3. Copy and paste `./design-review.sh <MY-BRANCH> <IS_NON_INTEGRATED>` into the Terminal prompt.
 4. Replace `<MY-BRANCH>` with the name of the GitHub branch you would like to conduct a review on. For example, `./design-review.sh main` will spin up an instance of the eCR Viewer based on the current state of the `main` branch of repository.
-5. Press enter. The script will now ensure that all required dependencies are installed on your machine, build and run the eCR Viewer, and finally navigate to the landing page in your system's default browser. Please note that because certain dependencies may need to be installed the script make take a few minutes the first time it is run on a machine. Additionally, depending on what needs to be installed you may be prompted at points during installation of dependencies to provide a password or click through some installation screens.
-6. When you are done with your review to shut the eCR Viewer down return to Terminal and press enter.
+5. Replace `<IS_NON_INTEGRATED>` with either `true` or `false`. Setting it to `true` will show the non-integrated version of the eCR Viewer, while setting it to `false` will show the integrated version. If any other text is used for this second argument, an error message will be displayed: `Invalid value for IS_NON_INTEGRATED. It must be 'true' or 'false'`.
+6. Press enter. The script will now ensure that all required dependencies are installed on your machine, build and run the eCR Viewer, and finally navigate to the landing page in your system's default browser. Please note that because certain dependencies may need to be installed the script make take a few minutes the first time it is run on a machine. Additionally, depending on what needs to be installed you may be prompted at points during installation of dependencies to provide a password or click through some installation screens.
+    - Note: If the landing page of the eCR Viewer displays `Something went wrong!`, try reloading the page to resolve the error.
+7. When you are done with your review to shut the eCR Viewer down return to Terminal and press enter.

--- a/containers/ecr-viewer/design-review/design-review.sh
+++ b/containers/ecr-viewer/design-review/design-review.sh
@@ -20,8 +20,6 @@ else
     IS_NON_INTEGRATED=true
 fi
 
-echo $IS_NON_INTEGRATED
-
 # Function to check if a command exists
 command_exists() {
     command -v "$1" &> /dev/null
@@ -80,27 +78,10 @@ cd ./containers/ecr-viewer
 # Checkout the specified branch
 git checkout $BRANCH_NAME
 
-# TEST .env.local
- echo "APP_ENV=test" > .env.local
- echo "DATABASE_URL=postgres://postgres:pw@db:5432/ecr_viewer_db" >> .env.local
- echo "NEXT_PUBLIC_NON_INTEGRATED_VIEWER=$IS_NON_INTEGRATED" >> .env.local
-
-# Export env variables
-# export APP_ENV=test
-# export DATABASE_URL=postgres://postgres:pw@db:5432/ecr_viewer_db
-# export NEXT_PUBLIC_NON_INTEGRATED_VIEWER=$IS_NON_INTEGRATED
-
-# # Print environment variable before running docker-compose
-echo "APP_ENV before docker-compose: $APP_ENV"
-echo "NEXT_PUBLIC_NON_INTEGRATED_VIEWER before docker-compose: $NEXT_PUBLIC_NON_INTEGRATED_VIEWER"
-
-# # Run npm install if package.json exists
-# if [ -f package.json ]; then
-#     echo "Running npm install..."
-#     npm install
-# else
-#     echo "No package.json found, skipping npm install."
-# fi
+# Write necessary env vars to .env.local
+echo "APP_ENV=test" > .env.local
+echo "DATABASE_URL=postgres://postgres:pw@db:5432/ecr_viewer_db" >> .env.local
+echo "NEXT_PUBLIC_NON_INTEGRATED_VIEWER=$IS_NON_INTEGRATED" >> .env.local
 
 # Build and run docker-compose with APP_ENV=TEST
 docker-compose build --no-cache && docker compose --env-file .env.local up -d
@@ -111,7 +92,6 @@ while ! curl -s -o /dev/null -w "%{http_code}" "$URL" | grep -q "200"; do
     echo "Waiting for $URL to be available..."
     sleep 5
 done
-
 
 # Open in default browser
 open http://localhost:3000/

--- a/containers/ecr-viewer/design-review/design-review.sh
+++ b/containers/ecr-viewer/design-review/design-review.sh
@@ -68,7 +68,7 @@ cd ./containers/ecr-viewer
 # Checkout the specified branch
 git checkout $BRANCH_NAME
 
-# Write necessary env vars to .env.local
+# Write env vars to .env.local
 echo "APP_ENV=test" > .env.local
 echo "DATABASE_URL=postgres://postgres:pw@db:5432/ecr_viewer_db" >> .env.local
 echo "NEXT_PUBLIC_NON_INTEGRATED_VIEWER=$IS_NON_INTEGRATED" >> .env.local

--- a/containers/ecr-viewer/design-review/design-review.sh
+++ b/containers/ecr-viewer/design-review/design-review.sh
@@ -51,16 +51,6 @@ while ! docker system info > /dev/null 2>&1; do
     sleep 1
 done
 
-# Install Docker Compose if it's not already installed
-if ! command_exists docker-compose; then
-    brew install docker-compose
-fi
-
-if ! command_exists node; then
-    echo "Node.js not found, installing it now..."
-    brew install node
-fi
-
 # Clone the repository if it doesn't exist, otherwise pull the latest changes
 REPO_URL="https://github.com/CDCgov/phdi.git"
 REPO_DIR="phdi"
@@ -83,8 +73,8 @@ echo "APP_ENV=test" > .env.local
 echo "DATABASE_URL=postgres://postgres:pw@db:5432/ecr_viewer_db" >> .env.local
 echo "NEXT_PUBLIC_NON_INTEGRATED_VIEWER=$IS_NON_INTEGRATED" >> .env.local
 
-# Build and run docker-compose with APP_ENV=TEST
-docker-compose build --no-cache && docker compose --env-file .env.local up -d
+# Build and run docker compose
+docker compose --env-file .env.local up -d ecr-viewer db --build
 
 # Wait for eCR Viewer to be available
 URL="http://localhost:3000/"
@@ -98,4 +88,4 @@ open http://localhost:3000/
 
 # Prompt to end review session
 read -p "Press enter to end review"
-docker compose down
+docker compose down -v

--- a/containers/ecr-viewer/design-review/design-review.sh
+++ b/containers/ecr-viewer/design-review/design-review.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# Check if branch name is provided
+if [ -z "$1" ]; then
+    echo "Usage: $0 <branch-name>"
+    exit 1
+fi
+
+BRANCH_NAME=$1
+
+# Function to check if a command exists
+command_exists() {
+    command -v "$1" &> /dev/null
+}
+
+# Install Homebrew if it's not already installed
+if ! command_exists brew; then
+    echo "Homebrew not found, installing it now..."
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+fi
+
+# Update Homebrew
+brew update
+
+# Install Git if it's not already installed
+if ! command_exists git; then
+    brew install git
+fi
+
+# Install Docker if it's not already installed
+if ! command_exists docker; then
+    brew install --cask docker
+fi
+
+# Start Docker
+open /Applications/Docker.app
+echo "Waiting for Docker to launch..."
+while ! docker system info > /dev/null 2>&1; do
+    sleep 1
+done
+
+# Install Docker Compose if it's not already installed
+if ! command_exists docker-compose; then
+    brew install docker-compose
+fi
+
+# Clone the repository if it doesn't exist, otherwise pull the latest changes
+REPO_URL="https://github.com/CDCgov/phdi.git"
+REPO_DIR="phdi"
+
+if [ ! -d "$REPO_DIR" ]; then
+    git clone $REPO_URL
+    cd $REPO_DIR
+else
+    cd $REPO_DIR
+    git pull
+fi
+
+cd ./containers/ecr-viewer
+
+# Checkout the specified branch
+git checkout $BRANCH_NAME
+
+# Build and run docker-compose
+docker-compose build --no-cache && docker-compose up -d
+
+# Wait for eCR Viewer to be available
+URL="http://localhost:3000/ecr-viewer"
+while ! curl -s -o /dev/null -w "%{http_code}" "$URL" | grep -q "200"; do
+    echo "Waiting for $URL to be available..."
+    sleep 5
+done
+
+
+# Open in default browser
+open http://localhost:3000/ecr-viewer
+
+# Prompt to end review session
+read -p "Press enter to end review"
+docker compose down


### PR DESCRIPTION
# PULL REQUEST

## Summary
- Change VIPER's design review script for the eCR Viewer
- Add an argument to indicate whether or not to view the non-integrated vs. integrated eCR Viewer

## Related Issue
Fixes #2289

## Additional Information
Ty VIPER!

## Checklist

- [ ] Perform a mock design review using the script, and make sure it works :)

**To test this PR locally (Usage):**
1. Make sure you're on this branch: `angela/2289-design-review-script`
2. `cd containers/ecr-viewer/design-review`
3. `./design-review.sh <branch-to-test> <is_non_integrated>` where is_non_integrated is `true` or `false`

**To Test `Initial Setup` from the README:** I think this can only be tested once the PR merges to main? Because there's no design review script in the `ecr-viewer` container to download yet.

[//]: # (PR title: Remember to name your PR descriptively!)
