### PR TITLE
fix spacing on the query results page

### DIFF
--- a/containers/tefca-viewer/src/app/query/components/ResultsView.tsx
+++ b/containers/tefca-viewer/src/app/query/components/ResultsView.tsx
@@ -64,21 +64,19 @@ const ResultsView: React.FC<ResultsViewProps> = ({
           </a>
         </div>
       </div>
-      <div className="main-container">
-        <div className="content-wrapper">
-          <div className="nav-wrapper">
-            <nav className="sticky-nav">
-              <SideNav />
-            </nav>
-          </div>
-          <div className={"ecr-viewer-container"}>
-            <div className="ecr-content">
-              <h2 className="margin-bottom-3" id="ecr-summary">
-                Query Results
-              </h2>
-              <div className="margin-top-6">
-                <AccordionContainer queryResponse={useCaseQueryResponse} />
-              </div>
+      <div className="main-container grid-container grid-row">
+        <div className="nav-wrapper tablet:grid-col-3">
+          <nav className="sticky-nav">
+            <SideNav />
+          </nav>
+        </div>
+        <div className="tablet:grid-col-9">
+          <div className="ecr-content">
+            <h2 className="margin-bottom-3" id="ecr-summary">
+              Query Results
+            </h2>
+            <div className="margin-top-6">
+              <AccordionContainer queryResponse={useCaseQueryResponse} />
             </div>
           </div>
         </div>

--- a/containers/tefca-viewer/src/styles/custom-styles.scss
+++ b/containers/tefca-viewer/src/styles/custom-styles.scss
@@ -150,15 +150,13 @@ h4 {
 
 .main-container {
   max-width: calc($ecr-viewer-max-width - 2 * $ecr-viewer-content-margin);
-  padding: 0 0 4.5rem 0;
+  padding: 3rem 0 4.5rem 0;
 }
-
 
 .nav-wrapper {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  margin-top: 3rem;
 }
 
 .sticky-nav {

--- a/containers/tefca-viewer/src/styles/custom-styles.scss
+++ b/containers/tefca-viewer/src/styles/custom-styles.scss
@@ -2,7 +2,7 @@
 
 // taken as values from Figma
 $ecr-viewer-max-width: 90rem;
-$ecr-viewer-content-margin: 13.75rem;
+$ecr-viewer-content-margin: 6.5rem;
 
 .section__line {
   border-top: 1px solid #99deea;

--- a/containers/tefca-viewer/src/styles/custom-styles.scss
+++ b/containers/tefca-viewer/src/styles/custom-styles.scss
@@ -1,5 +1,9 @@
 @use "uswds-core" as *;
 
+// taken as values from Figma
+$ecr-viewer-max-width: 90rem;
+$ecr-viewer-content-margin: 6.5rem;
+
 .section__line {
   border-top: 1px solid #99deea;
   margin-top: 0.5rem;
@@ -145,25 +149,16 @@ h4 {
 }
 
 .main-container {
-  display: flex;
-  justify-content: center;
-  overflow: visible;
+  max-width: calc($ecr-viewer-max-width - 2 * $ecr-viewer-content-margin);
+  padding: 0 0 4.5rem 0;
 }
 
-.content-wrapper {
-  display: flex;
-  // max-width: 1440px;
-  justify-content: center;
-  gap: 48px;
-  overflow: visible;
-}
 
 .nav-wrapper {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  margin-top: 48px;
-  min-width: 250px;
+  margin-top: 3rem;
 }
 
 .sticky-nav {
@@ -172,15 +167,6 @@ h4 {
   flex-basis: auto;
   position: sticky;
   top: 0;
-}
-
-.ecr-viewer-container {
-  display: flex;
-  flex-basis: auto;
-  justify-content: left;
-  margin-left: auto;
-  margin-right: auto;
-  margin-top: 48px;
 }
 
 .ecr-content h2:first-of-type {

--- a/containers/tefca-viewer/src/styles/custom-styles.scss
+++ b/containers/tefca-viewer/src/styles/custom-styles.scss
@@ -2,7 +2,7 @@
 
 // taken as values from Figma
 $ecr-viewer-max-width: 90rem;
-$ecr-viewer-content-margin: 6.5rem;
+$ecr-viewer-content-margin: 13.75rem;
 
 .section__line {
   border-top: 1px solid #99deea;


### PR DESCRIPTION
# PULL REQUEST

## Summary
I was playing around with the query connector demo site and noticed that the results page had some wonky spacing issues interacting with the accordions. Was annoyed by it so went ahead and fixed it as a starter PR. Resisting the urge to fix the view on mobile viewports for now.

Pulled a few spacing variables from Figma for ease of use in future frontend PR's.

Using the 12 column grid system to translate design intent to the spacing, which is implemented [in USWDS here](https://designsystem.digital.gov/utilities/layout-grid/) and is something I think we should formalize. A brief intro for the overall approach is [here](https://medium.com/@designwithabishek/a-beginners-guide-to-grid-system-57045b3f7035)

## Related Issue 
Didn't find a bug issue but going to pretend there was a starter bug ticket / flash my new team member badge as permission to fix something arbitrarily :). Won't work on something that isn't already prioritized in the future!

Before: 
https://github.com/user-attachments/assets/94049273-414f-495c-9bc7-b639e46ab765

After:
https://github.com/user-attachments/assets/9bc27375-b9d9-4036-83bc-21238e15dba6