### PR TITLE
Support pgSQL Infrastructure

### DIFF
--- a/containers/tefca-viewer/.env
+++ b/containers/tefca-viewer/.env
@@ -1,2 +1,0 @@
-NODE_TLS_REJECT_UNAUTHORIZED=0
-DATABASE_URL=postgres://postgres:pw@db:5432/tefca_db

--- a/containers/tefca-viewer/.env
+++ b/containers/tefca-viewer/.env
@@ -1,1 +1,2 @@
 NODE_TLS_REJECT_UNAUTHORIZED=0
+DATABASE_URL=postgres://postgres:pw@db:5432/tefca_db

--- a/containers/tefca-viewer/docker-compose-dev.yaml
+++ b/containers/tefca-viewer/docker-compose-dev.yaml
@@ -1,23 +1,20 @@
 services:
-  tefca-viewer:
-    build:
-      context: .
-      dockerfile: Dockerfile
+  db:
+    image: "postgres:alpine"
     ports:
-      - "3000:3000"
-    environment:
-      NODE_ENV: development
-  tefca-fhir-server:
-    image: "hapiproject/hapi:latest"
-    ports:
-      - "8080:8080"
-  tefca-data-loader:
-    build:
-      context: .
-      dockerfile: Dockerfile.dev
-    volumes:
-      - "./src/app/tests/assets/BundleHAPIServer.json:/etc/BundleHAPIServer.json"
-      - "./post_request.sh:/post_request.sh"
-    command: ["sh", "post_request.sh"]
-    depends_on:
-      - tefca-fhir-server
+      - "5432:5432"
+    # Once we have the migrations set up, we may need to use a mounted volume
+    # copy to get them into the container and create our table structure.
+    # The excerpt below is copied from the ECR Viewer, which has the most
+    # similar structure to what we're doing.
+    # volumes:
+    #  - ./sql/:/docker-entrypoint-initdb.d/
+    #  - ./seed-scripts/sql/:/docker-entrypoint-initdb.d/
+    #  - ./seed-scripts/sql/.pgpass/:/usr/local/lib/.pgpass
+    env_file:
+      - "./tefca.env"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 2s
+      timeout: 5s
+      retries: 20

--- a/containers/tefca-viewer/docker-compose.yaml
+++ b/containers/tefca-viewer/docker-compose.yaml
@@ -1,4 +1,29 @@
 services:
+  # PostgreSQL DB for custom query and value set storage
+  db:
+    image: "postgres:alpine"
+    ports:
+      - "5432:5432"
+    # Once we have the migrations set up, we may need to use a mounted volume
+    # copy to get them into the container and create our table structure.
+    # The excerpt below is copied from the ECR Viewer, which has the most
+    # similar structure to what we're doing.
+    # volumes:
+    #  - ./sql/:/docker-entrypoint-initdb.d/
+    #  - ./seed-scripts/sql/:/docker-entrypoint-initdb.d/
+    #  - ./seed-scripts/sql/.pgpass/:/usr/local/lib/.pgpass
+    environment:
+      - POSTGRES_USER=postgres
+      - PGUSER=postgres
+      - POSTGRES_PASSWORD=pw
+      - POSTGRES_DB=tefca_db
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 2s
+      timeout: 5s
+      retries: 20
+
+  # Next.js app
   tefca-viewer:
     platform: linux/amd64
     build:
@@ -7,4 +32,8 @@ services:
     ports:
       - "3000:3000"
     environment:
-      NODE_ENV: production
+      - DATABASE_URL=${DATABASE_URL:-postgres://postgres:pw@db:5432/tefca_db}
+      - NODE_ENV=production
+    depends_on:
+      db:
+        condition: service_healthy

--- a/containers/tefca-viewer/docker-compose.yaml
+++ b/containers/tefca-viewer/docker-compose.yaml
@@ -12,11 +12,8 @@ services:
     #  - ./sql/:/docker-entrypoint-initdb.d/
     #  - ./seed-scripts/sql/:/docker-entrypoint-initdb.d/
     #  - ./seed-scripts/sql/.pgpass/:/usr/local/lib/.pgpass
-    environment:
-      - POSTGRES_USER=postgres
-      - PGUSER=postgres
-      - POSTGRES_PASSWORD=pw
-      - POSTGRES_DB=tefca_db
+    env_file:
+      - "./tefca.env"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready"]
       interval: 2s
@@ -31,8 +28,9 @@ services:
       dockerfile: ./containers/tefca-viewer/Dockerfile
     ports:
       - "3000:3000"
+    env_file:
+      - "./tefca.env"
     environment:
-      - DATABASE_URL=${DATABASE_URL:-postgres://postgres:pw@db:5432/tefca_db}
       - NODE_ENV=production
     depends_on:
       db:

--- a/containers/tefca-viewer/package.json
+++ b/containers/tefca-viewer/package.json
@@ -4,8 +4,8 @@
   "version": "1.0.1",
   "private": true,
   "scripts": {
-    "dev": "NODE_TLS_REJECT_UNAUTHORIZED=0 next dev",
-    "dev-win": "next dev",
+    "dev": "docker-compose -f docker-compose-dev.yaml up && next dev",
+    "dev-win": "docker-compose -f docker-compose-dev.yaml && next dev",
     "setup-local-env": "./setup-env.sh",
     "build": "next build && cp -r .next/static .next/standalone/.next && cp -r public .next/standalone/",
     "start": "NODE_TLS_REJECT_UNAUTHORIZED=0 node .next/standalone/server.js",

--- a/containers/tefca-viewer/package.json
+++ b/containers/tefca-viewer/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "docker-compose -f docker-compose-dev.yaml up && next dev",
+    "dev-win": "start docker-compose -f docker-compose-dev.yaml up && next dev",
     "setup-local-env": "./setup-env.sh",
     "build": "next build && cp -r .next/static .next/standalone/.next && cp -r public .next/standalone/",
     "start": "NODE_TLS_REJECT_UNAUTHORIZED=0 node .next/standalone/server.js",

--- a/containers/tefca-viewer/package.json
+++ b/containers/tefca-viewer/package.json
@@ -5,7 +5,6 @@
   "private": true,
   "scripts": {
     "dev": "docker-compose -f docker-compose-dev.yaml up && next dev",
-    "dev-win": "docker-compose -f docker-compose-dev.yaml && next dev",
     "setup-local-env": "./setup-env.sh",
     "build": "next build && cp -r .next/static .next/standalone/.next && cp -r public .next/standalone/",
     "start": "NODE_TLS_REJECT_UNAUTHORIZED=0 node .next/standalone/server.js",

--- a/containers/tefca-viewer/tefca.env
+++ b/containers/tefca-viewer/tefca.env
@@ -1,0 +1,5 @@
+POSTGRES_USER=postgres
+PGUSER=postgres
+POSTGRES_PASSWORD=pw
+POSTGRES_DB=tefca_db
+DATABASE_URL=postgres://postgres:pw@db:5432/tefca_db


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR modifies the docker_compose file and the .env file (for `npm run dev` to use as its config) to add support for instantiating a postgres database. Currently, since there's nothing to migrate, the DB just kind of sits there, but I added some relevant commented instructions about how we'll need to use the docker entrypoint once we have the migrations figured out.

## Related Issue
Fixes #2436 

## Additional Information
Particularly curious to see how the entrypoint scripts directory will line up with @m-goggins 's work on migrating the SQLite file. Let me know if I can change this to support you in some way.