### PR TITLE
Add tests for utils.tsx

### DIFF
--- a/containers/tefca-viewer/src/app/query/components/Demographics.tsx
+++ b/containers/tefca-viewer/src/app/query/components/Demographics.tsx
@@ -1,5 +1,5 @@
 import { Patient } from "fhir/r4";
-import { DisplayData } from "@/app/utils";
+import { DataDisplayInfo } from "@/app/utils";
 import { DataDisplay } from "@/app/utils";
 import * as dateFns from "date-fns";
 import { evaluate } from "fhirpath";
@@ -46,8 +46,8 @@ export default Demographics;
  * @param patient - The patient to format demographic information for.
  * @returns The formatted demographic information as an array of DisplayData objects.
  */
-function formatDemographics(patient: Patient): DisplayData[] {
-  const demographicData: DisplayData[] = [
+function formatDemographics(patient: Patient): DataDisplayInfo[] {
+  const demographicData: DataDisplayInfo[] = [
     {
       title: "Patient Name",
       value: formatName(patient.name ?? []),
@@ -68,28 +68,28 @@ function formatDemographics(patient: Patient): DisplayData[] {
       title: "Race",
       value: evaluate(
         patient,
-        "Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').extension.first().valueCoding.display",
+        "Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').extension.first().valueCoding.display"
       )[0],
     },
     {
       title: "Ethnicity",
       value: evaluate(
         patient,
-        "Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').extension.first().valueCoding.display",
+        "Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').extension.first().valueCoding.display"
       )[0],
     },
     {
       title: "Tribal Affiliation",
       value: evaluate(
         patient,
-        "Patient.extension.where(url='http: //hl7.org/fhir/us/ecr/StructureDefinition/us-ph-tribal-affiliation-extension').extension.where(url='TribeName').value.display",
+        "Patient.extension.where(url='http: //hl7.org/fhir/us/ecr/StructureDefinition/us-ph-tribal-affiliation-extension').extension.where(url='TribeName').value.display"
       )[0],
     },
     {
       title: "Preferred Language",
       value: evaluate(
         patient,
-        "Patient.communication.first().language.coding.first().display",
+        "Patient.communication.first().language.coding.first().display"
       )[0],
     },
     {

--- a/containers/tefca-viewer/src/app/query/components/Demographics.tsx
+++ b/containers/tefca-viewer/src/app/query/components/Demographics.tsx
@@ -68,28 +68,28 @@ function formatDemographics(patient: Patient): DataDisplayInfo[] {
       title: "Race",
       value: evaluate(
         patient,
-        "Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').extension.first().valueCoding.display"
+        "Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').extension.first().valueCoding.display",
       )[0],
     },
     {
       title: "Ethnicity",
       value: evaluate(
         patient,
-        "Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').extension.first().valueCoding.display"
+        "Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').extension.first().valueCoding.display",
       )[0],
     },
     {
       title: "Tribal Affiliation",
       value: evaluate(
         patient,
-        "Patient.extension.where(url='http: //hl7.org/fhir/us/ecr/StructureDefinition/us-ph-tribal-affiliation-extension').extension.where(url='TribeName').value.display"
+        "Patient.extension.where(url='http: //hl7.org/fhir/us/ecr/StructureDefinition/us-ph-tribal-affiliation-extension').extension.where(url='TribeName').value.display",
       )[0],
     },
     {
       title: "Preferred Language",
       value: evaluate(
         patient,
-        "Patient.communication.first().language.coding.first().display"
+        "Patient.communication.first().language.coding.first().display",
       )[0],
     },
     {

--- a/containers/tefca-viewer/src/app/tests/unit/utils.test.tsx
+++ b/containers/tefca-viewer/src/app/tests/unit/utils.test.tsx
@@ -30,7 +30,7 @@ describe("DataDisplay Component", () => {
     // Check if the className is applied to the inner container
     expect(screen.getByText("Test Value")).toHaveClass("custom-class");
     expect(screen.getByText("Test Value").parentElement).toHaveClass(
-      "grid-row"
+      "grid-row",
     );
   });
 

--- a/containers/tefca-viewer/src/app/tests/unit/utils.test.tsx
+++ b/containers/tefca-viewer/src/app/tests/unit/utils.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { DataDisplay, DisplayData } from "../../utils";
+
+describe("DataDisplay Component", () => {
+  it("should render the title and value", () => {
+    const item: DisplayData = {
+      title: "Test Title",
+      value: "Test Value",
+    };
+
+    render(<DataDisplay item={item} />);
+
+    // Check if title is rendered
+    expect(screen.getByText("Test Title")).toBeInTheDocument();
+
+    // Check if value is rendered
+    expect(screen.getByText("Test Value")).toBeInTheDocument();
+  });
+
+  it("should apply the provided className", () => {
+    const item: DisplayData = {
+      title: "Test Title",
+      value: "Test Value",
+    };
+    const className = "custom-class";
+
+    render(<DataDisplay item={item} className={className} />);
+
+    // Check if the className is applied to the inner container
+    expect(screen.getByText("Test Value")).toHaveClass("custom-class");
+    expect(screen.getByText("Test Value").parentElement).toHaveClass(
+      "grid-row"
+    );
+  });
+
+  it("should render React elements as value", () => {
+    const item: DisplayData = {
+      title: "Test Title",
+      value: <span data-testid="custom-element">Custom Element</span>,
+    };
+
+    render(<DataDisplay item={item} />);
+
+    // Check if the custom React element is rendered
+    expect(screen.getByTestId("custom-element")).toBeInTheDocument();
+  });
+
+  it("should render an array of React elements as value", () => {
+    const item: DisplayData = {
+      title: "Test Title",
+      value: [
+        <span key="1" data-testid="element-1">
+          Element 1
+        </span>,
+        <span key="2" data-testid="element-2">
+          Element 2
+        </span>,
+      ],
+    };
+
+    render(<DataDisplay item={item} />);
+
+    // Check if the array of React elements is rendered
+    expect(screen.getByTestId("element-1")).toBeInTheDocument();
+    expect(screen.getByTestId("element-2")).toBeInTheDocument();
+  });
+});

--- a/containers/tefca-viewer/src/app/tests/unit/utils.test.tsx
+++ b/containers/tefca-viewer/src/app/tests/unit/utils.test.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import { DataDisplay, DisplayData } from "../../utils";
+import { DataDisplay, DataDisplayInfo } from "../../utils";
 
 describe("DataDisplay Component", () => {
   it("should render the title and value", () => {
-    const item: DisplayData = {
+    const item: DataDisplayInfo = {
       title: "Test Title",
       value: "Test Value",
     };
@@ -19,7 +19,7 @@ describe("DataDisplay Component", () => {
   });
 
   it("should apply the provided className", () => {
-    const item: DisplayData = {
+    const item: DataDisplayInfo = {
       title: "Test Title",
       value: "Test Value",
     };
@@ -35,7 +35,7 @@ describe("DataDisplay Component", () => {
   });
 
   it("should render React elements as value", () => {
-    const item: DisplayData = {
+    const item: DataDisplayInfo = {
       title: "Test Title",
       value: <span data-testid="custom-element">Custom Element</span>,
     };
@@ -47,7 +47,7 @@ describe("DataDisplay Component", () => {
   });
 
   it("should render an array of React elements as value", () => {
-    const item: DisplayData = {
+    const item: DataDisplayInfo = {
       title: "Test Title",
       value: [
         <span key="1" data-testid="element-1">

--- a/containers/tefca-viewer/src/app/utils.tsx
+++ b/containers/tefca-viewer/src/app/utils.tsx
@@ -11,7 +11,7 @@ export interface DisplayData {
 /**
  * Functional component for displaying data.
  * @param props - Props for the component.
- * @param props.item - The display data item to be rendered.
+ * @param props.item - The display data item(s) to be rendered.
  * @param [props.className] - Additional class name for styling purposes.
  * @returns - A React element representing the display of data.
  */

--- a/containers/tefca-viewer/src/app/utils.tsx
+++ b/containers/tefca-viewer/src/app/utils.tsx
@@ -3,7 +3,7 @@ import { createContext, ReactNode, useState } from "react";
 import React from "react";
 import classNames from "classnames";
 
-export interface DisplayData {
+export interface DataDisplayInfo {
   title: string;
   value?: string | React.JSX.Element | React.JSX.Element[];
 }
@@ -16,13 +16,13 @@ export interface DisplayData {
  * @returns - A React element representing the display of data.
  */
 export const DataDisplay: React.FC<{
-  item: DisplayData;
+  item: DataDisplayInfo;
   className?: string;
 }> = ({
   item,
   className,
 }: {
-  item: DisplayData;
+  item: DataDisplayInfo;
   className?: string;
 }): React.JSX.Element => {
   return (


### PR DESCRIPTION
# PULL REQUEST

## Summary
Adds unit tests to cover different scenarios for `DataDisplay` and renames the interface to `DataDisplayInfo`.

## Related Issue
Fixes #1736 

## Additional Information
You can rest easy knowing that we no longer have `DataDisplay` and `DisplayData` in our app.

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
