### PR TITLE
Moving TEFCA DB vars to docker compose

### DIFF
--- a/containers/tefca-viewer/docker-compose-dev.yaml
+++ b/containers/tefca-viewer/docker-compose-dev.yaml
@@ -9,7 +9,7 @@ services:
       - POSTGRES_PASSWORD=pw
       - POSTGRES_DB=tefca_db
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 2s
       timeout: 5s
       retries: 20

--- a/containers/tefca-viewer/docker-compose-dev.yaml
+++ b/containers/tefca-viewer/docker-compose-dev.yaml
@@ -4,8 +4,10 @@ services:
     image: "postgres:alpine"
     ports:
       - "5432:5432"
-    env_file:
-      - "./tefca.env"
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=pw
+      - POSTGRES_DB=tefca_db
     healthcheck:
       test: ["CMD-SHELL", "pg_isready"]
       interval: 2s

--- a/containers/tefca-viewer/docker-compose.yaml
+++ b/containers/tefca-viewer/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
       - POSTGRES_PASSWORD=pw
       - POSTGRES_DB=tefca_db
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 2s
       timeout: 5s
       retries: 20

--- a/containers/tefca-viewer/docker-compose.yaml
+++ b/containers/tefca-viewer/docker-compose.yaml
@@ -4,8 +4,10 @@ services:
     image: "postgres:alpine"
     ports:
       - "5432:5432"
-    env_file:
-      - "./tefca.env"
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=pw
+      - POSTGRES_DB=tefca_db
     healthcheck:
       test: ["CMD-SHELL", "pg_isready"]
       interval: 2s
@@ -31,10 +33,9 @@ services:
       dockerfile: ./containers/tefca-viewer/Dockerfile
     ports:
       - "3000:3000"
-    env_file:
-      - "./tefca.env"
     environment:
       - NODE_ENV=production
+      - DATABASE_URL=postgres://postgres:pw@db:5432/tefca_db
     depends_on:
       db:
         condition: service_healthy

--- a/containers/tefca-viewer/e2e/query_workflow.spec.ts
+++ b/containers/tefca-viewer/e2e/query_workflow.spec.ts
@@ -270,7 +270,7 @@ test.describe("Test the user journey of a 'tester'", () => {
     );
 
     // Check that there are multiple rows in the table
-    await expect(page.locator("tbody").locator("tr")).toHaveCount(9);
+    await expect(page.locator("tbody").locator("tr")).toHaveCount(10);
 
     // Click on the first patient's "View Record" button
     await page.locator(':nth-match(:text("View Record"), 1)').click();

--- a/containers/tefca-viewer/src/app/database-service.ts
+++ b/containers/tefca-viewer/src/app/database-service.ts
@@ -1,6 +1,6 @@
 "use server";
 import { Pool, PoolConfig, QueryResultRow } from "pg";
-import dotenv from "dotenv";
+// import dotenv from "dotenv";
 import { ValueSetItem, valueSetTypeToClincalServiceTypeMap } from "./constants";
 
 const getQuerybyNameSQL = `
@@ -14,7 +14,7 @@ select q.query_name, q.id, qtv.valueset_id, vs.name as valueset_name, vs.author 
 `;
 
 // Load environment variables from tefca.env and establish a Pool configuration
-dotenv.config({ path: "tefca.env" });
+// dotenv.config({ path: "tefca.env" });
 const dbConfig: PoolConfig = {
   connectionString: process.env.DATABASE_URL,
   max: 10, // Maximum # of connections in the pool

--- a/containers/tefca-viewer/tefca.env
+++ b/containers/tefca-viewer/tefca.env
@@ -1,7 +1,0 @@
-POSTGRES_USER=postgres
-PGUSER=postgres
-POSTGRES_PASSWORD=pw
-POSTGRES_DB=tefca_db
-DATABASE_URL=postgres://postgres:pw@db:5432/tefca_db
-POSTGRES_PORT=5432
-POSTGRES_HOST=localhost


### PR DESCRIPTION
# PULL REQUEST

## Summary
Deprecates `tefca.env` in favor of moving environment variables to docker-compose steps

## Related Issue
Fixes issue related to deployment

## Acceptance Criteria
Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information
Seems to work locally without issue. I tried a few times from a clean cache to confirm, but I think next steps would be to:
1. merge this
2. cut a new release
3. update dibbs.cloud

Are there any other steps we need?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
