### PR TITLE
Update design review script to run seed data FHIR conversion

### DIFF
--- a/containers/ecr-viewer/design-review/README.MD
+++ b/containers/ecr-viewer/design-review/README.MD
@@ -20,12 +20,16 @@ Follow these steps to run script and spin up a local instance of the eCR Viewer.
 
 1. Ensure you have completed the initial setup instructions.
 2. Open the Terminal application.
-3. Copy and paste `./design-review.sh <MY-BRANCH> <IS_NON_INTEGRATED>` into the Terminal prompt.
+3. Copy and paste `./design-review.sh <MY-BRANCH> <IS_NON_INTEGRATED> <CONVERT_SEED_DATA>` into the Terminal prompt.
 4. Replace `<MY-BRANCH>` with the name of the GitHub branch you would like to conduct a review on. 
     - For example, `./design-review.sh main` will spin up an instance of the eCR Viewer based on the current state of the `main` branch of repository.
 5. Replace `<IS_NON_INTEGRATED>` with either `true` or `false`. 
-    - Setting it to `true` will show the non-integrated version of the eCR Viewer, while setting it to `false` will show the integrated version. 
+    - Setting it to `true` will show the non-integrated version of the eCR Viewer, while setting it to `false` will show the integrated version. Default value is `true`.
     - If any other text is used for this second argument, an error message will be displayed: `Invalid value for IS_NON_INTEGRATED. It must be 'true' or 'false'`.
-6. Press enter. The script will now ensure that all required dependencies are installed on your machine, build and run the eCR Viewer, and finally navigate to the landing page in your system's default browser. Please note that because certain dependencies may need to be installed the script make take a few minutes the first time it is run on a machine. Additionally, depending on what needs to be installed you may be prompted at points during installation of dependencies to provide a password or click through some installation screens.
+6. Replace `<CONVERT_SEED_DATA>` with either `true` or `false`. 
+    - `true`: Runs the FHIR conversion process on the available seed data. Use this option when new sample eCRs have been added to the repository. Without running the converter, the new eCRs will not be viewable in the eCR Viewer.
+    - `false` (default): Skips the FHIR conversion step, which can save time. Use this option when no new seed data has been added.
+    - If any other text is used for this second argument, an error message will be displayed: `Invalid value for CONVERT_SEED_DATA. It must be 'true' or 'false'`.
+7. Press enter. The script will now ensure that all required dependencies are installed on your machine, build and run the eCR Viewer, and finally navigate to the landing page in your system's default browser. Please note that because certain dependencies may need to be installed the script make take a few minutes the first time it is run on a machine. Additionally, depending on what needs to be installed you may be prompted at points during installation of dependencies to provide a password or click through some installation screens.
     - Note: If the landing page of the eCR Viewer displays `Something went wrong!`, try reloading the page to resolve the error.
 7. When you are done with your review to shut the eCR Viewer down return to Terminal and press enter.

--- a/containers/ecr-viewer/design-review/design-review.sh
+++ b/containers/ecr-viewer/design-review/design-review.sh
@@ -99,14 +99,14 @@ fi
 docker compose --env-file .env.local up -d ecr-viewer db --build
 
 # Wait for eCR Viewer to be available
-URL="http://localhost:3000/"
+URL="http://localhost:3000/ecr-viewer"
 while ! curl -s -o /dev/null -w "%{http_code}" "$URL" | grep -q "200"; do
     echo "Waiting for $URL to be available..."
     sleep 5
 done
 
 # Open in default browser
-open http://localhost:3000/
+open http://localhost:3000/ecr-viewer
 
 # Prompt to end review session
 read -p "Press enter to end review"

--- a/containers/ecr-viewer/design-review/design-review.sh
+++ b/containers/ecr-viewer/design-review/design-review.sh
@@ -20,6 +20,18 @@ else
     IS_NON_INTEGRATED=true
 fi
 
+# Check if the value indicating whether to convert the seed data is provided/valid
+if [ -n "$3" ]; then
+    if [[ "$3" == "true" || "$3" == "false" ]]; then
+        CONVERT_SEED_DATA=$3
+    else
+        echo "Invalid value for CONVERT_SEED_DATA. It must be 'true' or 'false'."
+        exit 1
+    fi
+else
+    CONVERT_SEED_DATA=false
+fi
+
 # Function to check if a command exists
 command_exists() {
     command -v "$1" &> /dev/null
@@ -72,6 +84,16 @@ git checkout $BRANCH_NAME
 echo "APP_ENV=test" > .env.local
 echo "DATABASE_URL=postgres://postgres:pw@db:5432/ecr_viewer_db" >> .env.local
 echo "NEXT_PUBLIC_NON_INTEGRATED_VIEWER=$IS_NON_INTEGRATED" >> .env.local
+
+# Run FHIR conversion on seed data
+if [ "$CONVERT_SEED_DATA" = true ]; then
+  echo "Running seed data FHIR conversion..."
+  
+  docker compose -f ./seed-scripts/docker-compose.yml up --abort-on-container-exit
+  docker compose down -v
+else
+  echo "Skipping seed data FHIR conversion..."
+fi
 
 # Build and run docker compose
 docker compose --env-file .env.local up -d ecr-viewer db --build


### PR DESCRIPTION
# PULL REQUEST

## Summary
Add command line arg to design-review script that will run the FHIR converter on the seed data when set to `true`. Default is `false`.

## Related Issue
Fixes #2581 

## Acceptance Criteria
- [ ] The design review script has been updated to accept a command line argument for seed data conversion.
- [ ] If the parameter is set to `true`, the script will run the seed data through the FHIR conversion process.
- [ ] If the parameter is `false` or is not set, the script will skip the FHIR conversion step.
- [ ] The README documentation has been updated to explain the new parameter and how to use it.

## Testing Steps

- [ ] 1. Pull down this branch, and `cd` into `ecr-viewer`
- [ ] 2. Run `design-review/design-review.sh <BRANCH> <IS_NON_INTEGRATED> <CONVERT_SEED_DATA>` -- testing `true`, `false`, and no arg for <CONVERT_SEED_DATA>

[//]: # (PR title: Remember to name your PR descriptively!)
