### PR TITLE
Modify playwright tests to accommodate modal view

### DIFF
--- a/containers/tefca-viewer/e2e/query_workflow.spec.ts
+++ b/containers/tefca-viewer/e2e/query_workflow.spec.ts
@@ -11,21 +11,21 @@ test.describe("querying with the TryTEFCA viewer", () => {
   test("landing page loads", async ({ page }) => {
     // Check that each expected text section is present
     await expect(
-      page.getByRole("heading", { name: "Data collection made easier" }),
+      page.getByRole("heading", { name: "Data collection made easier" })
     ).toBeVisible();
     await expect(
-      page.getByRole("heading", { name: "What is it?" }),
+      page.getByRole("heading", { name: "What is it?" })
     ).toBeVisible();
     await expect(
-      page.getByRole("heading", { name: "How does it work?" }),
+      page.getByRole("heading", { name: "How does it work?" })
     ).toBeVisible();
 
     // Check that interactable elements are present (TEFCA header and Get Started)
     await expect(
-      page.getByRole("link", { name: "TEFCA Viewer" }),
+      page.getByRole("link", { name: "TEFCA Viewer" })
     ).toBeVisible();
     await expect(
-      page.getByRole("button", { name: "Go to the demo" }),
+      page.getByRole("button", { name: "Go to the demo" })
     ).toBeVisible();
   });
 
@@ -49,10 +49,10 @@ test.describe("querying with the TryTEFCA viewer", () => {
     const alert = page.locator(".custom-alert");
     await expect(alert).toBeVisible();
     await expect(alert).toHaveText(
-      "This site is for demo purposes only. Please do not enter PII on this website.",
+      "This site is for demo purposes only. Please do not enter PII on this website."
     );
     await expect(
-      page.getByRole("heading", { name: "Search for a Patient", exact: true }),
+      page.getByRole("heading", { name: "Search for a Patient", exact: true })
     ).toBeVisible();
 
     // Put in the search parameters for the elusive fruit person
@@ -73,7 +73,7 @@ test.describe("querying with the TryTEFCA viewer", () => {
     // Make sure we have a results page with a single patient
     // Non-interactive 'div' elements in the table should be located by text
     await expect(
-      page.getByRole("heading", { name: "Query Results" }),
+      page.getByRole("heading", { name: "Query Results" })
     ).toBeVisible();
     await expect(page.getByText("Patient Name")).toBeVisible();
     await expect(page.getByText("WATERMELON SPROUT MCGEE")).toBeVisible();
@@ -84,7 +84,7 @@ test.describe("querying with the TryTEFCA viewer", () => {
     const alert2 = page.locator(".custom-alert");
     await expect(alert2).toBeVisible();
     await expect(alert2).toHaveText(
-      "Interested in learning more about using the TEFCA Query Connector for your jurisdiction? Send us an email at dibbs@cdc.gov",
+      "Interested in learning more about using the TEFCA Query Connector for your jurisdiction? Send us an email at dibbs@cdc.gov"
     );
 
     // Let's get a little schwifty: there are multiple possible resolutions for 'Observations',
@@ -92,7 +92,7 @@ test.describe("querying with the TryTEFCA viewer", () => {
     await expect(
       page
         .getByTestId("accordionItem_observations_2")
-        .getByRole("heading", { name: "Observations" }),
+        .getByRole("heading", { name: "Observations" })
     ).toBeVisible();
     // We can also just directly ask the page to find us filtered table rows
     await expect(page.locator("tbody").locator("tr")).toHaveCount(5);
@@ -100,7 +100,7 @@ test.describe("querying with the TryTEFCA viewer", () => {
     // Now let's use the return to search to go back to a blank form
     await page.getByRole("link", { name: "New patient search" }).click();
     await expect(
-      page.getByRole("heading", { name: "Search for a Patient" }),
+      page.getByRole("heading", { name: "Search for a Patient" })
     ).toBeVisible();
   });
 
@@ -124,12 +124,12 @@ test.describe("querying with the TryTEFCA viewer", () => {
 
     // Better luck next time, user!
     await expect(
-      page.getByRole("heading", { name: "No Patients Found" }),
+      page.getByRole("heading", { name: "No Patients Found" })
     ).toBeVisible();
     await expect(page.getByText("There are no patient records")).toBeVisible();
     await page.getByRole("link", { name: "Search for a new patient" }).click();
     await expect(
-      page.getByRole("heading", { name: "Search for a Patient" }),
+      page.getByRole("heading", { name: "Search for a Patient" })
     ).toBeVisible();
   });
 
@@ -154,7 +154,7 @@ test.describe("querying with the TryTEFCA viewer", () => {
     // Among verification, make sure phone number is right
     await page.getByRole("button", { name: "Search for patient" }).click();
     await expect(
-      page.getByRole("heading", { name: "Query Results" }),
+      page.getByRole("heading", { name: "Query Results" })
     ).toBeVisible();
     await expect(page.getByText("Patient Name")).toBeVisible();
     await expect(page.getByText("Veronica Anne Blackstone")).toBeVisible();
@@ -168,13 +168,18 @@ test.describe("querying with the TryTEFCA viewer", () => {
     page,
   }) => {
     await page.getByRole("button", { name: "Go to the demo" }).click();
+    await page
+      .getByRole("button", {
+        name: "Gather social determinants of health for a patient",
+      })
+      .click();
     await page.getByRole("button", { name: "Next" }).click();
     await page
       .getByLabel("Query", { exact: true })
       .selectOption("social-determinants");
     await page.getByRole("button", { name: "Search for patient" }).click();
     await expect(
-      page.getByRole("heading", { name: "Query Results" }),
+      page.getByRole("heading", { name: "Query Results" })
     ).toBeVisible();
   });
 
@@ -182,12 +187,17 @@ test.describe("querying with the TryTEFCA viewer", () => {
     page,
   }) => {
     await page.getByRole("button", { name: "Go to the demo" }).click();
+    await page
+      .getByRole("button", {
+        name: "Chlamydia case investigation",
+      })
+      .click();
     await page.getByRole("button", { name: "Next" }).click();
     await page.getByLabel("Query", { exact: true }).selectOption("chlamydia");
     await page.getByLabel("Phone Number").fill("");
     await page.getByRole("button", { name: "Search for patient" }).click();
     await expect(
-      page.getByRole("heading", { name: "Query Results" }),
+      page.getByRole("heading", { name: "Query Results" })
     ).toBeVisible();
   });
 });
@@ -203,25 +213,25 @@ test.describe("Test the user journey of a 'tester'", () => {
   test("query/test page loads", async ({ page }) => {
     // Check that interactable elements are present
     await expect(
-      page.getByRole("button", { name: "Data Usage Policy" }),
+      page.getByRole("button", { name: "Data Usage Policy" })
     ).toBeVisible();
     await expect(
-      page.getByRole("link", { name: "TEFCA Viewer" }),
+      page.getByRole("link", { name: "TEFCA Viewer" })
     ).toBeVisible();
 
     // Check that each expected text section is present
     await expect(
-      page.getByRole("heading", { name: "Search for a Patient", exact: true }),
+      page.getByRole("heading", { name: "Search for a Patient", exact: true })
     ).toBeVisible();
     await expect(
-      page.getByRole("heading", { name: "Query information", exact: true }),
+      page.getByRole("heading", { name: "Query information", exact: true })
     ).toBeVisible();
     await expect(page.getByLabel("Query", { exact: true })).toBeVisible();
     await expect(
-      page.getByLabel("FHIR Server (QHIN)", { exact: true }),
+      page.getByLabel("FHIR Server (QHIN)", { exact: true })
     ).toBeVisible();
     await expect(
-      page.getByRole("heading", { name: "Patient information", exact: true }),
+      page.getByRole("heading", { name: "Patient information", exact: true })
     ).toBeVisible();
     await expect(page.getByLabel("Patient", { exact: true })).toBeVisible();
   });
@@ -238,7 +248,7 @@ test.describe("Test the user journey of a 'tester'", () => {
 
     // Make sure we have a results page with a single patient
     await expect(
-      page.getByRole("heading", { name: "Query Results" }),
+      page.getByRole("heading", { name: "Query Results" })
     ).toBeVisible();
     await expect(page.getByText("Patient Name")).toBeVisible();
     await expect(page.getByText("WATERMELON SPROUT MCGEE")).toBeVisible();
@@ -263,7 +273,7 @@ test.describe("Test the user journey of a 'tester'", () => {
 
     // Make sure we have a results page with a single patient
     await expect(
-      page.getByRole("heading", { name: "Query Results" }),
+      page.getByRole("heading", { name: "Query Results" })
     ).toBeVisible();
     await expect(page.getByText("Patient Name")).toBeVisible();
     await expect(page.getByText("WATERMELON SPROUT MCGEE")).toBeVisible();
@@ -284,11 +294,11 @@ test.describe("Test the user journey of a 'tester'", () => {
     await page.getByRole("button", { name: "Search for patient" }).click();
     // Make sure all the elements for the multiple patients view appear
     await expect(
-      page.getByRole("heading", { name: "Multiple Records Found" }),
+      page.getByRole("heading", { name: "Multiple Records Found" })
     ).toBeVisible();
     // Check that there is a Table element with the correct headers
     await expect(page.locator("thead").locator("tr")).toHaveText(
-      "NameDOBContactAddressMRNActions",
+      "NameDOBContactAddressMRNActions"
     );
 
     // Check that there are multiple rows in the table
@@ -299,15 +309,15 @@ test.describe("Test the user journey of a 'tester'", () => {
 
     // Make sure we have a results page with a single patient & appropriate back buttons
     await expect(
-      page.getByRole("heading", { name: "Query Results" }),
+      page.getByRole("heading", { name: "Query Results" })
     ).toBeVisible();
     await expect(
-      page.getByRole("link", { name: "New patient search" }),
+      page.getByRole("link", { name: "New patient search" })
     ).toBeVisible();
 
     await page.getByRole("link", { name: "Return to search results" }).click();
     await expect(
-      page.getByRole("heading", { name: "Multiple Records Found" }),
+      page.getByRole("heading", { name: "Multiple Records Found" })
     ).toBeVisible();
   });
 });

--- a/containers/tefca-viewer/e2e/query_workflow.spec.ts
+++ b/containers/tefca-viewer/e2e/query_workflow.spec.ts
@@ -11,21 +11,21 @@ test.describe("querying with the TryTEFCA viewer", () => {
   test("landing page loads", async ({ page }) => {
     // Check that each expected text section is present
     await expect(
-      page.getByRole("heading", { name: "Data collection made easier" })
+      page.getByRole("heading", { name: "Data collection made easier" }),
     ).toBeVisible();
     await expect(
-      page.getByRole("heading", { name: "What is it?" })
+      page.getByRole("heading", { name: "What is it?" }),
     ).toBeVisible();
     await expect(
-      page.getByRole("heading", { name: "How does it work?" })
+      page.getByRole("heading", { name: "How does it work?" }),
     ).toBeVisible();
 
     // Check that interactable elements are present (TEFCA header and Get Started)
     await expect(
-      page.getByRole("link", { name: "TEFCA Viewer" })
+      page.getByRole("link", { name: "TEFCA Viewer" }),
     ).toBeVisible();
     await expect(
-      page.getByRole("button", { name: "Go to the demo" })
+      page.getByRole("button", { name: "Go to the demo" }),
     ).toBeVisible();
   });
 
@@ -49,10 +49,10 @@ test.describe("querying with the TryTEFCA viewer", () => {
     const alert = page.locator(".custom-alert");
     await expect(alert).toBeVisible();
     await expect(alert).toHaveText(
-      "This site is for demo purposes only. Please do not enter PII on this website."
+      "This site is for demo purposes only. Please do not enter PII on this website.",
     );
     await expect(
-      page.getByRole("heading", { name: "Search for a Patient", exact: true })
+      page.getByRole("heading", { name: "Search for a Patient", exact: true }),
     ).toBeVisible();
 
     // Put in the search parameters for the elusive fruit person
@@ -73,7 +73,7 @@ test.describe("querying with the TryTEFCA viewer", () => {
     // Make sure we have a results page with a single patient
     // Non-interactive 'div' elements in the table should be located by text
     await expect(
-      page.getByRole("heading", { name: "Query Results" })
+      page.getByRole("heading", { name: "Query Results" }),
     ).toBeVisible();
     await expect(page.getByText("Patient Name")).toBeVisible();
     await expect(page.getByText("WATERMELON SPROUT MCGEE")).toBeVisible();
@@ -84,7 +84,7 @@ test.describe("querying with the TryTEFCA viewer", () => {
     const alert2 = page.locator(".custom-alert");
     await expect(alert2).toBeVisible();
     await expect(alert2).toHaveText(
-      "Interested in learning more about using the TEFCA Query Connector for your jurisdiction? Send us an email at dibbs@cdc.gov"
+      "Interested in learning more about using the TEFCA Query Connector for your jurisdiction? Send us an email at dibbs@cdc.gov",
     );
 
     // Let's get a little schwifty: there are multiple possible resolutions for 'Observations',
@@ -92,7 +92,7 @@ test.describe("querying with the TryTEFCA viewer", () => {
     await expect(
       page
         .getByTestId("accordionItem_observations_2")
-        .getByRole("heading", { name: "Observations" })
+        .getByRole("heading", { name: "Observations" }),
     ).toBeVisible();
     // We can also just directly ask the page to find us filtered table rows
     await expect(page.locator("tbody").locator("tr")).toHaveCount(5);
@@ -100,7 +100,7 @@ test.describe("querying with the TryTEFCA viewer", () => {
     // Now let's use the return to search to go back to a blank form
     await page.getByRole("link", { name: "New patient search" }).click();
     await expect(
-      page.getByRole("heading", { name: "Search for a Patient" })
+      page.getByRole("heading", { name: "Search for a Patient" }),
     ).toBeVisible();
   });
 
@@ -124,12 +124,12 @@ test.describe("querying with the TryTEFCA viewer", () => {
 
     // Better luck next time, user!
     await expect(
-      page.getByRole("heading", { name: "No Patients Found" })
+      page.getByRole("heading", { name: "No Patients Found" }),
     ).toBeVisible();
     await expect(page.getByText("There are no patient records")).toBeVisible();
     await page.getByRole("link", { name: "Search for a new patient" }).click();
     await expect(
-      page.getByRole("heading", { name: "Search for a Patient" })
+      page.getByRole("heading", { name: "Search for a Patient" }),
     ).toBeVisible();
   });
 
@@ -154,7 +154,7 @@ test.describe("querying with the TryTEFCA viewer", () => {
     // Among verification, make sure phone number is right
     await page.getByRole("button", { name: "Search for patient" }).click();
     await expect(
-      page.getByRole("heading", { name: "Query Results" })
+      page.getByRole("heading", { name: "Query Results" }),
     ).toBeVisible();
     await expect(page.getByText("Patient Name")).toBeVisible();
     await expect(page.getByText("Veronica Anne Blackstone")).toBeVisible();
@@ -179,7 +179,7 @@ test.describe("querying with the TryTEFCA viewer", () => {
       .selectOption("social-determinants");
     await page.getByRole("button", { name: "Search for patient" }).click();
     await expect(
-      page.getByRole("heading", { name: "Query Results" })
+      page.getByRole("heading", { name: "Query Results" }),
     ).toBeVisible();
   });
 
@@ -197,7 +197,7 @@ test.describe("querying with the TryTEFCA viewer", () => {
     await page.getByLabel("Phone Number").fill("");
     await page.getByRole("button", { name: "Search for patient" }).click();
     await expect(
-      page.getByRole("heading", { name: "Query Results" })
+      page.getByRole("heading", { name: "Query Results" }),
     ).toBeVisible();
   });
 });
@@ -213,25 +213,25 @@ test.describe("Test the user journey of a 'tester'", () => {
   test("query/test page loads", async ({ page }) => {
     // Check that interactable elements are present
     await expect(
-      page.getByRole("button", { name: "Data Usage Policy" })
+      page.getByRole("button", { name: "Data Usage Policy" }),
     ).toBeVisible();
     await expect(
-      page.getByRole("link", { name: "TEFCA Viewer" })
+      page.getByRole("link", { name: "TEFCA Viewer" }),
     ).toBeVisible();
 
     // Check that each expected text section is present
     await expect(
-      page.getByRole("heading", { name: "Search for a Patient", exact: true })
+      page.getByRole("heading", { name: "Search for a Patient", exact: true }),
     ).toBeVisible();
     await expect(
-      page.getByRole("heading", { name: "Query information", exact: true })
+      page.getByRole("heading", { name: "Query information", exact: true }),
     ).toBeVisible();
     await expect(page.getByLabel("Query", { exact: true })).toBeVisible();
     await expect(
-      page.getByLabel("FHIR Server (QHIN)", { exact: true })
+      page.getByLabel("FHIR Server (QHIN)", { exact: true }),
     ).toBeVisible();
     await expect(
-      page.getByRole("heading", { name: "Patient information", exact: true })
+      page.getByRole("heading", { name: "Patient information", exact: true }),
     ).toBeVisible();
     await expect(page.getByLabel("Patient", { exact: true })).toBeVisible();
   });
@@ -248,7 +248,7 @@ test.describe("Test the user journey of a 'tester'", () => {
 
     // Make sure we have a results page with a single patient
     await expect(
-      page.getByRole("heading", { name: "Query Results" })
+      page.getByRole("heading", { name: "Query Results" }),
     ).toBeVisible();
     await expect(page.getByText("Patient Name")).toBeVisible();
     await expect(page.getByText("WATERMELON SPROUT MCGEE")).toBeVisible();
@@ -273,7 +273,7 @@ test.describe("Test the user journey of a 'tester'", () => {
 
     // Make sure we have a results page with a single patient
     await expect(
-      page.getByRole("heading", { name: "Query Results" })
+      page.getByRole("heading", { name: "Query Results" }),
     ).toBeVisible();
     await expect(page.getByText("Patient Name")).toBeVisible();
     await expect(page.getByText("WATERMELON SPROUT MCGEE")).toBeVisible();
@@ -294,11 +294,11 @@ test.describe("Test the user journey of a 'tester'", () => {
     await page.getByRole("button", { name: "Search for patient" }).click();
     // Make sure all the elements for the multiple patients view appear
     await expect(
-      page.getByRole("heading", { name: "Multiple Records Found" })
+      page.getByRole("heading", { name: "Multiple Records Found" }),
     ).toBeVisible();
     // Check that there is a Table element with the correct headers
     await expect(page.locator("thead").locator("tr")).toHaveText(
-      "NameDOBContactAddressMRNActions"
+      "NameDOBContactAddressMRNActions",
     );
 
     // Check that there are multiple rows in the table
@@ -309,15 +309,15 @@ test.describe("Test the user journey of a 'tester'", () => {
 
     // Make sure we have a results page with a single patient & appropriate back buttons
     await expect(
-      page.getByRole("heading", { name: "Query Results" })
+      page.getByRole("heading", { name: "Query Results" }),
     ).toBeVisible();
     await expect(
-      page.getByRole("link", { name: "New patient search" })
+      page.getByRole("link", { name: "New patient search" }),
     ).toBeVisible();
 
     await page.getByRole("link", { name: "Return to search results" }).click();
     await expect(
-      page.getByRole("heading", { name: "Multiple Records Found" })
+      page.getByRole("heading", { name: "Multiple Records Found" }),
     ).toBeVisible();
   });
 });


### PR DESCRIPTION
# PULL REQUEST

## Summary
Modifies the TEFCA playwright tests to include the modal view and make the appropriate selections. These tests were failing after the modal feature was introduced, which I believe was the source of the errors the streamline team found [here](https://github.com/CDCgov/phdi/actions/runs/10458891294). I'm not totally sure how the modal feature was added without the tests failing before this. 

## Related Issue
Fixes #

## Additional Information
Anything else the review team should know?

## Checklist

- [X] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
