### PR TITLE
TEFCA Customize Query Accordion Updates

### DIFF
--- a/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
+++ b/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
@@ -120,7 +120,8 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
                     cursor: "pointer",
                     borderRadius: "4px",
                   }}
-                  onClick={() =>
+                  onClick={(e) => {
+                    e.stopPropagation();
                     handleSelectAllChange(
                       items,
                       (updatedItems) =>
@@ -129,8 +130,8 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
                           [activeTab]: updatedItems,
                         })),
                       selectedCount !== items.length,
-                    )
-                  }
+                    );
+                  }}
                 >
                   {selectedCount === items.length && (
                     <Icon.Check
@@ -206,7 +207,10 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
                             marginLeft: "30px",
                             backgroundColor: "#fff",
                           }}
-                          onClick={() => toggleInclude(index)}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            toggleInclude(index);
+                          }}
                         >
                           {item.include && (
                             <Icon.Check

--- a/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
+++ b/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
@@ -99,7 +99,10 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
       ? [
           {
             title: (
-              <div className="accordion-header display-flex flex-no-wrap flex-align-start">
+              <div
+                className="accordion-header display-flex flex-no-wrap flex-align-start"
+                onClick={handleToggleExpand}
+              >
                 <div
                   id="select-all"
                   className="hide-checkbox-label"

--- a/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
+++ b/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
@@ -61,6 +61,16 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
     }));
   };
 
+  // Handles the toggle of the 'include' state for individual items
+  const toggleInclude = (index: number) => {
+    const updatedItems = [...valueSetState[activeTab as keyof ValueSet]];
+    updatedItems[index].include = !updatedItems[index].include;
+    setValueSetState((prevState) => ({
+      ...prevState,
+      [activeTab]: updatedItems,
+    }));
+  };
+
   // Will eventually be the json object storing the parsed data to return on the results page
   const handleApplyChanges = () => {
     const selectedItems = Object.keys(valueSetState).reduce((acc, key) => {
@@ -168,15 +178,9 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
               <AccordianSection>
                 <div className="customize-query-grid-container customize-query-table">
                   <div className="customize-query-grid-header margin-top-10">
-                    <div style={{ marginLeft: "24px", marginTop: "10px" }}>
-                      Include
-                    </div>
-                    <div style={{ marginLeft: "6px", marginTop: "10px" }}>
-                      Code
-                    </div>
-                    <div style={{ marginLeft: "6px", marginTop: "10px" }}>
-                      Display
-                    </div>
+                    <div className="accordion-table-header">Include</div>
+                    <div className="accordion-table-header">Code</div>
+                    <div className="accordion-table-header">Display</div>
                   </div>
                   <div className="customize-query-grid-body">
                     {items.map((item, index) => (
@@ -198,15 +202,7 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
                             marginLeft: "30px",
                             backgroundColor: "#fff",
                           }}
-                          onClick={() => {
-                            const updatedItems = [...items];
-                            updatedItems[index].include =
-                              !updatedItems[index].include;
-                            setValueSetState((prevState) => ({
-                              ...prevState,
-                              [activeTab]: updatedItems,
-                            }));
-                          }}
+                          onClick={() => toggleInclude(index)}
                         >
                           {item.include && (
                             <Icon.Check

--- a/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
+++ b/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
@@ -165,6 +165,7 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
                     cursor: "pointer",
                     alignItems: "center",
                     display: "flex",
+                    margin: "-3px",
                   }}
                 >
                   {isExpanded ? (

--- a/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
+++ b/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
@@ -273,7 +273,9 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
         </li>
       </nav>
       <ul className="usa-nav__primary usa-accordion"></ul>
-      <hr className="custom-hr"></hr>
+      <div
+        style={{ width: "100%", height: "100%", border: "1px #71767A solid" }}
+      ></div>{" "}
       <a
         href="#"
         type="button"

--- a/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
+++ b/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
@@ -273,9 +273,7 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
         </li>
       </nav>
       <ul className="usa-nav__primary usa-accordion"></ul>
-      <div
-        style={{ width: "100%", height: "100%", border: "1px #71767A solid" }}
-      ></div>{" "}
+      <hr className="custom-hr"></hr>
       <a
         href="#"
         type="button"

--- a/containers/tefca-viewer/src/styles/custom-styles.scss
+++ b/containers/tefca-viewer/src/styles/custom-styles.scss
@@ -654,6 +654,12 @@ html {
   line-height: normal;
 }
 
+.usa-accordion {
+  // border: 1px solid #565C65;
+  border-radius: 4px;
+  padding: 0px;
+}
+
 .usa-accordion__button {
   background: var(--Base-base-dark, #565c65);
   color: white;
@@ -666,6 +672,7 @@ html {
   justify-content: space-between;
   padding: 8px 0;
   font-weight: bold;
+  word-wrap: break-word;
   align-items: center;
   gap: 20px;
   width: 100%;
@@ -778,7 +785,7 @@ html {
   display: flex;
   justify-content: flex-start;
   align-items: center;
-  margin-bottom: 1rem;
+  margin-bottom: 8px;
   width: 100%;
 }
 
@@ -790,7 +797,7 @@ html {
 }
 
 .usa-nav__primary-item {
-  margin-right: 1rem;
+  margin-right: 8px;
 }
 
 .usa-nav__primary-item a:hover {
@@ -892,6 +899,13 @@ html {
   padding: 0;
 }
 
+.usa-accordion--bordered .usa-accordion__content {
+  border-bottom: 1px solid #71767A;
+  border-left: 1px solid #71767A;
+  border-right: 1px solid #71767A;
+  border-radius: 4px;
+}
+
 .accordion-content {
   margin: 0;
   padding: 0;
@@ -926,7 +940,7 @@ html {
 
 .customize-query-grid-header {
   display: grid;
-  grid-template-columns: 160px 160px 1fr;
+  grid-template-columns: 130px 160px 1fr;
   align-items: center;
   padding: 0px 24px;
   border-bottom: 1px solid #71767A;
@@ -943,12 +957,13 @@ html {
   display: grid;
   grid-template-columns: 160px 160px 1fr;
   align-items: center;
-  padding: 14px 24px;
-  border-bottom: 1px solid #71767A;
+  padding: 14px 0px;
 }
 
 .customize-query-grid-row:nth-child(even) {
   background-color: rgba(223, 225, 226, 0.50);
+  border-bottom: 1px solid #71767A;
+  border-top: 1px solid #71767A;
 }
 
 .customize-query-grid-cell {

--- a/containers/tefca-viewer/src/styles/custom-styles.scss
+++ b/containers/tefca-viewer/src/styles/custom-styles.scss
@@ -92,6 +92,11 @@ h4 {
   }
 }
 
+.usa-accordion__content {
+  margin-top: -80px;
+}
+
+
 .minimize-container {
   position: absolute;
   right: 12px;
@@ -560,7 +565,7 @@ html {
   color: #1a4480;
   align-self: stretch;
   margin: 0;
-  aspect-ratio : 1.27;
+  aspect-ratio: 1.27;
   font-family: "Source Sans Pro Web" !important;
   font-size: 1rem;
   font-style: normal;
@@ -569,11 +574,12 @@ html {
   padding: 1.6rem;
 }
 
-#modal-2-description{
+#modal-2-description {
   font-size: 1rem;
   font-style: normal;
   font-weight: 400;
-  line-height: 162%; /* 25.92px */
+  line-height: 162%;
+  /* 25.92px */
   max-width: 100%;
   margin-bottom: 2.5rem;
 }
@@ -611,7 +617,7 @@ html {
 }
 
 .accordion-header-cell {
-  padding: 10px 24px;
+  padding: 0px 24px;
   align-items: flex-start;
   gap: 60px;
   align-self: stretch;
@@ -664,7 +670,8 @@ html {
   gap: 20px;
   width: 100%;
   box-sizing: border-box;
-  border-bottom: 1px solid #a9aeb1;
+  margin-left: 6px;
+  margin-top: 10px;
 }
 
 .usa-accordion__button:hover,
@@ -905,33 +912,62 @@ html {
   gap: 4px;
 }
 
+.customize-query-container {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
 .customize-query-grid-container {
-  display: grid;
-  grid-template-columns: 100px 100px 1fr;
-  /* Same width for Include and Code, Display takes the remaining space */
-  gap: 14px;
-  padding-left: 10px;
-  border-radius: 4px;
-  padding-bottom: 14px;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
 }
 
 .customize-query-grid-header {
-  display: contents;
-  font-weight: 700;
+  display: grid;
+  grid-template-columns: 160px 160px 1fr;
+  align-items: center;
+  padding: 0px 24px;
   border-bottom: 1px solid #71767A;
+  width: 100%;
 }
 
 .customize-query-grid-body {
-  display: contents;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
 }
 
 .customize-query-grid-row {
-  display: contents;
-  padding: 8px 0;
+  display: grid;
+  grid-template-columns: 160px 160px 1fr;
+  align-items: center;
+  padding: 14px 24px;
+  border-bottom: 1px solid #71767A;
 }
 
-.customize-query-striped-row:nth-child(even) {
-  background-color: #f9f9f9;
+.customize-query-grid-row:nth-child(even) {
+  background-color: rgba(223, 225, 226, 0.50);
+}
+
+.customize-query-grid-cell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.customize-query-grid-cell.code {
+  justify-content: flex-start;
+}
+
+.customize-query-grid-cell.display {
+  justify-content: flex-start;
+}
+
+.customize-query-grid-cell.include {
+  justify-content: center;
+  width: 60px;
 }
 
 hr.custom-hr {

--- a/containers/tefca-viewer/src/styles/custom-styles.scss
+++ b/containers/tefca-viewer/src/styles/custom-styles.scss
@@ -785,7 +785,7 @@ html {
   display: flex;
   justify-content: flex-start;
   align-items: center;
-  margin-bottom: 8px;
+  margin-bottom: 16px;
   width: 100%;
 }
 
@@ -964,6 +964,10 @@ html {
   background-color: rgba(223, 225, 226, 0.50);
   border-bottom: 1px solid #71767A;
   border-top: 1px solid #71767A;
+}
+
+.customize-query-grid-row:last-child {
+  border-bottom: none;
 }
 
 .customize-query-grid-cell {


### PR DESCRIPTION
# PULL REQUEST

## Summary
This fixes up the last few nits in the accordion, like the lines between rows and the perimeter and different colored rows every other line.

This also has a few of the other updates raised by @lg-king regarding background color, button color and copy.

The one that is still bedeviling me is the Accordion behavior to only open and close with the click of the ExpandMore/ExpandLess element. I will keep digging, but if anyone has any ideas, all ears. At most, I've figured out how to get the arrow to change direction when we click it, which could be a decent middle ground until we could solve it.

Per accessibility guidance, we may not want to disable making the whole accordion clickable to expand, or we might need to look into an outside-the-box accordion: https://designsystem.digital.gov/components/accordion/#usability-guidance.

## Related Issue
Fixes #2449 

## Acceptance Criteria
Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information
I changed from grid to table on the accordion, because some of the reading on css grid I found was that it wasn't optimal for handling nth row type changes we would need to properly format the rows. I kind of prefer grid, but I wasn't making really any progress in getting the alternate coloring to work.

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
