### PR TITLE
Update symptoms and problems unavailable data heading

### DIFF
--- a/containers/ecr-viewer/src/app/tests/components/Unavailable.test.tsx
+++ b/containers/ecr-viewer/src/app/tests/components/Unavailable.test.tsx
@@ -97,8 +97,10 @@ describe("UnavailableInfo", () => {
         socialUnavailableData={socialUnavailability}
         encounterUnavailableData={encounterUnavailableData}
         providerUnavailableData={providerUnavailableData}
-        reasonForVisitUnavailableData={reasonForVisitUnavailableData}
-        activeProblemsUnavailableData={activeProblemsUnavailableData}
+        symptomsProblemsUnavailableData={[
+          ...reasonForVisitUnavailableData,
+          ...activeProblemsUnavailableData,
+        ]}
         immunizationsUnavailableData={immunizationsUnavailableData}
         vitalUnavailableData={vitalUnavailableData}
         treatmentData={treatmentUnavailableData}

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/AccordionContent.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/AccordionContent.test.tsx.snap
@@ -929,6 +929,25 @@ exports[`Snapshot test for Accordion Content Given no data, info message for emp
                       <div
                         class="data-title"
                       >
+                        Reason for Visit
+                      </div>
+                      <div
+                        class="grid-col maxw7 text-pre-line text-italic text-base"
+                      >
+                        No data
+                      </div>
+                    </div>
+                    <div
+                      class="section__line_gray"
+                    />
+                  </div>
+                  <div>
+                    <div
+                      class="grid-row"
+                    >
+                      <div
+                        class="data-title"
+                      >
                         Problems List
                       </div>
                       <div

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/Unavailable.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/Unavailable.test.tsx.snap
@@ -284,6 +284,25 @@ exports[`UnavailableInfo should match snapshot 1`] = `
                 <div
                   class="data-title"
                 >
+                  Reason for Visit
+                </div>
+                <div
+                  class="grid-col maxw7 text-pre-line text-italic text-base"
+                >
+                  No data
+                </div>
+              </div>
+              <div
+                class="section__line_gray"
+              />
+            </div>
+            <div>
+              <div
+                class="grid-row"
+              >
+                <div
+                  class="data-title"
+                >
                   Problems List
                 </div>
                 <div

--- a/containers/ecr-viewer/src/app/view-data/components/AccordionContent.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/AccordionContent.tsx
@@ -183,6 +183,10 @@ const AccordionContent: React.FC<AccordionContainerProps> = ({
               demographicsUnavailableData={demographicsData.unavailableData}
               socialUnavailableData={social_data.unavailableData}
               encounterUnavailableData={encounterData.unavailableData}
+              symptomsProblemsUnavailableData={[
+                ...clinicalData.reasonForVisitDetails.unavailableData,
+                ...clinicalData.activeProblemsDetails.unavailableData,
+              ]}
               reasonForVisitUnavailableData={
                 clinicalData.reasonForVisitDetails.unavailableData
               }

--- a/containers/ecr-viewer/src/app/view-data/components/AccordionContent.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/AccordionContent.tsx
@@ -187,12 +187,6 @@ const AccordionContent: React.FC<AccordionContainerProps> = ({
                 ...clinicalData.reasonForVisitDetails.unavailableData,
                 ...clinicalData.activeProblemsDetails.unavailableData,
               ]}
-              reasonForVisitUnavailableData={
-                clinicalData.reasonForVisitDetails.unavailableData
-              }
-              activeProblemsUnavailableData={
-                clinicalData.activeProblemsDetails.unavailableData
-              }
               providerUnavailableData={providerData.unavailableData}
               vitalUnavailableData={clinicalData.vitalData.unavailableData}
               immunizationsUnavailableData={

--- a/containers/ecr-viewer/src/app/view-data/components/UnavailableInfo.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/UnavailableInfo.tsx
@@ -10,8 +10,7 @@ interface UnavailableInfoProps {
   socialUnavailableData: DisplayDataProps[];
   encounterUnavailableData: DisplayDataProps[];
   providerUnavailableData: DisplayDataProps[];
-  reasonForVisitUnavailableData: DisplayDataProps[];
-  activeProblemsUnavailableData: DisplayDataProps[];
+  symptomsProblemsUnavailableData: DisplayDataProps[];
   vitalUnavailableData: DisplayDataProps[];
   treatmentData: DisplayDataProps[];
   clinicalNotesData: DisplayDataProps[];
@@ -26,8 +25,7 @@ interface UnavailableInfoProps {
  * @param props.socialUnavailableData The unavailable social data
  * @param props.encounterUnavailableData The unavailable encounter data
  * @param props.providerUnavailableData The unavailable provider data
- * @param props.reasonForVisitUnavailableData The unavailable reason for visit data
- * @param props.activeProblemsUnavailableData The unavailable active problems data
+ * @param props.symptomsProblemsUnavailableData The unavailable symptoms and problems data
  * @param props.immunizationsUnavailableData The unavailable immunizations data
  * @param props.vitalUnavailableData The unavailable vital data
  * @param props.treatmentData The unavailable treatment data
@@ -40,8 +38,7 @@ const UnavailableInfo: React.FC<UnavailableInfoProps> = ({
   socialUnavailableData,
   encounterUnavailableData,
   providerUnavailableData,
-  reasonForVisitUnavailableData,
-  activeProblemsUnavailableData,
+  symptomsProblemsUnavailableData,
   immunizationsUnavailableData,
   vitalUnavailableData,
   treatmentData,
@@ -79,9 +76,8 @@ const UnavailableInfo: React.FC<UnavailableInfoProps> = ({
         renderSection("Clinical Notes", clinicalNotesData)}
       {providerUnavailableData.length > 0 &&
         renderSection("Provider Details", providerUnavailableData)}
-      {(reasonForVisitUnavailableData?.length > 0 ||
-        activeProblemsUnavailableData?.length > 0) &&
-        renderSection("Symptoms and Problems", activeProblemsUnavailableData)}
+      {symptomsProblemsUnavailableData?.length > 0 &&
+        renderSection("Symptoms and Problems", symptomsProblemsUnavailableData)}
       {vitalUnavailableData?.length > 0 &&
         renderSection("Diagnostics and Vital Signs", vitalUnavailableData)}
       {immunizationsUnavailableData?.length > 0 &&


### PR DESCRIPTION
# PULL REQUEST

<img width="1669" alt="Screen Shot 2024-08-22 at 12 25 08 PM" src="https://github.com/user-attachments/assets/4cdef368-8224-4b6b-9b91-78dfaed655e1">


## Summary
- Updated symptoms and problems unavailable data section to include both reason for visit and active problems instead of just 1 or the other 
- updated test snaps

## Related Issue
Fixes #2098 

## Testing
- run ecr-viewer 
- navigate to http://localhost:3000/view-data?id=a3266d94-ce19-11ec-81e1-8465ad080d41
- see reason for visit in unavailable section 

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
