### PR TITLE
Update Pydantic to fix error with Python >= 3.12.4

### DIFF
--- a/containers/dibbs/pyproject.toml
+++ b/containers/dibbs/pyproject.toml
@@ -6,4 +6,4 @@ build-backend = "setuptools.build_meta"
 name = "dibbs"
 version = "0.1.0"
 description = "A small library of tools shared across the DIBBS project"
-dependencies = ["pydantic==1.10.13", "fastapi>=0.109.1", "uvicorn"]
+dependencies = ["pydantic==1.10.17", "fastapi>=0.109.1", "uvicorn"]

--- a/containers/dibbs/requirements.txt
+++ b/containers/dibbs/requirements.txt
@@ -1,4 +1,4 @@
-pydantic==1.10.13
+pydantic==1.10.17
 fastapi>=0.109.1
 uvicorn
 httpx

--- a/containers/fhir-converter/requirements.txt
+++ b/containers/fhir-converter/requirements.txt
@@ -19,7 +19,7 @@ MarkupSafe==2.1.1
 orjson==3.9.15
 packaging==21.3
 pluggy==1.0.0
-pydantic==1.10.13
+pydantic==1.10.17
 pyparsing==3.0.9
 pytest==7.1.2
 python-dotenv==0.20.0

--- a/containers/orchestration/requirements.txt
+++ b/containers/orchestration/requirements.txt
@@ -1,6 +1,6 @@
 ../dibbs
 typing_extensions>=4.8.0
-pydantic==1.10.17
+pydantic>=1.10.13
 fastapi>=0.109.1
 uvicorn
 httpx

--- a/containers/orchestration/requirements.txt
+++ b/containers/orchestration/requirements.txt
@@ -1,8 +1,8 @@
 ../dibbs
 typing_extensions>=4.8.0
-pydantic==1.10.13
-fastapi==0.112.2
-uvicorn[standard]
+pydantic==1.10.17
+fastapi>=0.109.1
+uvicorn
 httpx
 pytest
 lxml


### PR DESCRIPTION
# PULL REQUEST

## Summary
Update Pydantic from 1.10.13 to 1.10.17. When running dibbs containers with Python >= 3.12.4 and Pydantic < 1.10.16 the user gets the error `TypeError: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard'`.

## Related Issue
Fixes #2415 

## Additional Information

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
