### PR TITLE
Begin populating codes in the TEFCA query customization page

### DIFF
--- a/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
+++ b/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
@@ -5,8 +5,10 @@ import { Accordion, Button, Icon } from "@trussworks/react-uswds";
 import { AccordianSection } from "../../query/component-utils";
 import { ValueSet } from "../../constants";
 import { AccordionItemProps } from "@trussworks/react-uswds/lib/components/Accordion/Accordion";
+import { UseCaseQueryResponse } from "../../query-service";
 
 interface CustomizeQueryProps {
+  useCaseQueryResponse: UseCaseQueryResponse;
   queryType: string;
   ValueSet: ValueSet;
   goBack: () => void;
@@ -15,12 +17,14 @@ interface CustomizeQueryProps {
 /**
  * CustomizeQuery component for displaying and customizing query details.
  * @param root0 - The properties object.
+ * @param root0.useCaseQueryResponse - The response from the query service.
  * @param root0.queryType - The type of the query.
  * @param root0.ValueSet - The value set of labs, conditions, and medications.
  * @param root0.goBack - Back button to go from "customize-queries" to "search" component.
  * @returns The CustomizeQuery component.
  */
 const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
+  useCaseQueryResponse,
   queryType,
   ValueSet,
   goBack,
@@ -259,21 +263,27 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
       </div>
       <nav className="usa-nav custom-nav">
         <li
-          className={`usa-nav__primary-item ${activeTab === "labs" ? "usa-current" : ""}`}
+          className={`usa-nav__primary-item ${
+            activeTab === "labs" ? "usa-current" : ""
+          }`}
         >
           <a href="#labs" onClick={() => handleTabChange("labs")}>
             Labs
           </a>
         </li>
         <li
-          className={`usa-nav__primary-item ${activeTab === "medications" ? "usa-current" : ""}`}
+          className={`usa-nav__primary-item ${
+            activeTab === "medications" ? "usa-current" : ""
+          }`}
         >
           <a href="#medications" onClick={() => handleTabChange("medications")}>
             Medications
           </a>
         </li>
         <li
-          className={`usa-nav__primary-item ${activeTab === "conditions" ? "usa-current" : ""}`}
+          className={`usa-nav__primary-item ${
+            activeTab === "conditions" ? "usa-current" : ""
+          }`}
         >
           <a href="#conditions" onClick={() => handleTabChange("conditions")}>
             Conditions

--- a/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
+++ b/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
@@ -6,6 +6,7 @@ import { AccordianSection } from "../../query/component-utils";
 import { ValueSet } from "../../constants";
 import { AccordionItemProps } from "@trussworks/react-uswds/lib/components/Accordion/Accordion";
 import { UseCaseQueryResponse } from "../../query-service";
+import LoadingView from "./LoadingView";
 
 interface CustomizeQueryProps {
   useCaseQueryResponse: UseCaseQueryResponse;
@@ -35,7 +36,7 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
   const [isExpanded, setIsExpanded] = useState(true);
 
   if (!useCaseQueryResponse) {
-    return <div>Loading...</div>;
+    return <LoadingView loading={true} />;
   }
 
   // Keeps track of whether the accordion is expanded to change the direction of the arrow

--- a/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
+++ b/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
@@ -38,13 +38,6 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
     return <div>Loading...</div>;
   }
 
-  useEffect(() => {
-    console.log(
-      "useCaseQueryResponse in CustomizeQuery:",
-      useCaseQueryResponse,
-    );
-  }, [useCaseQueryResponse]);
-
   // Keeps track of whether the accordion is expanded to change the direction of the arrow
   const handleToggleExpand = () => {
     setIsExpanded(!isExpanded);
@@ -93,6 +86,7 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
       acc[key as keyof ValueSet] = items.filter((item) => item.include);
       return acc;
     }, {} as ValueSet);
+    goBack();
   };
 
   useEffect(() => {

--- a/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
+++ b/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
@@ -34,6 +34,17 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
   const [valueSetState, setValueSetState] = useState<ValueSet>(ValueSet);
   const [isExpanded, setIsExpanded] = useState(true);
 
+  if (!useCaseQueryResponse) {
+    return <div>Loading...</div>;
+  }
+
+  useEffect(() => {
+    console.log(
+      "useCaseQueryResponse in CustomizeQuery:",
+      useCaseQueryResponse,
+    );
+  }, [useCaseQueryResponse]);
+
   // Keeps track of whether the accordion is expanded to change the direction of the arrow
   const handleToggleExpand = () => {
     setIsExpanded(!isExpanded);

--- a/containers/tefca-viewer/src/app/query/components/LoadingView.tsx
+++ b/containers/tefca-viewer/src/app/query/components/LoadingView.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import React from "react";
+
+interface LoadingViewProps {
+  loading: boolean;
+}
+
+/**
+ *
+ * @param root0 - Component for loading screen.
+ * @param root0.loading - Boolean to track loading state.
+ * @returns The LoadingView component.
+ */
+const LoadingView: React.FC<LoadingViewProps> = ({ loading }) => {
+  if (loading) {
+    return (
+      <div className="overlay">
+        <div className="spinner"></div>
+        <h2>Loading...</h2>
+      </div>
+    );
+  } else {
+    return null;
+  }
+};
+
+export default LoadingView;

--- a/containers/tefca-viewer/src/app/query/page.tsx
+++ b/containers/tefca-viewer/src/app/query/page.tsx
@@ -14,6 +14,7 @@ import {
   USE_CASES,
 } from "../constants";
 import CustomizeQuery from "./components/CustomizeQuery";
+import LoadingView from "./components/LoadingView";
 
 /**
  * Parent component for the query page. Based on the mode, it will display the search
@@ -75,11 +76,10 @@ const Query: React.FC = () => {
       )}
       {/* Show the no patients found view if there are no patients */}
       {mode === "no-patients" && <NoPatientsFound setMode={setMode} />}
-      {loading && (
-        <div className="overlay">
-          <div className="spinner"></div>
-        </div>
-      )}
+
+      {/* Use LoadingView component for loading state */}
+      <LoadingView loading={loading} />
+
       {/* Show the customize query view to select and change what is returned in results */}
       {mode === "customize-queries" && (
         <>
@@ -101,14 +101,3 @@ const Query: React.FC = () => {
   );
 };
 export default Query;
-function LoadingView({ loading }: { loading: boolean }) {
-  if (loading) {
-    return (
-      <div>
-        <h2>Loading...</h2>
-      </div>
-    );
-  } else {
-    return null;
-  }
-}

--- a/containers/tefca-viewer/src/app/query/page.tsx
+++ b/containers/tefca-viewer/src/app/query/page.tsx
@@ -86,18 +86,20 @@ const Query: React.FC = () => {
         </div>
       )}
       {/* Show the customize query view to select and change what is returned in results */}
-      {mode === "customize-queries" && useCaseQueryResponse && (
+      {mode === "customize-queries" && (
         <>
-          <CustomizeQuery
-            useCaseQueryResponse={useCaseQueryResponse}
-            queryType={queryType}
-            ValueSet={{
-              labs: dummyLabs,
-              medications: dummyMedications,
-              conditions: dummyConditions,
-            }}
-            goBack={() => setMode("search")}
-          />
+          {useCaseQueryResponse && (
+            <CustomizeQuery
+              useCaseQueryResponse={useCaseQueryResponse}
+              queryType={queryType}
+              ValueSet={{
+                labs: dummyLabs,
+                medications: dummyMedications,
+                conditions: dummyConditions,
+              }}
+              goBack={() => setMode("search")}
+            />
+          )}
         </>
       )}
     </div>

--- a/containers/tefca-viewer/src/app/query/page.tsx
+++ b/containers/tefca-viewer/src/app/query/page.tsx
@@ -14,7 +14,6 @@ import {
   USE_CASES,
 } from "../constants";
 import CustomizeQuery from "./components/CustomizeQuery";
-import { useEffect } from "react";
 
 /**
  * Parent component for the query page. Based on the mode, it will display the search
@@ -32,10 +31,6 @@ const Query: React.FC = () => {
     demoQueryOptions.find((option) => option.value === useCase)?.label || "",
   );
 
-  useEffect(() => {
-    console.log("Mode:", mode);
-    console.log("useCaseQueryResponse:", useCaseQueryResponse);
-  }, [mode, useCaseQueryResponse]);
   return (
     <div>
       {mode === "search" && (

--- a/containers/tefca-viewer/src/app/query/page.tsx
+++ b/containers/tefca-viewer/src/app/query/page.tsx
@@ -14,6 +14,7 @@ import {
   USE_CASES,
 } from "../constants";
 import CustomizeQuery from "./components/CustomizeQuery";
+import { useEffect } from "react";
 
 /**
  * Parent component for the query page. Based on the mode, it will display the search
@@ -31,6 +32,10 @@ const Query: React.FC = () => {
     demoQueryOptions.find((option) => option.value === useCase)?.label || "",
   );
 
+  useEffect(() => {
+    console.log("Mode:", mode);
+    console.log("useCaseQueryResponse:", useCaseQueryResponse);
+  }, [mode, useCaseQueryResponse]);
   return (
     <div>
       {mode === "search" && (
@@ -81,9 +86,10 @@ const Query: React.FC = () => {
         </div>
       )}
       {/* Show the customize query view to select and change what is returned in results */}
-      {mode === "customize-queries" && (
+      {mode === "customize-queries" && useCaseQueryResponse && (
         <>
           <CustomizeQuery
+            useCaseQueryResponse={useCaseQueryResponse}
             queryType={queryType}
             ValueSet={{
               labs: dummyLabs,


### PR DESCRIPTION
# PULL REQUEST

## Summary
This updates the `customize-queries` to begin to take the `UseCaseQueryResponse` into that response. We will need that to then update that response based off the concepts returned by the TCR, then pare down the `UseCaseQueryResponse` based off selections made on the Customize Query page. So if I understand the sequence right:
1. User selects demo of interest.
2. We run the condition against the eRSD.
3. Customize Queries displays the full gamut of potential concepts based off the condition(s) selected.

A smaller, minor fix is to also move `LoadingView.tsx` to its own component to be able to take advantage of it while rendering other pieces, as the the `/query` work gets more complex.

## Related Issue
Fixes #2311 

## Acceptance Criteria
Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information
My original intention was to do more with the demo query data, but I was not actually sure if the sequencing of the work was correct, and if we wanted to get further along with the the eRSD DB call work before implementing it as a full replacement for our demo work.

Basically, I started thinking of how to retrofit our dummy data and realized it would be a lot of work when I think we are closer to maybe just all focusing on the DB connection the updating/removing our dummy data entirely? Curious if y'all think that makes sense.

I could pull data for the sample queries, but idk if we would want to get further the eRSD SQL queries and then just that as the basis for updating.

I think my main concern is releasing the full branch in what will not be a completed state. Right now, the customize query will take you to that page and display just dummy data regardless of demo type. We could implement everything as-is, then just hide the button when we release the full feature branch, I suppose.

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
