### PR TITLE
Fix TEFCA Customize Query Nav Tab Styling

### DIFF
--- a/containers/tefca-viewer/src/app/constants.ts
+++ b/containers/tefca-viewer/src/app/constants.ts
@@ -257,4 +257,5 @@ export type Mode =
   | "results"
   | "multiple-patients"
   | "no-patients"
-  | "multiple-patients-results";
+  | "multiple-patients-results"
+  | "customize-queries";

--- a/containers/tefca-viewer/src/app/customize/page.tsx
+++ b/containers/tefca-viewer/src/app/customize/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from "react";
 import CustomizeQuery from "../query/components/CustomizeQuery"; // Adjust the path if necessary
-import { Mode } from "../query/page";
+import { Mode } from "../constants";
 
 const dummyLabs = [
   {

--- a/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
+++ b/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from "react";
 import { Accordion, Button, Icon, Checkbox } from "@trussworks/react-uswds";
-import { Mode } from "../page";
+import { Mode } from "../../constants";
 import { AccordianSection, AccordianDiv } from "../component-utils";
 
 interface Lab {

--- a/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
+++ b/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
@@ -124,48 +124,47 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
   ) => {
     const selectedCount = items.filter((item) => item.include).length;
     return items.length
-      ? [
-          {
-            title: (
-              <div className="accordion-title">
-                <div className="accordion-header">
-                  <Checkbox
-                    id="select-all"
-                    name="select-all"
-                    className="custom-checkbox"
-                    checked={selectedCount === items.length}
-                    onChange={(e) =>
-                      handleSelectAllChange(items, setItems, e.target.checked)
-                    }
-                    label={undefined}
-                  />
-                  {`${items[0].display}`}
-                  <div>{`${selectedCount} selected`}</div>
-                </div>
-                <div className="accordion-subtitle">
-                  <strong>Author:</strong> {items[0].author}{" "}
-                  <strong>System:</strong> {items[0].system}
-                </div>
+      ? items.map((item, index) => ({
+          id: `${title}-${index}`,
+          title: (
+            <div className="accordion-title">
+              <div className="accordion-header">
+                <Checkbox
+                  id="select-all"
+                  name="select-all"
+                  className="custom-checkbox"
+                  checked={selectedCount === items.length}
+                  onChange={(e) =>
+                    handleSelectAllChange(items, setItems, e.target.checked)
+                  }
+                  label={undefined}
+                />
+                {`${item.display}`}
+                <div>{`${selectedCount} selected`}</div>
               </div>
-            ),
-            content: (
-              <>
-                <AccordianSection>
-                  <AccordianDiv>
-                    <div className="accordion-table-header">
-                      <div className="accordion-header-cell">Include</div>
-                      <div className="accordion-header-cell">Code</div>
-                      <div className="accordion-header-cell">Display</div>
-                    </div>
-                    {renderItems(items, setItems)}
-                  </AccordianDiv>
-                </AccordianSection>
-              </>
-            ),
-            expanded: true,
-            headingLevel: "h3",
-          },
-        ]
+              <div className="accordion-subtitle">
+                <strong>Author:</strong> {item.author} <strong>System:</strong>{" "}
+                {item.system}
+              </div>
+            </div>
+          ),
+          content: (
+            <>
+              <AccordianSection>
+                <AccordianDiv>
+                  <div className="accordion-table-header">
+                    <div className="accordion-header-cell">Include</div>
+                    <div className="accordion-header-cell">Code</div>
+                    <div className="accordion-header-cell">Display</div>
+                  </div>
+                  {renderItems(items, setItems)}
+                </AccordianDiv>
+              </AccordianSection>
+            </>
+          ),
+          expanded: true,
+          headingLevel: "h3" as "h3",
+        }))
       : [];
   };
 

--- a/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
+++ b/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
@@ -175,39 +175,41 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
 
   return (
     <div className="customize-query-container">
-      <a href="#" onClick={() => setMode("search")} className="text-bold">
+      <a
+        href="#"
+        onClick={() => setMode("search")}
+        className="text-bold"
+        style={{ fontSize: "16px", fontFamily: "Public Sans" }}
+      >
         <Icon.ArrowBack /> Return to patient search
       </a>
       <h1 className="font-sans-2xl text-bold">Customize query</h1>
       <p className="font-sans-lg text-light">Query: {queryType}</p>
       <nav className="usa-nav custom-nav">
-        <ul className="usa-nav__primary usa-accordion">
-          <li
-            className={`usa-nav__primary-item ${activeTab === "labs" ? "usa-current" : ""}`}
-          >
-            <a href="#labs" onClick={() => handleTabChange("labs")}>
-              Labs
-            </a>
-          </li>
-          <li
-            className={`usa-nav__primary-item ${activeTab === "medications" ? "usa-current" : ""}`}
-          >
-            <a
-              href="#medications"
-              onClick={() => handleTabChange("medications")}
-            >
-              Medications
-            </a>
-          </li>
-          <li
-            className={`usa-nav__primary-item ${activeTab === "conditions" ? "usa-current" : ""}`}
-          >
-            <a href="#conditions" onClick={() => handleTabChange("conditions")}>
-              Conditions
-            </a>
-          </li>
-        </ul>
+        <li
+          className={`usa-nav__primary-item ${activeTab === "labs" ? "usa-current" : ""}`}
+        >
+          <a href="#labs" onClick={() => handleTabChange("labs")}>
+            Labs
+          </a>
+        </li>
+        <li
+          className={`usa-nav__primary-item ${activeTab === "medications" ? "usa-current" : ""}`}
+        >
+          <a href="#medications" onClick={() => handleTabChange("medications")}>
+            Medications
+          </a>
+        </li>
+        <li
+          className={`usa-nav__primary-item ${activeTab === "conditions" ? "usa-current" : ""}`}
+        >
+          <a href="#conditions" onClick={() => handleTabChange("conditions")}>
+            Conditions
+          </a>
+        </li>
       </nav>
+      <ul className="usa-nav__primary usa-accordion"></ul>
+      <hr className="custom-hr"></hr>
       <a
         href="#"
         type="button"

--- a/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
+++ b/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
@@ -213,7 +213,12 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
       <a
         href="#"
         type="button"
-        style={{ fontSize: "16px", fontFamily: "Public Sans" }}
+        style={{
+          fontSize: "16px",
+          fontFamily: "Public Sans",
+          paddingTop: "20px",
+          paddingBottom: "20px",
+        }}
         onClick={() => {
           if (activeTab === "labs") handleIncludeAll(setLabsState, true);
           if (activeTab === "medications")

--- a/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
+++ b/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
@@ -178,12 +178,14 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
         href="#"
         onClick={() => setMode("search")}
         className="text-bold"
-        style={{ fontSize: "16px", fontFamily: "Public Sans" }}
+        style={{ fontSize: "16px" }}
       >
         <Icon.ArrowBack /> Return to patient search
       </a>
       <h1 className="font-sans-2xl text-bold">Customize query</h1>
-      <p className="font-sans-lg text-light">Query: {queryType}</p>
+      <p className="font-sans-lg text-light" style={{ paddingBottom: "0px" }}>
+        Query: {queryType}
+      </p>
       <nav className="usa-nav custom-nav">
         <li
           className={`usa-nav__primary-item ${activeTab === "labs" ? "usa-current" : ""}`}
@@ -212,12 +214,7 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
       <a
         href="#"
         type="button"
-        style={{
-          fontSize: "16px",
-          fontFamily: "Public Sans",
-          paddingTop: "20px",
-          paddingBottom: "20px",
-        }}
+        className="include-all-link"
         onClick={() => {
           if (activeTab === "labs") handleIncludeAll(setLabsState, true);
           if (activeTab === "medications")

--- a/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
+++ b/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
@@ -185,12 +185,12 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
       <h1 className="font-sans-2xl text-bold" style={{ paddingBottom: "0px" }}>
         Customize query
       </h1>
-      <p
+      <div
         className="font-sans-lg text-light"
         style={{ paddingBottom: "0px", paddingTop: "4px" }}
       >
         Query: {queryType}
-      </p>
+      </div>
       <nav className="usa-nav custom-nav">
         <li
           className={`usa-nav__primary-item ${activeTab === "labs" ? "usa-current" : ""}`}

--- a/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
+++ b/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
@@ -182,8 +182,13 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
       >
         <Icon.ArrowBack /> Return to patient search
       </a>
-      <h1 className="font-sans-2xl text-bold">Customize query</h1>
-      <p className="font-sans-lg text-light" style={{ paddingBottom: "0px" }}>
+      <h1 className="font-sans-2xl text-bold" style={{ paddingBottom: "0px" }}>
+        Customize query
+      </h1>
+      <p
+        className="font-sans-lg text-light"
+        style={{ paddingBottom: "0px", paddingTop: "4px" }}
+      >
         Query: {queryType}
       </p>
       <nav className="usa-nav custom-nav">

--- a/containers/tefca-viewer/src/styles/custom-styles.scss
+++ b/containers/tefca-viewer/src/styles/custom-styles.scss
@@ -807,7 +807,7 @@ html {
 
 hr.custom-hr {
   width: 100%;
-  height: 1px;
+  height: 0px;
   background-color: #ddd;
   margin-top: 0;
   margin-bottom: 0;
@@ -815,4 +815,5 @@ hr.custom-hr {
   position: relative;
   top: -6px;
   z-index: -1;
+  border-top: 1px solid #71767A;
 }

--- a/containers/tefca-viewer/src/styles/custom-styles.scss
+++ b/containers/tefca-viewer/src/styles/custom-styles.scss
@@ -732,6 +732,8 @@ html {
 
 .custom-nav li {
   list-style: none;
+  padding: 0;
+  margin: 0;
 }
 
 .custom-nav a {
@@ -739,6 +741,8 @@ html {
   text-decoration: none;
   font-weight: normal;
   font-size: 18px;
+  padding: 0;
+  margin: 0;
   // font-family: "Source Sans Pro";
 }
 

--- a/containers/tefca-viewer/src/styles/custom-styles.scss
+++ b/containers/tefca-viewer/src/styles/custom-styles.scss
@@ -683,10 +683,13 @@ html {
   transform: translate(-50%, -50%) scale(1);
 }
 
+// navigations
 .usa-nav {
   display: flex;
   justify-content: flex-start;
+  align-items: center;
   margin-bottom: 1rem;
+  width: 100%;
 }
 
 .usa-nav__primary {
@@ -708,6 +711,11 @@ html {
   font-weight: bold;
 }
 
+.custom-nav {
+  display: flex;
+  justify-content: flex-start;
+}
+
 .custom-nav ul {
   list-style-type: none;
   padding: 0;
@@ -716,8 +724,8 @@ html {
   gap: 20px;
   align-items: flex-start;
   color: #565C65;
-  font-family: "Source Sans Pro";
-  position: relative;
+  // font-family: "Source Sans Pro";
+  position: left;
 }
 
 .custom-nav li {
@@ -725,40 +733,60 @@ html {
 }
 
 .custom-nav a {
-  color: #565C65; /* Same gray color */
+  color: #565C65;
   text-decoration: none;
   font-weight: normal;
   font-size: 18px;
-  font-family: "Source Sans Pro";
+  // font-family: "Source Sans Pro";
 }
 
 .custom-nav a:hover,
 .custom-nav a:focus {
   color: #565C65;
-  background-color: transparent; /* Remove the background */
-  border: none; /* Remove the blue border */
-  outline: none; /* Remove the outline */
+  background-color: transparent;
+  border: none;
+  outline: none;
 }
 
-/* Ensure the current tab is bolded but doesn't change color */
 .custom-nav .usa-current a {
+  position: relative;
   font-weight: bold;
   font-size: 18px;
-  font-family: "Source Sans Pro";
-  color: #565C65; /* Maintain the same gray color */
-  background-color: transparent; /* Remove any background */
-  border: none; /* Remove any border */
-  outline: none; /* Remove any outline */
+  color: #565C65;
+  background-color: transparent;
+  border: none;
+  outline: none;
+  text-decoration: none;
+  /* Remove default underline */
 }
+
+.custom-nav .usa-current a::after {
+  content: '';
+  position: absolute;
+  bottom: -8px;
+  /* Position the underline just below the text */
+  left: 0;
+  width: 100%;
+  height: 4px;
+  /* Stroke width */
+  background-color: #005EA2;
+  /* Blue color for the underline */
+}
+
+/* Adjust this rule to avoid interference */
 .custom-nav ul::after {
   content: '';
   display: block;
-  width: 960px;
+  width: 100%;
+  /* Make the width relative to the parent */
   height: 1px;
   background-color: #ddd;
   position: absolute;
-  bottom: 10px;
-  left: -560px;
+  bottom: 0;
+  /* Align it with the bottom of the container */
+  left: 0;
+  right: 0;
+  /* Ensures it spans the entire width of the container */
 }
 
 .usa-accordion__content {
@@ -777,10 +805,24 @@ html {
   gap: 10px;
   margin-top: 20px;
   padding-bottom: 20px;
-}  
+}
 
 .back-link {
   display: inline-flex;
   align-items: center;
   gap: 4px;
+}
+
+hr.custom-hr {
+  width: 100%;
+  height: 1px;
+  background-color: #ddd;
+  margin-top: 0;
+  margin-bottom: 0;
+  border: none;
+  position: relative;
+  top: -6px;
+  /* Adjust this to align it with the blue underline */
+  z-index: -1;
+  /* Place it behind the blue underline */
 }

--- a/containers/tefca-viewer/src/styles/custom-styles.scss
+++ b/containers/tefca-viewer/src/styles/custom-styles.scss
@@ -714,6 +714,8 @@ html {
 .custom-nav {
   display: flex;
   justify-content: flex-start;
+  gap: 32px;
+  padding-top: 32px;
 }
 
 .custom-nav ul {
@@ -779,6 +781,18 @@ html {
   bottom: 0;
   left: 0;
   right: 0;
+}
+
+.include-all-link {
+  font-size: 16px;
+  padding-top: 20px;
+  padding-bottom: 20px;
+}
+
+.include-all-link:hover,
+.include-all-link:focus {
+  border: none;
+  outline: none;
 }
 
 .usa-accordion__content {

--- a/containers/tefca-viewer/src/styles/custom-styles.scss
+++ b/containers/tefca-viewer/src/styles/custom-styles.scss
@@ -757,36 +757,28 @@ html {
   border: none;
   outline: none;
   text-decoration: none;
-  /* Remove default underline */
 }
 
 .custom-nav .usa-current a::after {
   content: '';
   position: absolute;
   bottom: -8px;
-  /* Position the underline just below the text */
   left: 0;
   width: 100%;
   height: 4px;
-  /* Stroke width */
   background-color: #005EA2;
-  /* Blue color for the underline */
 }
 
-/* Adjust this rule to avoid interference */
 .custom-nav ul::after {
   content: '';
   display: block;
   width: 100%;
-  /* Make the width relative to the parent */
   height: 1px;
   background-color: #ddd;
   position: absolute;
   bottom: 0;
-  /* Align it with the bottom of the container */
   left: 0;
   right: 0;
-  /* Ensures it spans the entire width of the container */
 }
 
 .usa-accordion__content {
@@ -822,7 +814,5 @@ hr.custom-hr {
   border: none;
   position: relative;
   top: -6px;
-  /* Adjust this to align it with the blue underline */
   z-index: -1;
-  /* Place it behind the blue underline */
 }


### PR DESCRIPTION
# PULL REQUEST

## Summary
This _should_ fix the styling of the navigation tab (Labs/Medication/Conditions) to more closely align with the Figma: https://www.figma.com/design/YU5hAHY1Eg7J6gtNbBxm7d/DIBBs-Site-Experiences?m=dev

The primary fixes:
* left-aligning the tabs
* updating the :after effect to have a blue underline in addition to bolding
* aligning the hr align beneath nav tab with the new underline.
* fixed the padding around `include all` to match figma.

## Related Issue
Fixes #2372 

## Additional Information
I carried over many of the stylings from figma, however, the `font-family: "Source Sans Pro";` looks...wrong? The default font looks more like the picture, but we can add that back if we want to align?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
