### PR TITLE
Add sub text to eCR Summary & Document headers

### DIFF
--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/LoadingComponent.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/LoadingComponent.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`Snapshot test for EcrLoadingSkeleton should match snapshot 1`] = `
             class="sticky-nav"
           >
             <div
-              class="nav-wrapper"
+              class="nav-wrapper padding-top-10px"
             >
               <nav
                 class="sticky-nav top-550"

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/LoadingComponent.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/LoadingComponent.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`Snapshot test for EcrLoadingSkeleton should match snapshot 1`] = `
             class="sticky-nav"
           >
             <div
-              class="nav-wrapper padding-top-10px"
+              class="nav-wrapper padding-top-1-25"
             >
               <nav
                 class="sticky-nav top-550"

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/LoadingComponent.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/LoadingComponent.test.tsx.snap
@@ -30,6 +30,16 @@ exports[`Snapshot test for EcrLoadingSkeleton should match snapshot 1`] = `
                   >
                     <a
                       class=""
+                      href="#ecr-summary"
+                    >
+                      eCR Summary
+                    </a>
+                  </li>
+                  <li
+                    class="usa-sidenav__item"
+                  >
+                    <a
+                      class=""
                       href="#ecr-document"
                     >
                       eCR Document
@@ -280,12 +290,22 @@ exports[`Snapshot test for EcrLoadingSkeleton should match snapshot 1`] = `
           <div
             class="ecr-content"
           >
-            <h2
-              class="margin-bottom-3 side-nav-ignore"
-              id="ecr-summary"
+            <div
+              class="margin-bottom-3"
             >
-              eCR Summary
-            </h2>
+              <h2
+                class="margin-bottom-05"
+                data-sectionid="ecr-summary"
+                id="ecr-summary"
+              >
+                eCR Summary
+              </h2>
+              <div
+                class="text-base-darker line-height-sans-5"
+              >
+                Provides key info upfront to help you understand the eCR at a glance
+              </div>
+            </div>
             <div
               class="info-container"
             >
@@ -594,7 +614,7 @@ exports[`Snapshot test for EcrLoadingSkeleton should match snapshot 1`] = `
                 data-testid="gridContainer"
               >
                 <div
-                  class="grid-row"
+                  class="grid-row margin-bottom-05"
                   data-testid="grid"
                 >
                   <div
@@ -633,6 +653,11 @@ exports[`Snapshot test for EcrLoadingSkeleton should match snapshot 1`] = `
                       Collapse all sections
                     </button>
                   </div>
+                </div>
+                <div
+                  class="text-base-darker line-height-sans-5"
+                >
+                  Displays entire eICR and RR documents to help you dig further into eCR data
                 </div>
               </div>
               <div

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/SideNav.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/SideNav.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`SectionConfig should match the snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="nav-wrapper padding-top-10px"
+    class="nav-wrapper padding-top-1-25"
   >
     <nav
       class="sticky-nav top-550"

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/SideNav.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/SideNav.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`SectionConfig should match the snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="nav-wrapper"
+    class="nav-wrapper padding-top-10px"
   >
     <nav
       class="sticky-nav top-550"

--- a/containers/ecr-viewer/src/app/view-data/components/LoadingComponent.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/LoadingComponent.tsx
@@ -170,13 +170,19 @@ export const EcrLoadingSkeleton = () => {
           </div>
           <div className={"ecr-viewer-container"}>
             <div className="ecr-content">
-              <h2 className="margin-bottom-3 side-nav-ignore" id="ecr-summary">
-                eCR Summary
-              </h2>
+              <div className="margin-bottom-3">
+                <h2 className="margin-bottom-05" id="ecr-summary">
+                  eCR Summary
+                </h2>
+                <div className="text-base-darker line-height-sans-5">
+                  Provides key info upfront to help you understand the eCR at a
+                  glance
+                </div>
+              </div>
               <EcrSummaryLoadingSkeleton />
               <div className="margin-top-10">
                 <GridContainer className={"padding-0 margin-bottom-3"}>
-                  <Grid row>
+                  <Grid row className="margin-bottom-05">
                     <Grid>
                       <h2 className="margin-bottom-0" id="ecr-document">
                         eCR Document
@@ -194,6 +200,10 @@ export const EcrLoadingSkeleton = () => {
                       />
                     </Grid>
                   </Grid>
+                  <div className="text-base-darker line-height-sans-5">
+                    Displays entire eICR and RR documents to help you dig
+                    further into eCR data
+                  </div>
                 </GridContainer>
                 <AccordionLoadingSkeleton />
               </div>

--- a/containers/ecr-viewer/src/app/view-data/components/SideNav.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/SideNav.tsx
@@ -217,7 +217,7 @@ const SideNav: React.FC = () => {
   let sideNavItems = buildSideNav(sectionConfigs);
 
   return (
-    <div className="nav-wrapper">
+    <div className="nav-wrapper padding-top-10px">
       <nav
         className={classNames("sticky-nav", {
           "top-0": !isNonIntegratedViewer,

--- a/containers/ecr-viewer/src/app/view-data/components/SideNav.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/SideNav.tsx
@@ -217,7 +217,7 @@ const SideNav: React.FC = () => {
   let sideNavItems = buildSideNav(sectionConfigs);
 
   return (
-    <div className="nav-wrapper padding-top-10px">
+    <div className="nav-wrapper padding-top-1-25">
       <nav
         className={classNames("sticky-nav", {
           "top-0": !isNonIntegratedViewer,

--- a/containers/ecr-viewer/src/app/view-data/page.tsx
+++ b/containers/ecr-viewer/src/app/view-data/page.tsx
@@ -108,9 +108,15 @@ const ECRViewerPage: React.FC = () => {
             <div className="content-wrapper">
               <SideNav />
               <div className={"ecr-viewer-container"}>
-                <h2 className="margin-bottom-3" id="ecr-summary">
-                  eCR Summary
-                </h2>
+                <div className="margin-bottom-3">
+                  <h2 className="margin-bottom-05" id="ecr-summary">
+                    eCR Summary
+                  </h2>
+                  <div className="text-base-darker line-height-sans-5">
+                    Provides key info upfront to help you understand the eCR at
+                    a glance
+                  </div>
+                </div>
                 <EcrSummary
                   patientDetails={
                     evaluateEcrSummaryPatientDetails(fhirBundle, mappings)
@@ -131,7 +137,7 @@ const ECRViewerPage: React.FC = () => {
                   <GridContainer
                     className={"padding-0 margin-bottom-3 maxw-none"}
                   >
-                    <Grid row>
+                    <Grid row className="margin-bottom-05">
                       <Grid>
                         <h2 className="margin-bottom-0" id="ecr-document">
                           eCR Document
@@ -151,6 +157,10 @@ const ECRViewerPage: React.FC = () => {
                         />
                       </Grid>
                     </Grid>
+                    <div className="text-base-darker line-height-sans-5">
+                      Displays entire eICR and RR documents to help you dig
+                      further into eCR data
+                    </div>
                   </GridContainer>
                   <AccordionContent
                     fhirPathMappings={mappings}

--- a/containers/ecr-viewer/src/styles/utilities.scss
+++ b/containers/ecr-viewer/src/styles/utilities.scss
@@ -45,6 +45,6 @@
   width: 25%;
 }
 
-.padding-top-10px {
+.padding-top-1-25 {
   padding-top: 0.625rem;
 }

--- a/containers/ecr-viewer/src/styles/utilities.scss
+++ b/containers/ecr-viewer/src/styles/utilities.scss
@@ -45,3 +45,6 @@
   width: 25%;
 }
 
+.padding-top-10px {
+  padding-top: 0.625rem;
+}


### PR DESCRIPTION
# PULL REQUEST

## Summary
- Add sub-header text below the `eCR Summary` and `eCR Document` headers (applies to both main page & Loading component)
- Update snapshot test

## Related Issue
Fixes #2179

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
