### PR TITLE
Run ECR tests, when fhir converter changes

### DIFF
--- a/.github/workflows/container-ecr-viewer.yaml
+++ b/.github/workflows/container-ecr-viewer.yaml
@@ -6,6 +6,7 @@ on:
       - "**"
     paths:
       - containers/ecr-viewer/**
+      - containers/fhir-converter/**
       - packages/**
   merge_group:
     types:

--- a/.github/workflows/container-ingestion.yaml
+++ b/.github/workflows/container-ingestion.yaml
@@ -7,6 +7,7 @@ on:
     paths:
       - containers/ingestion/**
       - containers/dibbs/**
+      - containers/fhir-converter/**
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/container-message-parser.yaml
+++ b/.github/workflows/container-message-parser.yaml
@@ -7,6 +7,7 @@ on:
     paths:
       - containers/message-parser/**
       - containers/dibbs/**
+      - containers/fhir-converter/**
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/container-message-refiner.yaml
+++ b/.github/workflows/container-message-refiner.yaml
@@ -7,6 +7,7 @@ on:
     paths:
       - containers/message-refiner/**
       - containers/dibbs/**
+      - containers/fhir-converter/**
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/container-validation.yaml
+++ b/.github/workflows/container-validation.yaml
@@ -7,6 +7,7 @@ on:
     paths:
       - containers/validation/**
       - containers/dibbs/**
+      - containers/fhir-converter/**
   merge_group:
     types:
       - checks_requested


### PR DESCRIPTION
# PULL REQUEST

## Summary
Because the ecr viewer relies on things being converted a certain way, run ecr-viewer tests when the fhir converter changes
