### PR TITLE
Increase test coverage of query-service

### DIFF
--- a/containers/tefca-viewer/e2e/query_workflow.spec.ts
+++ b/containers/tefca-viewer/e2e/query_workflow.spec.ts
@@ -173,6 +173,7 @@ test.describe("querying with the TryTEFCA viewer", () => {
     await page.getByRole("button", { name: "Go to the demo" }).click();
     await page.getByRole("button", { name: "Next" }).click();
     await page.getByLabel("Query", { exact: true }).selectOption("chlamydia");
+    await page.getByLabel("Phone Number").fill("");
     await page.getByRole("button", { name: "Search for patient" }).click();
     await expect(
       page.getByRole("heading", { name: "Query Results" }),

--- a/containers/tefca-viewer/e2e/query_workflow.spec.ts
+++ b/containers/tefca-viewer/e2e/query_workflow.spec.ts
@@ -152,6 +152,32 @@ test.describe("querying with the TryTEFCA viewer", () => {
     await expect(page.getByText("Patient Identifiers")).toBeVisible();
     await expect(page.getByText("34972316")).toBeVisible();
   });
+
+  test("social determinants query with generalized function", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Go to the demo" }).click();
+    await page.getByRole("button", { name: "Next" }).click();
+    await page
+      .getByLabel("Query", { exact: true })
+      .selectOption("social-determinants");
+    await page.getByRole("button", { name: "Search for patient" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Query Results" }),
+    ).toBeVisible();
+  });
+
+  test("form-fillable STI query using generalized function", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Go to the demo" }).click();
+    await page.getByRole("button", { name: "Next" }).click();
+    await page.getByLabel("Query", { exact: true }).selectOption("chlamydia");
+    await page.getByRole("button", { name: "Search for patient" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Query Results" }),
+    ).toBeVisible();
+  });
 });
 
 test.describe("Test the user journey of a 'tester'", () => {

--- a/containers/tefca-viewer/src/app/query-service.ts
+++ b/containers/tefca-viewer/src/app/query-service.ts
@@ -117,10 +117,15 @@ async function patientQuery(
     const phonesToSearch = request.phone.split(";");
     let phonePossibilities: string[] = [];
     for (const phone of phonesToSearch) {
-      const possibilities = await GetPhoneQueryFormats(phone);
-      phonePossibilities.push(...possibilities);
+      let possibilities = await GetPhoneQueryFormats(phone);
+      possibilities = possibilities.filter((phone) => phone !== "");
+      if (possibilities.length !== 0) {
+        phonePossibilities.push(...possibilities);
+      }
     }
-    query += `phone=${phonePossibilities.join(",")}&`;
+    if (phonePossibilities.length > 0) {
+      query += `phone=${phonePossibilities.join(",")}&`;
+    }
   }
 
   const response = await fhirClient.get(query);

--- a/containers/tefca-viewer/src/app/query-service.ts
+++ b/containers/tefca-viewer/src/app/query-service.ts
@@ -206,7 +206,7 @@ async function generalizedQuery(
  * @param queryResponse - The response object to store the results.
  * @returns - The parsed response.
  */
-async function parseFhirSearch(
+export async function parseFhirSearch(
   response: fetch.Response | Array<fetch.Response>,
   queryResponse: QueryResponse = {},
 ): Promise<QueryResponse> {
@@ -239,7 +239,9 @@ async function parseFhirSearch(
  * @param response - The response from the FHIR server.
  * @returns - The array of resources from the response.
  */
-async function processResponse(response: fetch.Response): Promise<any[]> {
+export async function processResponse(
+  response: fetch.Response,
+): Promise<any[]> {
   let resourceArray: any[] = [];
   if (response.status === 200) {
     const body = await response.json();

--- a/containers/tefca-viewer/src/app/tests/integration/api-query.test.ts
+++ b/containers/tefca-viewer/src/app/tests/integration/api-query.test.ts
@@ -3,22 +3,7 @@
  */
 
 import { GET, POST } from "../../api/query/route";
-import * as fs from "fs";
-
-/**
- * Helper function to read a JSON file from a given file path.
- * @param filePath The relative string path to the file.
- * @returns A JSON object of the string representation of the file.
- */
-function readJsonFile(filePath: string): any {
-  try {
-    const data = fs.readFileSync(filePath, "utf-8");
-    return JSON.parse(data);
-  } catch (error) {
-    console.error(`Error reading JSON file from ${filePath}:`, error);
-    return null;
-  }
-}
+import { readJsonFile } from "../shared_utils/readJsonFile";
 
 const PatientBundle = readJsonFile("./src/app/tests/assets/BundlePatient.json");
 const PatientResource = PatientBundle?.entry[0].resource;

--- a/containers/tefca-viewer/src/app/tests/shared_utils/readJsonFile.ts
+++ b/containers/tefca-viewer/src/app/tests/shared_utils/readJsonFile.ts
@@ -1,0 +1,20 @@
+/**
+ * @jest-environment node
+ */
+
+import * as fs from "fs";
+
+/**
+ * Helper function to read a JSON file from a given file path.
+ * @param filePath The relative string path to the file.
+ * @returns A JSON object of the string representation of the file.
+ */
+export function readJsonFile(filePath: string): any {
+  try {
+    const data = fs.readFileSync(filePath, "utf-8");
+    return JSON.parse(data);
+  } catch (error) {
+    console.error(`Error reading JSON file from ${filePath}:`, error);
+    return null;
+  }
+}

--- a/containers/tefca-viewer/src/app/tests/unit/format-service.test.tsx
+++ b/containers/tefca-viewer/src/app/tests/unit/format-service.test.tsx
@@ -9,6 +9,7 @@ import {
   formatMRN,
   formatString,
   FormatPhoneAsDigits,
+  GetPhoneQueryFormats,
 } from "@/app/format-service";
 import {
   Address,
@@ -463,5 +464,31 @@ describe("FormatPhoneAsDigits", () => {
     const givenPhone = "+44 202 555 8736";
     const expectedResult = "+44 202 555 8736";
     expect(FormatPhoneAsDigits(givenPhone)).toEqual(expectedResult);
+  });
+});
+
+describe("GetPhoneQueryFormats", () => {
+  it("should fail gracefully on partial phone number inputs", async () => {
+    const partialPhone = "456 7890";
+    const expectedResult = ["456+7890"];
+    expect(await GetPhoneQueryFormats(partialPhone)).toEqual(expectedResult);
+  });
+  it("should fail gracefully on given phones with separators remaining", async () => {
+    const phoneWithStuff = "+44.202.456.7890";
+    const expectedResult = ["+44.202.456.7890"];
+    expect(await GetPhoneQueryFormats(phoneWithStuff)).toEqual(expectedResult);
+  });
+  it("should fully process ten-digit input strings", async () => {
+    const inputPhone = "1234567890";
+    const expectedResult = [
+      "1234567890",
+      "123-456-7890",
+      "123+456+7890",
+      "(123)+456+7890",
+      "(123)-456-7890",
+      "(123)456-7890",
+      "1(123)456-7890",
+    ];
+    expect(await GetPhoneQueryFormats(inputPhone)).toEqual(expectedResult);
   });
 });

--- a/containers/tefca-viewer/src/app/tests/unit/format-service.test.tsx
+++ b/containers/tefca-viewer/src/app/tests/unit/format-service.test.tsx
@@ -478,6 +478,9 @@ describe("GetPhoneQueryFormats", () => {
     const expectedResult = ["+44.202.456.7890"];
     expect(await GetPhoneQueryFormats(phoneWithStuff)).toEqual(expectedResult);
   });
+  it("should fail gracefully when given an empty string or missing phone number", async () => {
+    expect(await GetPhoneQueryFormats("")).toEqual([""]);
+  });
   it("should fully process ten-digit input strings", async () => {
     const inputPhone = "1234567890";
     const expectedResult = [

--- a/containers/tefca-viewer/src/app/tests/unit/query-service.test.tsx
+++ b/containers/tefca-viewer/src/app/tests/unit/query-service.test.tsx
@@ -1,27 +1,112 @@
-import { GetPhoneQueryFormats } from "@/app/format-service";
+import fetch from "node-fetch";
 
-describe("GetPhoneQueryFormats", () => {
-  it("should fail gracefully on partial phone number inputs", async () => {
-    const partialPhone = "456 7890";
-    const expectedResult = ["456+7890"];
-    expect(await GetPhoneQueryFormats(partialPhone)).toEqual(expectedResult);
+import {
+  createBundle,
+  QueryResponse,
+  processResponse,
+  parseFhirSearch,
+} from "@/app/query-service";
+import { readJsonFile } from "../shared_utils/readJsonFile";
+import { DiagnosticReport, Observation, Patient } from "fhir/r4";
+
+describe("create bundle", () => {
+  it("should turn a collection of resource arrays into a search set FHIR bundle", async () => {
+    const patientBundle = readJsonFile(
+      "./src/app/tests/assets/BundlePatient.json",
+    );
+    const PatientResource = patientBundle?.entry[0].resource;
+    const labsBundle = readJsonFile(
+      "./src/app/tests/assets/BundleLabInfo.json",
+    );
+    const diagnosticReportResource = labsBundle?.entry.filter(
+      (e: any) => e?.resource?.resourceType === "DiagnosticReport",
+    );
+    const observationResources = labsBundle?.entry.filter(
+      (e: any) => e?.resource?.resourceType === "Observation",
+    );
+    const queryResponse: QueryResponse = {
+      Patient: [PatientResource as Patient],
+      DiagnosticReport: diagnosticReportResource as DiagnosticReport[],
+      Observation: observationResources as Observation[],
+    };
+
+    const fhirBundle = await createBundle(queryResponse);
+    expect(fhirBundle.resourceType).toEqual("Bundle");
+    expect(fhirBundle.type).toEqual("searchset");
+    expect(fhirBundle.total).toEqual(4);
+    expect(fhirBundle.entry?.length).toEqual(4);
   });
-  it("should fail gracefully on given phones with separators remaining", async () => {
-    const phoneWithStuff = "+44.202.456.7890";
-    const expectedResult = ["+44.202.456.7890"];
-    expect(await GetPhoneQueryFormats(phoneWithStuff)).toEqual(expectedResult);
+});
+
+describe("process response", () => {
+  it("should unpack a response from the server into an array of resources", async () => {
+    const patientBundle = readJsonFile(
+      "./src/app/tests/assets/BundlePatient.json",
+    );
+    const labsBundle = readJsonFile(
+      "./src/app/tests/assets/BundleLabInfo.json",
+    );
+    const diagnosticReportResource = labsBundle?.entry.filter(
+      (e: any) => e?.resource?.resourceType === "DiagnosticReport",
+    );
+    const observationResources = labsBundle?.entry.filter(
+      (e: any) => e?.resource?.resourceType === "Observation",
+    );
+    patientBundle?.entry?.push(diagnosticReportResource[0]);
+    observationResources.forEach((or: any) => {
+      patientBundle?.entry?.push(or);
+    });
+
+    const response = {
+      status: 200,
+      json: async () => patientBundle,
+    } as unknown as fetch.Response;
+    const resourceArray = await processResponse(response);
+    expect(resourceArray.length).toEqual(4);
+    expect(resourceArray.find((r) => r.resourceType === "Patient")) ===
+      patientBundle?.entry[0].resource;
+    expect(
+      resourceArray.filter((r) => r.resourceType === "Observation").length,
+    ).toEqual(2);
   });
-  it("should fully process ten-digit input strings", async () => {
-    const inputPhone = "1234567890";
-    const expectedResult = [
-      "1234567890",
-      "123-456-7890",
-      "123+456+7890",
-      "(123)+456+7890",
-      "(123)-456-7890",
-      "(123)456-7890",
-      "1(123)456-7890",
-    ];
-    expect(await GetPhoneQueryFormats(inputPhone)).toEqual(expectedResult);
+});
+
+describe("parse fhir search", () => {
+  it("should turn the FHIR server's response into a QueryResponse struct", async () => {
+    const patientBundle = readJsonFile(
+      "./src/app/tests/assets/BundlePatient.json",
+    );
+    const labsBundle = readJsonFile(
+      "./src/app/tests/assets/BundleLabInfo.json",
+    );
+    const diagnosticReportEntry = labsBundle?.entry.filter(
+      (e: any) => e?.resource?.resourceType === "DiagnosticReport",
+    );
+    const observationEntries = labsBundle?.entry.filter(
+      (e: any) => e?.resource?.resourceType === "Observation",
+    );
+    patientBundle?.entry?.push(diagnosticReportEntry[0]);
+    observationEntries.forEach((or: any) => {
+      patientBundle?.entry?.push(or);
+    });
+
+    const response = {
+      status: 200,
+      json: async () => patientBundle,
+    } as unknown as fetch.Response;
+    const queryResponse: QueryResponse = await parseFhirSearch(response);
+    expect((queryResponse.Patient || [{}])[0]).toEqual(
+      patientBundle?.entry[0]?.resource,
+    );
+    expect((queryResponse.DiagnosticReport || [{}])[0]).toEqual(
+      diagnosticReportEntry[0]?.resource,
+    );
+    expect(queryResponse.Observation?.length).toEqual(2);
+    const observationResources: Observation[] = observationEntries.map(
+      (oe: any) => oe.resource,
+    );
+    queryResponse.Observation?.forEach((o: Observation) => {
+      expect(observationResources).toContain(o);
+    });
   });
 });


### PR DESCRIPTION
# Query Service Test Coverage

## Summary
This PR adds unit and e2e tests into our app to complete coverage of the query service. Helper and data manipulation functions used by the query-service are tested in jest's unit framework, while tests of the larger, central `generalizedQuery` function are better suited to integration to verify that patient results are found.

## Related Issue
Fixes #1737 