### PR TITLE
update readme for orchestration

### DIFF
--- a/containers/orchestration/README.md
+++ b/containers/orchestration/README.md
@@ -77,7 +77,7 @@ curl --location 'https://your_url_here/orchestration/process-zip' \
 --form 'message_type="ecr"' \
 --form 'include_error_types="[errors]"' \
 --form 'config_file_name="sample-orchestration-s3-config.json"' \
---form 'upload_file=@"/path_to_your_zip/sample.zip"' \
+--form 'upload_file=@"/path_to_your_zip/sample.zip";type=application/zip' \
 --form 'data_type="zip"'
 ```
 


### PR DESCRIPTION
# PULL REQUEST

## Summary
- Update the readme instructions for CURL to include `type=application/zip`
  - Previously the curl command would fail because the file type was being read as `type=application/octet-stream`