### PR TITLE
add visual indicator for apply changes --> patient info reroute

### DIFF
--- a/containers/tefca-viewer/package.json
+++ b/containers/tefca-viewer/package.json
@@ -37,6 +37,7 @@
     "pg-promise": "^11.5.4",
     "react": "^18",
     "react-dom": "^18",
+    "react-toastify": "^10.0.5",
     "sharp": "^0.33.5"
   },
   "devDependencies": {

--- a/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
+++ b/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/app/database-service";
 import { UseCaseQueryResponse } from "@/app/query-service";
 import LoadingView from "./LoadingView";
+import { showRedirectConfirmation } from "./RedirectionToast";
 
 interface CustomizeQueryProps {
   useCaseQueryResponse: UseCaseQueryResponse;
@@ -43,10 +44,6 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
     conditions: [],
   });
   const [isExpanded, setIsExpanded] = useState(true);
-
-  if (!useCaseQueryResponse) {
-    return <LoadingView loading={true} />;
-  }
 
   // Keeps track of whether the accordion is expanded to change the direction of the arrow
   const handleToggleExpand = () => {
@@ -97,6 +94,11 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
       return acc;
     }, {} as ValueSet);
     goBack();
+    showRedirectConfirmation({
+      heading: QUERY_CUSTOMIZATION_CONFIRMATION_HEADER,
+      body: QUERY_CUSTOMIZATION_CONFIRMATION_BODY,
+      headingLevel: "h4",
+    });
   };
 
   useEffect(() => {
@@ -302,6 +304,7 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
           <Icon.ArrowBack /> Return to patient search
         </a>
       </div>
+      <LoadingView loading={!useCaseQueryResponse} />
       <h1 className="font-sans-2xl text-bold" style={{ paddingBottom: "0px" }}>
         Customize query
       </h1>
@@ -368,3 +371,8 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
 };
 
 export default CustomizeQuery;
+
+export const QUERY_CUSTOMIZATION_CONFIRMATION_HEADER =
+  "Query Customization Successful!";
+export const QUERY_CUSTOMIZATION_CONFIRMATION_BODY =
+  "You've successfully customized your query. Once you're done adding patient details, submit your completed query to get results";

--- a/containers/tefca-viewer/src/app/query/components/LoadingView.tsx
+++ b/containers/tefca-viewer/src/app/query/components/LoadingView.tsx
@@ -4,6 +4,7 @@ import React from "react";
 
 interface LoadingViewProps {
   loading: boolean;
+  message?: string;
 }
 
 /**

--- a/containers/tefca-viewer/src/app/query/components/LoadingView.tsx
+++ b/containers/tefca-viewer/src/app/query/components/LoadingView.tsx
@@ -4,7 +4,6 @@ import React from "react";
 
 interface LoadingViewProps {
   loading: boolean;
-  message?: string;
 }
 
 /**

--- a/containers/tefca-viewer/src/app/query/components/RedirectionToast.tsx
+++ b/containers/tefca-viewer/src/app/query/components/RedirectionToast.tsx
@@ -1,0 +1,77 @@
+import { Alert, HeadingLevel } from "@trussworks/react-uswds";
+import { toast } from "react-toastify";
+
+import styles from "./redirectToast.module.css";
+
+export type AlertType = "info" | "success" | "warning" | "error";
+
+type RedirectionToastProps = {
+  toastVariant: AlertType;
+  heading: string;
+  body: string;
+  headingLevel?: HeadingLevel;
+};
+/**
+ * Redirection toast to be invoked when there's a need to confirm with the user
+ * something has occurred
+ * @param root0 - The config object to specify content / styling of the toast
+ * @param root0.toastVariant - A string from the enum set "info" | "success" | "warning" | "error"
+ * indicating what type of toast variant we want. Will style the USWDS component accordingly
+ * @param root0.heading - The heading / title of the alert
+ * @param root0.body - The body content of the alert
+ * @param root0.headingLevel - string of h1-6 indicating which heading level the alert will be.
+ * defaults to h4
+ * @returns A toast component using the USWDS alert
+ */
+const RedirectionToast: React.FC<RedirectionToastProps> = ({
+  toastVariant,
+  heading,
+  body,
+  headingLevel,
+}) => {
+  return (
+    <Alert
+      type={toastVariant}
+      heading={heading}
+      headingLevel={headingLevel ? headingLevel : "h4"}
+    >
+      {body}
+    </Alert>
+  );
+};
+
+const options = {
+  hideProgressBar: false,
+  position: "bottom-left" as const,
+  closeOnClick: true,
+  closeButton: false,
+  className: styles.padding0,
+  bodyClassName: styles.padding0,
+  pauseOnFocusLoss: false,
+};
+
+/**
+ *
+ * @param content - content object to configure the redirect confirmation toast
+ * @param content.heading - heading of the redirect toast
+ * @param content.body - body text of the redirect toast
+ * @param content.headingLevel - h1-6 level of the heading tag associated with
+ * content.heading. defaults to h4
+ */
+export function showRedirectConfirmation(content: {
+  heading: string;
+  body: string;
+  headingLevel?: HeadingLevel;
+}) {
+  toast.success(
+    <RedirectionToast
+      toastVariant="success"
+      heading={content.heading}
+      headingLevel={content.headingLevel}
+      body={content.body}
+    />,
+    options
+  );
+}
+
+export default RedirectionToast;

--- a/containers/tefca-viewer/src/app/query/components/redirectToast.module.css
+++ b/containers/tefca-viewer/src/app/query/components/redirectToast.module.css
@@ -1,0 +1,7 @@
+.toastWidth {
+  width: 35%;
+}
+
+.padding0 {
+  padding: 0 !important;
+}

--- a/containers/tefca-viewer/src/app/query/page.tsx
+++ b/containers/tefca-viewer/src/app/query/page.tsx
@@ -13,6 +13,9 @@ import {
 } from "../constants";
 import CustomizeQuery from "./components/CustomizeQuery";
 import LoadingView from "./components/LoadingView";
+import { ToastContainer } from "react-toastify";
+
+import "react-toastify/dist/ReactToastify.min.css";
 
 /**
  * Parent component for the query page. Based on the mode, it will display the search
@@ -85,10 +88,13 @@ const Query: React.FC = () => {
             useCaseQueryResponse={useCaseQueryResponse}
             queryType={queryType}
             queryName={UseCaseToQueryNameMap[useCase]}
-            goBack={() => setMode("search")}
+            goBack={() => {
+              setMode("search");
+            }}
           />
         </>
       )}
+      <ToastContainer icon={false} />
     </div>
   );
 };

--- a/containers/tefca-viewer/src/app/query/test/page.tsx
+++ b/containers/tefca-viewer/src/app/query/test/page.tsx
@@ -77,14 +77,3 @@ const Query: React.FC = () => {
   );
 };
 export default Query;
-function LoadingView({ loading }: { loading: boolean }) {
-  if (loading) {
-    return (
-      <div>
-        <h2>Loading...</h2>
-      </div>
-    );
-  } else {
-    return null;
-  }
-}

--- a/containers/tefca-viewer/src/styles/custom-styles.scss
+++ b/containers/tefca-viewer/src/styles/custom-styles.scss
@@ -978,3 +978,7 @@ hr.custom-hr {
   border: none;
   border-top: 1px solid #71767a;
 }
+
+.Toastify__toast-container {
+  width: calc($ecr-viewer-max-width * 0.4) !important;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -905,6 +905,7 @@
         "pg-promise": "^11.5.4",
         "react": "^18",
         "react-dom": "^18",
+        "react-toastify": "^10.0.5",
         "sharp": "^0.33.5"
       },
       "devDependencies": {
@@ -7561,6 +7562,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -14373,6 +14382,18 @@
     "node_modules/react-property": {
       "version": "2.0.2",
       "license": "MIT"
+    },
+    "node_modules/react-toastify": {
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.5.tgz",
+      "integrity": "sha512-mNKt2jBXJg4O7pSdbNUfDdTsK9FIdikfsIE/yUCxbAEXl4HMyJaivrVFcn3Elvt5xvCQYhUZm+hqTIu1UXM3Pw==",
+      "dependencies": {
+        "clsx": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",


### PR DESCRIPTION
# PULL REQUEST

## Summary
Adds a toast confirmation for the apply changes --> patient info reroute that tells the user that they've successfully applied a query customization. Toast disappears automatically after 5 seconds / can be dismissed if clicked on.

Laura and I chatted and agreed that we'd steal a pattern from SimpleReport that does something similar. There's a possibility that we want another permanent pill / visual indicator around the type of customized query that we added, but we agreed that the redirect notification is a good first step. 

https://github.com/user-attachments/assets/80aae31f-9595-4a72-b408-9a5278de0a9e

## Related Issue
Fixes #2515 

## Acceptance Criteria
After clicking "Apply Changes" on the customize page and being rerouted, the query page has some notification to let them know that they are executing the custom query they created (might need design work on this)

## Additional Information
To accomplish this, we're using [react-toastify](https://www.npmjs.com/package/react-toastify) which is also a package that we're using on SR. Can imagine other instances where we want toasts to show up, but if folks have concerns with adding this package, happy to field them.

We are using the provided [USWDS alert ](https://designsystem.digital.gov/components/alert/) component as the visual piece of the toast, so shouldn't run into any accessibility contrast issues there. Chatted with Brandon about large accessibility QA processes and we decided we can table that until we can have a convo with the wider eng team.

