### PR TITLE
update uvicorn dependency to uvicorn[standard] for orchestration

### DIFF
--- a/containers/orchestration/requirements.txt
+++ b/containers/orchestration/requirements.txt
@@ -1,7 +1,7 @@
 ../dibbs
 typing_extensions>=4.8.0
 pydantic==1.10.13
-fastapi>=0.109.1
+fastapi==0.112.2
 uvicorn[standard]
 httpx
 pytest

--- a/containers/orchestration/requirements.txt
+++ b/containers/orchestration/requirements.txt
@@ -2,7 +2,7 @@
 typing_extensions>=4.8.0
 pydantic==1.10.13
 fastapi>=0.109.1
-uvicorn
+uvicorn[standard]
 httpx
 pytest
 lxml
@@ -19,7 +19,6 @@ sqlalchemy
 requests-mock
 psycopg2-binary==2.9.9
 pytest-mock
-pyyaml
 opentelemetry-distro
 opentelemetry-exporter-otlp
 opentelemetry-exporter-prometheus

--- a/containers/orchestration/requirements.txt
+++ b/containers/orchestration/requirements.txt
@@ -19,6 +19,7 @@ sqlalchemy
 requests-mock
 psycopg2-binary==2.9.9
 pytest-mock
+pyyaml
 opentelemetry-distro
 opentelemetry-exporter-otlp
 opentelemetry-exporter-prometheus


### PR DESCRIPTION
# PULL REQUEST

## Summary
- Pin `fastapi` to 0.112.2 to prevent upgrading without noticing breaking changes.
- Install uvicorn[standard] to include pyyaml.  
  - [`fastapi` 0.112.0 ](https://github.com/fastapi/fastapi/releases/tag/0.112.0) contained a breaking change to only include pure python and no dependencies. 

## Related Issue
Fixes #

## Acceptance Criteria
Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information
Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
