### PR TITLE
Fix TEFCA CustomizeQuery Checkboxes

### DIFF
--- a/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
+++ b/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
@@ -89,10 +89,7 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
       ? [
           {
             title: (
-              <div
-                className="accordion-header display-flex flex-no-wrap flex-align-start"
-                onClick={handleToggleExpand}
-              >
+              <div className="accordion-header display-flex flex-no-wrap flex-align-start">
                 <div
                   id="select-all"
                   className="hide-checkbox-label"
@@ -296,9 +293,9 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
       </div>
       <div className="button-container">
         <Button type="button" onClick={handleApplyChanges}>
-          Apply Changes
+          Apply changes
         </Button>
-        <Button type="button" onClick={() => goBack()}>
+        <Button type="button" outline onClick={() => goBack()}>
           Cancel
         </Button>
       </div>

--- a/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
+++ b/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
@@ -96,8 +96,7 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
                   style={{
                     width: "36px",
                     height: "36px",
-                    backgroundColor:
-                      selectedCount === items.length ? "#005ea2" : "#fff",
+                    backgroundColor: "#fff",
                     border: "1px solid #A9AEB1",
                     display: "flex",
                     justifyContent: "center",
@@ -118,6 +117,14 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
                 >
                   {selectedCount === items.length && (
                     <Icon.Check
+                      className="usa-icon"
+                      style={{ backgroundColor: "white" }}
+                      size={4}
+                      color="#565C65"
+                    />
+                  )}
+                  {selectedCount > 0 && selectedCount < items.length && (
+                    <Icon.Remove
                       className="usa-icon"
                       style={{ backgroundColor: "white" }}
                       size={4}
@@ -176,9 +183,6 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
                         <div
                           className="hide-checkbox-label"
                           style={{
-                            // width: "24px",
-                            // height: "24px",
-                            // backgroundColor: item.include ? "#005ea2" : "#fff",
                             border: "1px solid #A9AEB1",
                             display: "flex",
                             justifyContent: "center",

--- a/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
+++ b/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
@@ -96,8 +96,11 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
                   style={{
                     width: "36px",
                     height: "36px",
-                    backgroundColor: "#fff",
-                    border: "1px solid #A9AEB1",
+                    backgroundColor: selectedCount === 0 ? "#565C65" : "#fff",
+                    border:
+                      selectedCount === 0
+                        ? "3px white solid"
+                        : "1px solid #A9AEB1",
                     display: "flex",
                     justifyContent: "center",
                     alignItems: "center",

--- a/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
+++ b/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
@@ -89,7 +89,10 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
       ? [
           {
             title: (
-              <div className="accordion-header display-flex flex-no-wrap flex-align-start">
+              <div
+                className="accordion-header display-flex flex-no-wrap flex-align-start"
+                onClick={handleToggleExpand}
+              >
                 <div
                   id="select-all"
                   className="hide-checkbox-label"

--- a/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
+++ b/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
@@ -90,13 +90,21 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
           {
             title: (
               <div className="accordion-header display-flex flex-no-wrap flex-align-start">
-                <input
-                  type="checkbox"
+                <div
                   id="select-all"
                   className="hide-checkbox-label"
-                  style={{ width: "36px", height: "36px" }}
-                  checked={selectedCount === items.length}
-                  onChange={(e) =>
+                  style={{
+                    width: "36px",
+                    height: "36px",
+                    backgroundColor:
+                      selectedCount === items.length ? "#005ea2" : "#fff",
+                    border: "1px solid #A9AEB1",
+                    display: "flex",
+                    justifyContent: "center",
+                    alignItems: "center",
+                    cursor: "pointer",
+                  }}
+                  onClick={() =>
                     handleSelectAllChange(
                       items,
                       (updatedItems) =>
@@ -104,10 +112,19 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
                           ...prevState,
                           [activeTab]: updatedItems,
                         })),
-                      e.target.checked,
+                      selectedCount !== items.length,
                     )
                   }
-                />
+                >
+                  {selectedCount === items.length && (
+                    <Icon.Check
+                      className="usa-icon"
+                      style={{ backgroundColor: "white" }}
+                      size={4}
+                      color="#565C65"
+                    />
+                  )}
+                </div>
                 <div>
                   {`${items[0].display}`}
 
@@ -156,19 +173,37 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
                         className="customize-query-grid-row customize-query-striped-row"
                         key={item.code}
                       >
-                        <input
-                          type="checkbox"
+                        <div
                           className="hide-checkbox-label"
-                          checked={item.include}
-                          onChange={(e) => {
+                          style={{
+                            // width: "24px",
+                            // height: "24px",
+                            // backgroundColor: item.include ? "#005ea2" : "#fff",
+                            border: "1px solid #A9AEB1",
+                            display: "flex",
+                            justifyContent: "center",
+                            alignItems: "center",
+                            cursor: "pointer",
+                          }}
+                          onClick={() => {
                             const updatedItems = [...items];
-                            updatedItems[index].include = e.target.checked;
+                            updatedItems[index].include =
+                              !updatedItems[index].include;
                             setValueSetState((prevState) => ({
                               ...prevState,
                               [activeTab]: updatedItems,
                             }));
                           }}
-                        />
+                        >
+                          {item.include && (
+                            <Icon.Check
+                              className="usa-icon"
+                              style={{ backgroundColor: "white" }}
+                              size={4}
+                              color="#005EA2"
+                            />
+                          )}
+                        </div>
                         <div>{item.code}</div>
                         <div>{item.display}</div>
                       </div>

--- a/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
+++ b/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
@@ -94,6 +94,7 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
                   type="checkbox"
                   id="select-all"
                   className="hide-checkbox-label"
+                  style={{ width: "36px", height: "36px" }}
                   checked={selectedCount === items.length}
                   onChange={(e) =>
                     handleSelectAllChange(

--- a/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
+++ b/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
@@ -102,6 +102,7 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
                     justifyContent: "center",
                     alignItems: "center",
                     cursor: "pointer",
+                    borderRadius: "4px",
                   }}
                   onClick={() =>
                     handleSelectAllChange(
@@ -188,6 +189,11 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
                             justifyContent: "center",
                             alignItems: "center",
                             cursor: "pointer",
+                            borderRadius: "4px",
+                            width: "36px",
+                            height: "36px",
+                            marginLeft: "30px",
+                            backgroundColor: "#fff",
                           }}
                           onClick={() => {
                             const updatedItems = [...items];

--- a/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
+++ b/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import React, { useMemo, useState } from "react";
-import { Accordion, Button, Icon, Checkbox } from "@trussworks/react-uswds";
+import React, { useMemo, useState, useEffect } from "react";
+import { Accordion, Button, Icon } from "@trussworks/react-uswds";
 import { AccordianSection } from "../../query/component-utils";
 import { ValueSet } from "../../constants";
 import { AccordionItemProps } from "@trussworks/react-uswds/lib/components/Accordion/Accordion";
@@ -30,7 +30,7 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
   const [valueSetState, setValueSetState] = useState<ValueSet>(ValueSet);
   const [isExpanded, setIsExpanded] = useState(true);
 
-  /*Keeps track of whether the accordion is expanded to change the direction of the arrow*/
+  // Keeps track of whether the accordion is expanded to change the direction of the arrow
   const handleToggleExpand = () => {
     setIsExpanded(!isExpanded);
   };
@@ -70,6 +70,18 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
     }, {} as ValueSet);
   };
 
+  useEffect(() => {
+    const items = valueSetState[activeTab as keyof ValueSet];
+    const selectedCount = items.filter((item) => item.include).length;
+    const topCheckbox = document.getElementById(
+      "select-all",
+    ) as HTMLInputElement;
+    if (topCheckbox) {
+      topCheckbox.indeterminate =
+        selectedCount > 0 && selectedCount < items.length;
+    }
+  }, [valueSetState, activeTab]);
+
   const accordionItems: AccordionItemProps[] = useMemo(() => {
     const items = valueSetState[activeTab as keyof ValueSet];
     const selectedCount = items.filter((item) => item.include).length;
@@ -78,9 +90,9 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
           {
             title: (
               <div className="accordion-header display-flex flex-no-wrap flex-align-start">
-                <Checkbox
+                <input
+                  type="checkbox"
                   id="select-all"
-                  name="select-all"
                   className="hide-checkbox-label"
                   checked={selectedCount === items.length}
                   onChange={(e) =>
@@ -94,7 +106,6 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
                       e.target.checked,
                     )
                   }
-                  label={<span className="hide-me">Select/deselect all</span>}
                 />
                 <div>
                   {`${items[0].display}`}
@@ -144,23 +155,19 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
                         className="customize-query-grid-row customize-query-striped-row"
                         key={item.code}
                       >
-                        <div style={{ marginLeft: "24px" }}>
-                          <Checkbox
-                            id={`checkbox-${index}`}
-                            name={`checkbox-${index}`}
-                            checked={item.include}
-                            className="hide-checkbox-label"
-                            onChange={(e) => {
-                              const updatedItems = [...items];
-                              updatedItems[index].include = e.target.checked;
-                              setValueSetState((prevState) => ({
-                                ...prevState,
-                                [activeTab]: updatedItems,
-                              }));
-                            }}
-                            label={<span className="hide-me">Include</span>}
-                          />
-                        </div>
+                        <input
+                          type="checkbox"
+                          className="hide-checkbox-label"
+                          checked={item.include}
+                          onChange={(e) => {
+                            const updatedItems = [...items];
+                            updatedItems[index].include = e.target.checked;
+                            setValueSetState((prevState) => ({
+                              ...prevState,
+                              [activeTab]: updatedItems,
+                            }));
+                          }}
+                        />
                         <div>{item.code}</div>
                         <div>{item.display}</div>
                       </div>
@@ -199,27 +206,21 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
       </div>
       <nav className="usa-nav custom-nav">
         <li
-          className={`usa-nav__primary-item ${
-            activeTab === "labs" ? "usa-current" : ""
-          }`}
+          className={`usa-nav__primary-item ${activeTab === "labs" ? "usa-current" : ""}`}
         >
           <a href="#labs" onClick={() => handleTabChange("labs")}>
             Labs
           </a>
         </li>
         <li
-          className={`usa-nav__primary-item ${
-            activeTab === "medications" ? "usa-current" : ""
-          }`}
+          className={`usa-nav__primary-item ${activeTab === "medications" ? "usa-current" : ""}`}
         >
           <a href="#medications" onClick={() => handleTabChange("medications")}>
             Medications
           </a>
         </li>
         <li
-          className={`usa-nav__primary-item ${
-            activeTab === "conditions" ? "usa-current" : ""
-          }`}
+          className={`usa-nav__primary-item ${activeTab === "conditions" ? "usa-current" : ""}`}
         >
           <a href="#conditions" onClick={() => handleTabChange("conditions")}>
             Conditions

--- a/containers/tefca-viewer/src/styles/custom-styles.scss
+++ b/containers/tefca-viewer/src/styles/custom-styles.scss
@@ -882,7 +882,7 @@ html {
 .customize-query-grid-header {
   display: contents;
   font-weight: 700;
-  border-bottom: 2px solid #b;
+  border-bottom: 1px solid #71767A;
 }
 
 .customize-query-grid-body {
@@ -896,7 +896,6 @@ html {
 
 .customize-query-grid-row>div {
   padding: 8px;
-  // border-bottom: 1px solid #ddd;
 }
 
 .customize-query-striped-row:nth-child(even) {

--- a/containers/tefca-viewer/src/styles/custom-styles.scss
+++ b/containers/tefca-viewer/src/styles/custom-styles.scss
@@ -905,11 +905,8 @@ hr.custom-hr {
   width: 100%;
   height: 0px;
   background-color: #ddd;
-  margin-top: 0;
+  margin-top: -6px;
   margin-bottom: 0;
   border: none;
-  position: static;
-  top: -6px;
-  z-index: -1;
   border-top: 1px solid #71767a;
 }

--- a/containers/tefca-viewer/src/styles/custom-styles.scss
+++ b/containers/tefca-viewer/src/styles/custom-styles.scss
@@ -708,6 +708,9 @@ html {
 
 .hide-checkbox-label {
   background-color: transparent;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
 
   &>label {
     margin-top: 0;
@@ -870,13 +873,16 @@ html {
   display: grid;
   grid-template-columns: 100px 100px 1fr;
   /* Same width for Include and Code, Display takes the remaining space */
-  gap: 0px;
+  gap: 14px;
+  padding-left: 10px;
+  border-radius: 4px;
+  padding-bottom: 14px;
 }
 
 .customize-query-grid-header {
   display: contents;
   font-weight: 700;
-  border-bottom: 2px solid #ddd;
+  border-bottom: 2px solid #b;
 }
 
 .customize-query-grid-body {
@@ -890,17 +896,11 @@ html {
 
 .customize-query-grid-row>div {
   padding: 8px;
-  border-bottom: 1px solid #ddd;
+  // border-bottom: 1px solid #ddd;
 }
 
 .customize-query-striped-row:nth-child(even) {
   background-color: #f9f9f9;
-}
-
-.hide-checkbox-label {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
 }
 
 hr.custom-hr {

--- a/containers/tefca-viewer/src/styles/custom-styles.scss
+++ b/containers/tefca-viewer/src/styles/custom-styles.scss
@@ -227,6 +227,7 @@ body {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  background-color: rgba(247, 249, 250, 1);
 }
 
 .main-body {
@@ -282,6 +283,7 @@ body {
 
 .usa-footer {
   margin-top: auto;
+  background-color: green !important;
 }
 
 .get-started-button {
@@ -906,7 +908,7 @@ hr.custom-hr {
   margin-top: 0;
   margin-bottom: 0;
   border: none;
-  position: relative;
+  position: static;
   top: -6px;
   z-index: -1;
   border-top: 1px solid #71767a;

--- a/containers/tefca-viewer/src/styles/custom-styles.scss
+++ b/containers/tefca-viewer/src/styles/custom-styles.scss
@@ -55,7 +55,7 @@ h4 {
   font-weight: bold;
 }
 
-.info-container > .usa-accordion__heading > .usa-accordion__button {
+.info-container>.usa-accordion__heading>.usa-accordion__button {
   font-size: 32px;
   color: white !important;
   background-color: #2e6276;
@@ -191,19 +191,11 @@ h4 {
   line-height: 18px;
 }
 
-ul.usa-sidenav
-  > li.usa-sidenav__item
-  > ul.usa-sidenav__sublist
-  > li.usa-sidenav__item
-  > a {
+ul.usa-sidenav>li.usa-sidenav__item>ul.usa-sidenav__sublist>li.usa-sidenav__item>a {
   font-weight: bold;
 }
 
-ul.usa-sidenav
-  > li.usa-sidenav__item
-  > ul.usa-sidenav__sublist
-  > li.usa-sidenav__item
-  > a.usa-current {
+ul.usa-sidenav>li.usa-sidenav__item>ul.usa-sidenav__sublist>li.usa-sidenav__item>a.usa-current {
   &::after {
     background-color: rgb(0, 94, 162);
     content: "";
@@ -389,11 +381,9 @@ html {
 }
 
 .gradient-blue-background {
-  background: linear-gradient(
-    109.54deg,
-    rgba(173, 207, 220, 0.025) 8.02%,
-    rgba(46, 98, 118, 0.5) 117.53%
-  );
+  background: linear-gradient(109.54deg,
+      rgba(173, 207, 220, 0.025) 8.02%,
+      rgba(46, 98, 118, 0.5) 117.53%);
 
   padding: 0.5rem;
   /* Optional: some padding to make the background more noticeable */
@@ -592,7 +582,8 @@ html {
 }
 
 .accordion-header-cell.include {
-  width: 60px; /* Fixed width */
+  width: 60px;
+  /* Fixed width */
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
@@ -611,6 +602,7 @@ html {
   align-items: flex-start;
   justify-content: space-between;
 }
+
 .accordion-subtitle {
   display: block;
   font-weight: normal;
@@ -696,11 +688,11 @@ html {
 .accordion-item {
   padding-bottom: 0 !important;
 
-  & > div > div.padding-bottom-3 {
+  &>div>div.padding-bottom-3 {
     padding-bottom: 0;
   }
 
-  & > button {
+  &>button {
     background-image: none !important;
   }
 
@@ -716,7 +708,8 @@ html {
 
 .hide-checkbox-label {
   background-color: transparent;
-  & > label {
+
+  &>label {
     margin-top: 0;
     width: 24px;
     height: 24px;
@@ -728,7 +721,7 @@ html {
       background-size: 14px auto !important;
     }
 
-    & > .hide-me {
+    &>.hide-me {
       display: none;
     }
   }
@@ -875,7 +868,7 @@ html {
 
 .customize-query-grid-container {
   display: grid;
-  grid-template-columns: 100px 100px 1fr; /* Same width for Include and Code, Display takes the remaining space */
+  grid-template-columns: 100px 100px 1fr;
   gap: 0px;
 }
 
@@ -894,7 +887,7 @@ html {
   padding: 8px 0;
 }
 
-.customize-query-grid-row > div {
+.customize-query-grid-row>div {
   padding: 8px;
   border-bottom: 1px solid #ddd;
 }

--- a/containers/tefca-viewer/src/styles/custom-styles.scss
+++ b/containers/tefca-viewer/src/styles/custom-styles.scss
@@ -869,6 +869,7 @@ html {
 .customize-query-grid-container {
   display: grid;
   grid-template-columns: 100px 100px 1fr;
+  /* Same width for Include and Code, Display takes the remaining space */
   gap: 0px;
 }
 

--- a/containers/tefca-viewer/src/styles/custom-styles.scss
+++ b/containers/tefca-viewer/src/styles/custom-styles.scss
@@ -894,10 +894,6 @@ html {
   padding: 8px 0;
 }
 
-.customize-query-grid-row>div {
-  padding: 8px;
-}
-
 .customize-query-striped-row:nth-child(even) {
   background-color: #f9f9f9;
 }

--- a/containers/tefca-viewer/src/styles/custom-styles.scss
+++ b/containers/tefca-viewer/src/styles/custom-styles.scss
@@ -234,6 +234,7 @@ body {
   grid-template-columns: 1fr; // Defines a single column
   justify-content: center; // Centers the column in the container
   row-gap: 0.1em; // Adjusts the gap between rows/items
+  background-color: rgba(247, 249, 250, 1);
 }
 
 .home {


### PR DESCRIPTION
# PULL REQUEST

## Summary
This does a few things:
* Changes the checkboxes to the the Icon.Check from USWDS
* Adds the indeterminate state with the Icon.Remove from USWDS
* Bonus: Fixes the Expand Less / Expand More arrows to change direction based on opening/closing the Accordions.

## Related Issue
Fixes #2411 

## Additional Information
As far as I can tell, the last work on the UI should be to add borderlines in the accordion and to make every other row gray. There's some CSS code that should be doing this; I tried to tweak it a bit in this ticket without much success, so wanted to break that into a new ticket instead.

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
