### PR TITLE
Save changes to valuesets when customizing query

### DIFF
--- a/containers/tefca-viewer/src/app/constants.ts
+++ b/containers/tefca-viewer/src/app/constants.ts
@@ -1,3 +1,5 @@
+import * as dq from "./demoQueries";
+
 /**
  * The use cases that can be used in the app
  */
@@ -11,7 +13,31 @@ export const UseCases = [
 ] as const;
 export type USE_CASES = (typeof UseCases)[number];
 
-/*Labels and values for the query options dropdown on the query page*/
+export const UseCaseToQueryName: {
+  [key in USE_CASES]: string;
+} = {
+  "social-determinants": "Social Determinants of Health",
+  "newborn-screening": "Newborn Screening",
+  syphilis: "Congenital syphilis (disorder)",
+  gonorrhea: "Gonorrhea (disorder)",
+  chlamydia: "Chlamydia trachomatis infection (disorder)",
+  cancer: "Cancer (Leukemia)",
+};
+
+export const UseCaseToStructMap: {
+  [key in USE_CASES]: dq.QueryStruct;
+} = {
+  "social-determinants": dq.SOCIAL_DETERMINANTS_QUERY,
+  "newborn-screening": dq.NEWBORN_SCREENING_QUERY,
+  syphilis: dq.SYPHILIS_QUERY,
+  gonorrhea: dq.GONORRHEA_QUERY,
+  chlamydia: dq.CHLAMYDIA_QUERY,
+  cancer: dq.CANCER_QUERY,
+};
+
+/**
+ * Labels and values for the query options dropdown on the query page
+ */
 export const demoQueryOptions = [
   { value: "cancer", label: "Cancer case investigation" },
   { value: "chlamydia", label: "Chlamydia case investigation" },
@@ -287,6 +313,7 @@ export interface ValueSetItem {
   system: string;
   include: boolean;
   author: string;
+  clinicalServiceType: string;
 }
 
 /*Type to specify the expected expected types of valueset items that will be displayed 

--- a/containers/tefca-viewer/src/app/database-service.ts
+++ b/containers/tefca-viewer/src/app/database-service.ts
@@ -2,6 +2,7 @@
 import { Pool, PoolConfig, QueryResultRow } from "pg";
 import dotenv from "dotenv";
 import { ValueSetItem } from "./constants";
+import { QueryStruct } from "./demoQueries";
 
 const getQuerybyNameSQL = `
 select q.query_name, q.id, q.author, qtv.valueset_id, vs.type, qic.concept_id, qic.include, c.code, c.code_system, c.display 
@@ -53,14 +54,14 @@ export const getSavedQueryByName = async (name: string) => {
 };
 
 /**
- * Helper function to filter the rows of results returned from the DB for particular
- * types of related clinical services.
- * @param dbResults The list of results returned from the DB.
+ * Helper function to filter the valueset-mapped rows of results returned from
+ * the DB for particular types of related clinical services.
+ * @param vsItems A list of value sets mapped from DB rows.
  * @param type One of "labs", "medications", or "conditions".
  * @returns A list of rows containing only the predicate service type.
  */
-export const filterQueryRows = async (
-  dbResults: QueryResultRow[],
+export const filterValueSets = async (
+  vsItems: ValueSetItem[],
   type: "labs" | "medications" | "conditions",
 ) => {
   // Assign clinical code type based on desired filter
@@ -73,8 +74,8 @@ export const filterQueryRows = async (
   } else {
     valuesetFilters = ["dxtc", "sdtc"];
   }
-  const results = dbResults.filter((row) =>
-    valuesetFilters.includes(row["type"]),
+  const results = vsItems.filter((vs) =>
+    valuesetFilters.includes(vs.clinicalServiceType),
   );
   return results;
 };
@@ -93,8 +94,45 @@ export const mapQueryRowsToValueSetItems = async (rows: QueryResultRow[]) => {
       system: r["code_system"],
       include: r["include"],
       author: r["author"],
+      clinicalServiceType: r["type"],
     };
     return vsTranslation;
   });
   return vsItems;
+};
+
+/**
+ * Formats a statefully updated list of value set items into a JSON structure
+ * used for executing custom queries.
+ * @param useCase The base use case being queried for.
+ * @param vsItems The list of value set items the user wants included.
+ * @returns A structured specification of a query that can be executed.
+ */
+export const formatValueSetItemsAsQuerySpec = async (
+  useCase: string,
+  vsItems: ValueSetItem[],
+) => {
+  let secondEncounter: boolean = false;
+  if (["cancer", "chlamydia", "gonorrhea", "syphilis"].includes(useCase)) {
+    secondEncounter = true;
+  }
+  const labCodes: string[] = vsItems
+    .filter((vs) => vs.system === "http://loinc.org")
+    .map((vs) => vs.code);
+  const snomedCodes: string[] = vsItems
+    .filter((vs) => vs.system === "http://snomed.info/sct")
+    .map((vs) => vs.code);
+  const rxnormCodes: string[] = vsItems
+    .filter((vs) => vs.system === "http://www.nlm.nih.gov/research/umls/rxnorm")
+    .map((vs) => vs.code);
+
+  const spec: QueryStruct = {
+    labCodes: labCodes,
+    snomedCodes: snomedCodes,
+    rxnormCodes: rxnormCodes,
+    classTypeCodes: [] as string[],
+    hasSecondEncounterQuery: secondEncounter,
+  };
+
+  return spec;
 };

--- a/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
+++ b/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
@@ -35,11 +35,7 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
   setQueryValuesets,
   goBack,
 }) => {
-  console.log("UseCaseQueryResponse:");
-  console.log(useCaseQueryResponse);
-
   const [activeTab, setActiveTab] = useState("labs");
-
   const [valueSetState, setValueSetState] = useState<ValueSet>({
     labs: [],
     medications: [],
@@ -88,7 +84,8 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
     }));
   };
 
-  // Will eventually be the json object storing the parsed data to return on the results page
+  // Persist the changes made on this page to the valueset state maintained
+  // by the entire query branch of the app
   const handleApplyChanges = () => {
     const selectedItems = Object.keys(valueSetState).reduce((acc, key) => {
       const items = valueSetState[key as keyof ValueSet];
@@ -96,6 +93,8 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
       return acc;
     }, {} as ValueSet);
 
+    // Use a prop spread to concatenate the three separate types of codes
+    // back into one coherent structure
     setQueryValuesets([
       ...selectedItems.labs,
       ...selectedItems.medications,
@@ -111,9 +110,11 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
 
   useEffect(() => {
     // Gate whether we actually update state after fetching so we
-    // avoid name-change race conditions
+    // avoid race conditions if the user goes back to the SearchForm
     let isSubscribed = true;
 
+    // DB results are only guaranteed as Promises, so we need to async/await
+    // manipulations to the rows
     const filterVS = async () => {
       const labs = await filterValueSets(queryValuesets, "labs");
       const medications = await filterValueSets(queryValuesets, "medications");

--- a/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
+++ b/containers/tefca-viewer/src/app/query/components/CustomizeQuery.tsx
@@ -35,6 +35,9 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
   setQueryValuesets,
   goBack,
 }) => {
+  console.log("UseCaseQueryResponse:");
+  console.log(useCaseQueryResponse);
+
   const [activeTab, setActiveTab] = useState("labs");
 
   const [valueSetState, setValueSetState] = useState<ValueSet>({

--- a/containers/tefca-viewer/src/app/query/components/SearchForm.tsx
+++ b/containers/tefca-viewer/src/app/query/components/SearchForm.tsx
@@ -72,8 +72,6 @@ const SearchForm: React.FC<SearchFormProps> = ({
 
   const [autofilled, setAutofilled] = useState(false); // boolean indicating if the form was autofilled, changes color if true
 
-  console.log("use case: " + useCase);
-
   // Fills fields with sample data based on the selected patientOption
   const fillFields = useCallback(
     (patientOption: PatientType, highlightAutofilled = true) => {
@@ -86,29 +84,27 @@ const SearchForm: React.FC<SearchFormProps> = ({
         setPhone(data.Phone);
         setFhirServer(data.FhirServer as FHIR_SERVERS);
         setUseCase(data.UseCase as USE_CASES);
-        setQueryType(
-          demoQueryOptions.find((option) => option.value === data.UseCase)
-            ?.label || "",
-        );
+        // setQueryType(
+        //     demoQueryOptions.find((option) => option.value === data.UseCase)
+        //         ?.label || "",
+        // );
         setAutofilled(highlightAutofilled);
       }
     },
     [patientOption, setUseCase, setQueryType],
   );
 
-  // // Fills fields if patientOption changes (auto-fill)
+  // Fills fields if patientOption changes (auto-fill)
   useEffect(() => {
     if (!patientOption || userJourney !== "demo") {
       return;
     }
-    // fillFields(patientOption as PatientType);
+    fillFields(patientOption as PatientType);
   }, [fillFields, patientOption, userJourney]);
 
-  // Change the selectedDemoOption (the option selected once you are past the modal) and set the patientOption to the first patientOption for the selectedDemoOption
+  // Change the selectedDemoOption in the dropdown and update the
+  // query type (which governs the DB fetch) accordingly
   const handleDemoQueryChange = (selectedDemoOption: string) => {
-    console.log("handling demoQuery Change");
-    // const useCaseDescriptor = patientOptions[selectedDemoOption][0];
-    // console.log(useCaseDescriptor);
     setPatientOption(patientOptions[selectedDemoOption][0].value);
     setQueryType(
       demoQueryOptions.find((dqo) => dqo.value == selectedDemoOption)?.label ||
@@ -139,8 +135,6 @@ const SearchForm: React.FC<SearchFormProps> = ({
     };
     setOriginalRequest(originalRequest);
     const queryResponse = await UseCaseQuery(originalRequest);
-    console.log("calling query response via UseCaseQuery");
-    console.log(queryResponse);
     setUseCaseQueryResponse(queryResponse);
     if (!queryResponse.Patient || queryResponse.Patient.length === 0) {
       setMode("no-patients");

--- a/containers/tefca-viewer/src/app/query/components/SearchForm.tsx
+++ b/containers/tefca-viewer/src/app/query/components/SearchForm.tsx
@@ -54,7 +54,7 @@ const SearchForm: React.FC<SearchFormProps> = ({
   userJourney,
 }) => {
   // Get the demoOption (initial selection) selected from modal via the URL
-  const [useCase, setUseCase] = useState<USE_CASES>("cancer");
+  const [useCase, setUseCase] = useState<USE_CASES>("" as USE_CASES);
 
   //Set the patient options based on the demoOption
   const [patientOption, setPatientOption] = useState<string>(
@@ -68,6 +68,8 @@ const SearchForm: React.FC<SearchFormProps> = ({
   const [mrn, setMRN] = useState<string>("");
 
   const [autofilled, setAutofilled] = useState(false); // boolean indicating if the form was autofilled, changes color if true
+
+  console.log("Search form component");
 
   // Fills fields with sample data based on the selected patientOption
   const fillFields = useCallback(
@@ -101,7 +103,9 @@ const SearchForm: React.FC<SearchFormProps> = ({
 
   // Change the selectedDemoOption (the option selected once you are past the modal) and set the patientOption to the first patientOption for the selectedDemoOption
   const handleDemoQueryChange = (selectedDemoOption: string) => {
-    setPatientOption(patientOptions[selectedDemoOption][0].value);
+    const useCaseDescriptor = patientOptions[selectedDemoOption][0];
+    setPatientOption(useCaseDescriptor.value);
+    setQueryType(useCaseDescriptor.label);
   };
 
   const handleClick = () => {
@@ -127,6 +131,7 @@ const SearchForm: React.FC<SearchFormProps> = ({
     };
     setOriginalRequest(originalRequest);
     const queryResponse = await UseCaseQuery(originalRequest);
+    console.log(queryResponse);
     setUseCaseQueryResponse(queryResponse);
     if (!queryResponse.Patient || queryResponse.Patient.length === 0) {
       setMode("no-patients");
@@ -140,6 +145,7 @@ const SearchForm: React.FC<SearchFormProps> = ({
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
+
   return (
     <>
       <Alert type="info" headingLevel="h4" slim className="custom-alert">

--- a/containers/tefca-viewer/src/app/query/components/SearchForm.tsx
+++ b/containers/tefca-viewer/src/app/query/components/SearchForm.tsx
@@ -27,6 +27,8 @@ import {
 import { FormatPhoneAsDigits } from "@/app/format-service";
 
 interface SearchFormProps {
+  useCase: USE_CASES;
+  setUseCase: (useCase: USE_CASES) => void;
   setOriginalRequest: (originalRequest: UseCaseQueryRequest) => void;
   setUseCaseQueryResponse: (UseCaseQueryResponse: UseCaseQueryResponse) => void;
   setMode: (mode: Mode) => void;
@@ -37,6 +39,8 @@ interface SearchFormProps {
 
 /**
  * @param root0 - SearchFormProps
+ * @param root0.useCase - The use case this query will cover.
+ * @param root0.setUseCase - Update stateful use case.
  * @param root0.setOriginalRequest - The function to set the original request.
  * @param root0.setUseCaseQueryResponse - The function to set the use case query response.
  * @param root0.setMode - The function to set the mode.
@@ -46,6 +50,8 @@ interface SearchFormProps {
  * @returns - The SearchForm component.
  */
 const SearchForm: React.FC<SearchFormProps> = ({
+  useCase,
+  setUseCase,
   setOriginalRequest,
   setUseCaseQueryResponse,
   setMode,
@@ -53,9 +59,6 @@ const SearchForm: React.FC<SearchFormProps> = ({
   setQueryType,
   userJourney,
 }) => {
-  // Get the demoOption (initial selection) selected from modal via the URL
-  const [useCase, setUseCase] = useState<USE_CASES>("" as USE_CASES);
-
   //Set the patient options based on the demoOption
   const [patientOption, setPatientOption] = useState<string>(
     patientOptions[useCase]?.[0]?.value || "",
@@ -69,7 +72,7 @@ const SearchForm: React.FC<SearchFormProps> = ({
 
   const [autofilled, setAutofilled] = useState(false); // boolean indicating if the form was autofilled, changes color if true
 
-  console.log("Search form component");
+  console.log("use case: " + useCase);
 
   // Fills fields with sample data based on the selected patientOption
   const fillFields = useCallback(
@@ -93,19 +96,24 @@ const SearchForm: React.FC<SearchFormProps> = ({
     [patientOption, setUseCase, setQueryType],
   );
 
-  // Fills fields if patientOption changes (auto-fill)
+  // // Fills fields if patientOption changes (auto-fill)
   useEffect(() => {
     if (!patientOption || userJourney !== "demo") {
       return;
     }
-    fillFields(patientOption as PatientType);
+    // fillFields(patientOption as PatientType);
   }, [fillFields, patientOption, userJourney]);
 
   // Change the selectedDemoOption (the option selected once you are past the modal) and set the patientOption to the first patientOption for the selectedDemoOption
   const handleDemoQueryChange = (selectedDemoOption: string) => {
-    const useCaseDescriptor = patientOptions[selectedDemoOption][0];
-    setPatientOption(useCaseDescriptor.value);
-    setQueryType(useCaseDescriptor.label);
+    console.log("handling demoQuery Change");
+    // const useCaseDescriptor = patientOptions[selectedDemoOption][0];
+    // console.log(useCaseDescriptor);
+    setPatientOption(patientOptions[selectedDemoOption][0].value);
+    setQueryType(
+      demoQueryOptions.find((dqo) => dqo.value == selectedDemoOption)?.label ||
+        "",
+    );
   };
 
   const handleClick = () => {
@@ -131,6 +139,7 @@ const SearchForm: React.FC<SearchFormProps> = ({
     };
     setOriginalRequest(originalRequest);
     const queryResponse = await UseCaseQuery(originalRequest);
+    console.log("calling query response via UseCaseQuery");
     console.log(queryResponse);
     setUseCaseQueryResponse(queryResponse);
     if (!queryResponse.Patient || queryResponse.Patient.length === 0) {
@@ -265,12 +274,17 @@ const SearchForm: React.FC<SearchFormProps> = ({
                 id="query"
                 name="query"
                 className="usa-select margin-top-1"
+                defaultValue={""}
                 value={useCase}
                 onChange={(event) => {
                   handleDemoQueryChange(event.target.value);
                   setUseCase(event.target.value as USE_CASES);
                 }}
               >
+                <option value="" disabled>
+                  {" "}
+                  -- Select An Option --{" "}
+                </option>
                 {demoQueryOptions.map((option) => (
                   <option key={option.value} value={option.value}>
                     {option.label}

--- a/containers/tefca-viewer/src/app/query/page.tsx
+++ b/containers/tefca-viewer/src/app/query/page.tsx
@@ -5,7 +5,12 @@ import ResultsView from "./components/ResultsView";
 import MultiplePatientSearchResults from "./components/MultiplePatientSearchResults";
 import SearchForm from "./components/SearchForm";
 import NoPatientsFound from "./components/NoPatientsFound";
-import { Mode, QueryTypeToQueryName, ValueSetItem } from "../constants";
+import {
+  Mode,
+  QueryTypeToQueryName,
+  USE_CASES,
+  ValueSetItem,
+} from "../constants";
 import CustomizeQuery from "./components/CustomizeQuery";
 import LoadingView from "./components/LoadingView";
 import { ToastContainer } from "react-toastify";
@@ -22,9 +27,8 @@ import {
  * @returns - The Query component.
  */
 const Query: React.FC = () => {
-  const [queryType, setQueryType] = useState<string>(
-    "Cancer case investigation",
-  );
+  const [useCase, setUseCase] = useState<USE_CASES>("" as USE_CASES);
+  const [queryType, setQueryType] = useState<string>("");
   const [queryValuesets, setQueryValuesets] = useState<ValueSetItem[]>(
     [] as ValueSetItem[],
   );
@@ -34,7 +38,8 @@ const Query: React.FC = () => {
     useState<UseCaseQueryResponse>({});
   const [originalRequest, setOriginalRequest] = useState<UseCaseQueryRequest>();
 
-  console.log("on query page");
+  console.log(queryType);
+  console.log(queryValuesets);
 
   useEffect(() => {
     // Gate whether we actually update state after fetching so we
@@ -42,14 +47,17 @@ const Query: React.FC = () => {
     let isSubscribed = true;
 
     const queryName = QueryTypeToQueryName[queryType];
+    console.log("query name: " + queryName);
     const fetchQuery = async () => {
+      console.log("fetching via useEffect");
       const queryResults = await getSavedQueryByName(queryName);
       const vsItems = await mapQueryRowsToValueSetItems(queryResults);
 
       // Only update if the fetch hasn't altered state yet
       if (isSubscribed) {
-        setQueryValuesets(vsItems);
+        console.log("updating queryValuesets");
         console.log(vsItems);
+        setQueryValuesets(vsItems);
       }
     };
 
@@ -66,6 +74,8 @@ const Query: React.FC = () => {
       {mode === "search" && (
         <Suspense fallback="...Loading">
           <SearchForm
+            useCase={useCase}
+            setUseCase={setUseCase}
             setMode={setMode}
             setLoading={setLoading}
             setUseCaseQueryResponse={setUseCaseQueryResponse}

--- a/containers/tefca-viewer/src/app/query/page.tsx
+++ b/containers/tefca-viewer/src/app/query/page.tsx
@@ -38,25 +38,18 @@ const Query: React.FC = () => {
     useState<UseCaseQueryResponse>({});
   const [originalRequest, setOriginalRequest] = useState<UseCaseQueryRequest>();
 
-  console.log(queryType);
-  console.log(queryValuesets);
-
   useEffect(() => {
     // Gate whether we actually update state after fetching so we
     // avoid name-change race conditions
     let isSubscribed = true;
 
     const queryName = QueryTypeToQueryName[queryType];
-    console.log("query name: " + queryName);
     const fetchQuery = async () => {
-      console.log("fetching via useEffect");
       const queryResults = await getSavedQueryByName(queryName);
       const vsItems = await mapQueryRowsToValueSetItems(queryResults);
 
       // Only update if the fetch hasn't altered state yet
       if (isSubscribed) {
-        console.log("updating queryValuesets");
-        console.log(vsItems);
         setQueryValuesets(vsItems);
       }
     };

--- a/containers/tefca-viewer/src/app/query/test/page.tsx
+++ b/containers/tefca-viewer/src/app/query/test/page.tsx
@@ -8,7 +8,7 @@ import ResultsView from "../components/ResultsView";
 import MultiplePatientSearchResults from "../components/MultiplePatientSearchResults";
 import SearchForm from "../components/SearchForm";
 import NoPatientsFound from "../components/NoPatientsFound";
-import { Mode } from "../../constants";
+import { Mode, USE_CASES } from "../../constants";
 
 /**
  * Parent component for the query page. Based on the mode, it will display the search
@@ -16,6 +16,7 @@ import { Mode } from "../../constants";
  * @returns - The Query component.
  */
 const Query: React.FC = () => {
+  const [useCase, setUseCase] = useState<USE_CASES>("" as USE_CASES);
   const [mode, setMode] = useState<Mode>("search");
   const [loading, setLoading] = useState<boolean>(false);
   const [useCaseQueryResponse, setUseCaseQueryResponse] =
@@ -27,6 +28,8 @@ const Query: React.FC = () => {
       {mode === "search" && (
         <Suspense fallback="...Loading">
           <SearchForm
+            useCase={useCase}
+            setUseCase={setUseCase}
             setMode={setMode}
             setLoading={setLoading}
             setUseCaseQueryResponse={setUseCaseQueryResponse}


### PR DESCRIPTION
# Persist valueset changes in state

## Summary
This PR implements all of the work up to the point of executing a custom query. When the user presses apply on the `CustomizeQuery` page/component, inclusions/exclusions they've made to particular value sets are saved into the overall state structure maintained by the `page` workflow. Further, this PR moves some of the lower level state into the top level page component to stop re-renders when moving between modes (like search, customize, etc.). Finally, this PR implements a formatting function that transforms the statefully held collection of value set items into a `querySpec` that can eventually be used to execute a custom query.

## Related Issue
Fixes #2512 