### PR TITLE
Add missing demo use case queryNames

### DIFF
--- a/containers/tefca-viewer/playwright.config.ts
+++ b/containers/tefca-viewer/playwright.config.ts
@@ -18,8 +18,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  workers: undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
@@ -73,8 +72,8 @@ export default defineConfig({
   webServer: {
     command: "docker compose build --no-cache && docker compose up",
     port: 3000,
-    timeout: 300 * 1000,
-    reuseExistingServer: true,
+    timeout: 120 * 1000,
+    reuseExistingServer: !process.env.CI,
   },
 
   /* Hook to ensure Docker is shut down after tests or on error */

--- a/containers/tefca-viewer/playwright.config.ts
+++ b/containers/tefca-viewer/playwright.config.ts
@@ -74,7 +74,7 @@ export default defineConfig({
     command: "docker compose build --no-cache && docker compose up",
     port: 3000,
     timeout: 120 * 1000,
-    reuseExistingServer: true,
+    reuseExistingServer: false,
   },
 
   /* Hook to ensure Docker is shut down after tests or on error */

--- a/containers/tefca-viewer/playwright.config.ts
+++ b/containers/tefca-viewer/playwright.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  workers: undefined,
+  workers: process.env.CI ? 4 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/containers/tefca-viewer/playwright.config.ts
+++ b/containers/tefca-viewer/playwright.config.ts
@@ -73,8 +73,8 @@ export default defineConfig({
   webServer: {
     command: "docker compose build --no-cache && docker compose up",
     port: 3000,
-    timeout: 240 * 1000,
-    reuseExistingServer: false,
+    timeout: 300 * 1000,
+    reuseExistingServer: true,
   },
 
   /* Hook to ensure Docker is shut down after tests or on error */

--- a/containers/tefca-viewer/playwright.config.ts
+++ b/containers/tefca-viewer/playwright.config.ts
@@ -73,7 +73,7 @@ export default defineConfig({
   webServer: {
     command: "docker compose build --no-cache && docker compose up",
     port: 3000,
-    timeout: 120 * 1000,
+    timeout: 240 * 1000,
     reuseExistingServer: false,
   },
 

--- a/containers/tefca-viewer/playwright.config.ts
+++ b/containers/tefca-viewer/playwright.config.ts
@@ -72,7 +72,7 @@ export default defineConfig({
   webServer: {
     command: "docker compose build --no-cache && docker compose up",
     port: 3000,
-    timeout: 120 * 1000,
+    timeout: 300 * 1000,
     reuseExistingServer: !process.env.CI,
   },
 

--- a/containers/tefca-viewer/src/app/constants.ts
+++ b/containers/tefca-viewer/src/app/constants.ts
@@ -14,12 +14,12 @@ export type USE_CASES = (typeof UseCases)[number];
 export const UseCaseToQueryNameMap: {
   [key in USE_CASES]: string;
 } = {
-  "social-determinants": "",
-  "newborn-screening": "",
-  syphilis: "",
-  gonorrhea: "",
+  "social-determinants": "Social Determinants of Health",
+  "newborn-screening": "Newborn Screening",
+  syphilis: "Congenital syphilis (disorder)",
+  gonorrhea: "Gonorrhea (disorder)",
   chlamydia: "Chlamydia trachomatis infection (disorder)",
-  cancer: "",
+  cancer: "Cancer (Leukemia)",
 };
 
 /**

--- a/containers/tefca-viewer/src/app/query/components/SearchForm.tsx
+++ b/containers/tefca-viewer/src/app/query/components/SearchForm.tsx
@@ -164,11 +164,10 @@ const SearchForm: React.FC<SearchFormProps> = ({
                 <select
                   id="query"
                   name="query"
-                  className="usa-select  margin-top-1"
-                  value={useCase}
+                  className="usa-select margin-top-1"
+                  defaultValue={useCase}
                   onChange={(event) => {
                     handleDemoQueryChange(event.target.value);
-                    setUseCase(event.target.value as USE_CASES);
                   }}
                 >
                   {demoQueryOptions.map((option) => (
@@ -224,6 +223,7 @@ const SearchForm: React.FC<SearchFormProps> = ({
                     id="patient"
                     name="patient"
                     className="usa-select margin-top-1"
+                    defaultValue=""
                     value={patientOption}
                     onChange={(event) => {
                       setPatientOption(event.target.value);


### PR DESCRIPTION
# Add missing demo query names

## Summary
This PR adds in the rest of the queryNames for our other demo use cases.

## Related Issue
Fixes #2311 

## Additional Information
Our playwright tests were breaking for two reasons.
1. The infrastructure configuration in `playwright.config.ts` had settings that in combination were causing the github actions tests to timeout. We were always re-using an existing webserver as part of the config, which means that when github first spins up the playwright tests, there's no server to use so they'll always fail. We were getting lucky that sometimes re-runs would catch an existing build image or were recycling something cached rather than spinning up something fresh. That's now fixed so that locally we'll use existing servers (for ease of development) but Github will spin up fresh versions each time. Additionally, we had specified that for `process.CI` mode, only 1 worker would be available for test running, which was causing the test suite to fail by virtue of timeout before they could all finish. I've since parallelized this to a lesser extent than what's available locally (so as to not co-opt all the runners), but now the tests will execute in reasonable time.
2. There is a bug in the test workflow that I documented here https://app.zenhub.com/workspaces/skylight-dibbs-viper-6480ba23b5a07644e0e46d23/issues/gh/cdcgov/phdi/2538 . This PR _does not_ fix those issues since it's both bigger and potentially moot if we collapse user journeys, but until that bug gets fixed our e2es will stay broken.
