### PR TITLE
check for empty string in device2 fhir converter

### DIFF
--- a/containers/fhir-converter/Templates/eCR/Entry/Result/_entry_organizer_component.liquid
+++ b/containers/fhir-converter/Templates/eCR/Entry/Result/_entry_organizer_component.liquid
@@ -9,7 +9,7 @@
 
       {% assign labDeviceNameReference = component.observation.text.reference.value | replace: '#', '' | append: 'TestMethodName1'-%}
       {% assign labDeviceName = text | find_object_by_id: labDeviceNameReference | to_html_string -%}
-      {% if labDeviceName != null %}
+      {% if labDeviceName != null and labDeviceName != "" %}
         {% assign deviceId = labDeviceName | generate_uuid %}
         {% assign fullDeviceId = deviceId | prepend: 'Device/' %}
         {% include 'Resource/Device2', ID: deviceId, deviceName: labDeviceName -%}


### PR DESCRIPTION
# PULL REQUEST

## Summary
- Some Devices are being generated as empty in the FHIR bundle.

## Additional Information
Before:
![image](https://github.com/user-attachments/assets/ae8535a6-df9f-4578-9a68-ea057808bf7f)

After:
![image](https://github.com/user-attachments/assets/a9c5b47e-5183-4bf5-83cc-cae1d5921422)

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
