### PR TITLE
Launch flyway with docker

### DIFF
--- a/containers/tefca-viewer/docker-compose-dev.yaml
+++ b/containers/tefca-viewer/docker-compose-dev.yaml
@@ -1,16 +1,19 @@
 services:
+  # Flyway migrations and DB version control
+  flyway:
+    image: flyway/flyway:10.16-alpine
+    command: -configFiles=/flyway/conf/flyway.conf -schemas=public -connectRetries=60 migrate
+    volumes:
+      - ./flyway/sql:/flyway/sql
+      - ./flyway/conf/flyway.conf:/flyway/conf/flyway.conf
+    depends_on:
+      - db
+
+  # Postgresql DB
   db:
     image: "postgres:alpine"
     ports:
       - "5432:5432"
-    # Once we have the migrations set up, we may need to use a mounted volume
-    # copy to get them into the container and create our table structure.
-    # The excerpt below is copied from the ECR Viewer, which has the most
-    # similar structure to what we're doing.
-    # volumes:
-    #  - ./sql/:/docker-entrypoint-initdb.d/
-    #  - ./seed-scripts/sql/:/docker-entrypoint-initdb.d/
-    #  - ./seed-scripts/sql/.pgpass/:/usr/local/lib/.pgpass
     env_file:
       - "./tefca.env"
     healthcheck:

--- a/containers/tefca-viewer/docker-compose.yaml
+++ b/containers/tefca-viewer/docker-compose.yaml
@@ -14,14 +14,6 @@ services:
     image: "postgres:alpine"
     ports:
       - "5432:5432"
-    # Once we have the migrations set up, we may need to use a mounted volume
-    # copy to get them into the container and create our table structure.
-    # The excerpt below is copied from the ECR Viewer, which has the most
-    # similar structure to what we're doing.
-    # volumes:
-    #  - ./sql/:/docker-entrypoint-initdb.d/
-    #  - ./seed-scripts/sql/:/docker-entrypoint-initdb.d/
-    #  - ./seed-scripts/sql/.pgpass/:/usr/local/lib/.pgpass
     env_file:
       - "./tefca.env"
     healthcheck:

--- a/containers/tefca-viewer/docker-compose.yaml
+++ b/containers/tefca-viewer/docker-compose.yaml
@@ -1,4 +1,14 @@
 services:
+  # Flyway migrations and DB version control
+  flyway:
+    image: flyway/flyway:10.16-alpine
+    command: -configFiles=/flyway/conf/flyway.conf -schemas=public -connectRetries=60 migrate
+    volumes:
+      - ./flyway/sql:/flyway/sql
+      - ./flyway/conf/flyway.conf:/flyway/conf/flyway.conf
+    depends_on:
+      - db
+
   # PostgreSQL DB for custom query and value set storage
   db:
     image: "postgres:alpine"

--- a/containers/tefca-viewer/flyway/conf/flyway.conf
+++ b/containers/tefca-viewer/flyway/conf/flyway.conf
@@ -1,0 +1,5 @@
+flyway.url=jdbc:postgresql://db:5432/tefca_db
+flyway.locations=filesystem:/flyway/sql
+flyway.user=postgres
+flyway.password=pw
+flyway.baselineOnMigrate=false

--- a/containers/tefca-viewer/flyway/sql/V01_01__tcr_custom_query_schema.sql
+++ b/containers/tefca-viewer/flyway/sql/V01_01__tcr_custom_query_schema.sql
@@ -63,7 +63,7 @@ CREATE TABLE IF NOT EXISTS query_to_valueset (
     id TEXT PRIMARY KEY,
     query_id UUID,
     valueset_id TEXT,
-    FOREIGN KEY (query_id) REFERENCES query(query_id),
+    FOREIGN KEY (query_id) REFERENCES query(id),
     FOREIGN KEY (valueset_id) REFERENCES valuesets(id)
 );
 


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR gets Flyway going with the tefca viewer's postgres DB using the migration Marcelle defined for our tables. I've opted to use the `flyway-docker` preferred flyway repo structure, which just meant that our migrations folder is now the `/sql` subdirectory within `/flyway`.

## Related Issue
Fixes #2441 

## Additional Information
I encountered a lot of connection refusal errors and timeouts when pulling the latest version of flyway (as did some users reporting on github), so I'm pinning us to the relatively recent 10.16 for alpine. It came out in the last two months and has no connection problems resolving underlying drivers, so I don't think we're losing anything, but just calling it out.