### PR TITLE
configure local prettier to align with CI config

### DIFF
--- a/containers/tefca-viewer/.prettierrc
+++ b/containers/tefca-viewer/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "trailingComma": "all"
+}

--- a/containers/tefca-viewer/package.json
+++ b/containers/tefca-viewer/package.json
@@ -73,7 +73,7 @@
     "jest-extended": "^4.0.2",
     "mocha": "^10.2.0",
     "postcss": "^8",
-    "prettier": "3.1.1",
+    "prettier": "4.0.0-alpha.8",
     "sass": "^1.69.5",
     "supertest": "^7.0.0",
     "tailwindcss": "^3.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -941,7 +941,7 @@
         "jest-extended": "^4.0.2",
         "mocha": "^10.2.0",
         "postcss": "^8",
-        "prettier": "3.1.1",
+        "prettier": "4.0.0-alpha.8",
         "sass": "^1.69.5",
         "supertest": "^7.0.0",
         "tailwindcss": "^3.3.0",
@@ -1229,6 +1229,72 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "containers/tefca-viewer/node_modules/prettier": {
+      "version": "4.0.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-4.0.0-alpha.8.tgz",
+      "integrity": "sha512-7FFBkQb0Eg0wJRYzA7ucc31nqTjWgoSpmS0ey9OATHU6WiV0z53Uzo5hA3tZs/pbhhIG7YvOIBNmkRQ7Dr/k5A==",
+      "dev": true,
+      "dependencies": {
+        "@prettier/cli": "^0.3.0"
+      },
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "containers/tefca-viewer/node_modules/prettier/node_modules/@prettier/cli": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@prettier/cli/-/cli-0.3.0.tgz",
+      "integrity": "sha512-8qq527QT5n8paE9eoHeulmGw7a3MroVk5+8ITf+xoWJn1gcVaZiOP6vb9OlwZv49hhdRZ1WX+0MyisSSXL/4fA==",
+      "dev": true,
+      "dependencies": {
+        "@iarna/toml": "^2.2.5",
+        "atomically": "^2.0.2",
+        "fast-ignore": "^1.1.1",
+        "find-up-json": "^2.0.2",
+        "import-meta-resolve": "^4.0.0",
+        "is-binary-path": "^2.1.0",
+        "js-yaml": "^4.1.0",
+        "json-sorted-stringify": "^1.0.0",
+        "json5": "^2.2.3",
+        "kasi": "^1.1.0",
+        "pioppo": "^1.1.0",
+        "specialist": "^1.4.0",
+        "tiny-editorconfig": "^1.0.0",
+        "tiny-jsonc": "^1.0.1",
+        "tiny-readdir-glob": "^1.2.1",
+        "tiny-spinner": "^2.0.3",
+        "worktank": "^2.6.0",
+        "zeptomatch": "^1.2.2"
+      },
+      "bin": {
+        "prettier-next": "dist/bin.js"
+      },
+      "peerDependencies": {
+        "prettier": "^3.1.0 || ^4.0.0"
+      }
+    },
+    "containers/tefca-viewer/node_modules/prettier/node_modules/prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3173,6 +3239,12 @@
       "version": "2.0.3",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+      "dev": true
     },
     "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.33.5",
@@ -6378,6 +6450,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ansi-purge": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-purge/-/ansi-purge-1.0.0.tgz",
+      "integrity": "sha512-kbm4dtp1jcI8ZWhttEPzmga9fwbhGMinIDghOcBng5q9dOsnM6PYV3ih+5TO4D7inGXU9zBmVi7x1Z4dluY85Q==",
+      "dev": true
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "license": "MIT",
@@ -6396,6 +6474,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ansi-truncate": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ansi-truncate/-/ansi-truncate-1.1.2.tgz",
+      "integrity": "sha512-yhyu5Y/rRWku5GJfCCHHKyJsWahCRuy/ORI8wmClls+bUWMVpcVL6nEqmVnZZ9gaaWq+AWB6FCyarrt0ewVUXQ==",
+      "dev": true,
+      "dependencies": {
+        "fast-string-truncated-width": "^1.1.0"
       }
     },
     "node_modules/antlr4": {
@@ -6785,6 +6872,16 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/atomically": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.0.3.tgz",
+      "integrity": "sha512-kU6FmrwZ3Lx7/7y3hPS5QnbJfaohcIul5fGqf7ok+4KklIEk9tJ0C2IQPdacSbVUWv6zVHXEBWoWd6NrVMT7Cw==",
+      "dev": true,
+      "dependencies": {
+        "stubborn-fs": "^1.2.5",
+        "when-exit": "^2.1.1"
       }
     },
     "node_modules/autoprefixer": {
@@ -8214,6 +8311,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/dettle": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dettle/-/dettle-1.0.4.tgz",
+      "integrity": "sha512-ktaWiLYYc/ajSa819+HxwABpqtk3dGIAmo5CbHvT3B6XyQSM7VNGDvCPNu94Ptc+Ti4tjTvAKRUCXU/lrVG4WQ==",
+      "dev": true
+    },
     "node_modules/dezalgo": {
       "version": "1.0.4",
       "dev": true,
@@ -9480,6 +9583,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fast-ignore": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-ignore/-/fast-ignore-1.1.3.tgz",
+      "integrity": "sha512-xTo4UbrOKfEQgOFlPaqFScodTV/Wf3KATEqCZZSMh6OP4bcez0lTsqww3n3/Fve1q9u0jmfDP0q0nOhH4POZEg==",
+      "dev": true,
+      "dependencies": {
+        "grammex": "^3.1.2",
+        "string-escape-regex": "^1.0.0"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "dev": true,
@@ -9494,6 +9607,21 @@
       "version": "2.1.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-string-truncated-width": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-1.1.0.tgz",
+      "integrity": "sha512-FfsFREOllHpnSl6cxpLi6wvqd9UebrZPxWlOJCCcWoOJzy02xyjPbafF9tyg2Usnf3GLmRr5Q6s7n+GO+6VB5A==",
+      "dev": true
+    },
+    "node_modules/fast-string-width": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-1.0.5.tgz",
+      "integrity": "sha512-rO3M39p2w0AaF81drD42Q+v77cyhUKWixavoTAsORzYtjMIHhZ33KgdsjEaxMBwI0zI0zLUNBL0CYqVMipXp4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-string-truncated-width": "^1.0.4"
+      }
     },
     "node_modules/fast-xml-parser": {
       "version": "4.4.1",
@@ -9670,6 +9798,21 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/find-up-json": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/find-up-json/-/find-up-json-2.0.4.tgz",
+      "integrity": "sha512-ABaCm3V1H5UYRHtClHvFFyxPIAC/bxd43tKwmcSco8/EuM5O7zDL2R7ORaA+rEltwgxoNOIK8LQFwQUfA/2GIw==",
+      "dev": true,
+      "dependencies": {
+        "find-up-path": "^1.0.0"
+      }
+    },
+    "node_modules/find-up-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/find-up-path/-/find-up-path-1.0.0.tgz",
+      "integrity": "sha512-cjXDXnYfEezIqqbzctBNNqUax/rRCyNo/VTCFId3Hp9FyVL4uk0PvWrs7Xibtl2E4P5HnWnlxxJsbHqK6DsDPw==",
+      "dev": true
     },
     "node_modules/flat": {
       "version": "5.0.2",
@@ -9918,6 +10061,15 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-current-package": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-current-package/-/get-current-package-1.0.0.tgz",
+      "integrity": "sha512-mEZ43mmPMdRz+7vouBd/fhnEMRF0omBzcwwwf2GmbWSeZJGdWHRp9RGLZxW7ZnnZ14jPc3GreHh0s/7u7PZJpQ==",
+      "dev": true,
+      "dependencies": {
+        "find-up-json": "^2.0.1"
+      }
+    },
     "node_modules/get-func-name": {
       "version": "2.0.2",
       "dev": true,
@@ -10132,6 +10284,12 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "license": "ISC"
+    },
+    "node_modules/grammex": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/grammex/-/grammex-3.1.3.tgz",
+      "integrity": "sha512-rUZoJJQguOCaAMTuoyxs40OxqSLgVhzCCwDn1mbp2vETWutv/TmgAz7KxMR8Tz4z4cty/zIh88HrOWKqWgeGjg==",
+      "dev": true
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -10457,6 +10615,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
+      "integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "dev": true,
@@ -10495,6 +10663,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/ini-simple-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ini-simple-parser/-/ini-simple-parser-1.0.0.tgz",
+      "integrity": "sha512-cZUGzkBd1W8FoIbFNMbscMvIGwp+riO/4PaPAy2owQp0sja+ni6Yty11GBNnxaI1ePkSVXzPb8iMOOYuYw/MOQ==",
+      "dev": true
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.3",
       "license": "MIT"
@@ -10511,6 +10685,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/ionstore": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ionstore/-/ionstore-1.0.0.tgz",
+      "integrity": "sha512-ikEvmeZFh9u5SkjKbFqJlmmhaQTulB3P7QoSoZ/xL8EDP5uj5QWbPeKcQ8ZJtszBLHRRnhIJJE8P1dhFx/oCMw==",
+      "dev": true
     },
     "node_modules/is-arguments": {
       "version": "1.1.1",
@@ -12309,6 +12489,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-sorted-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-sorted-stringify/-/json-sorted-stringify-1.0.0.tgz",
+      "integrity": "sha512-r27DgPdI80AXd6Hm0zJ7nPCYTBFUersR7sn7xcYyafvcgYOvwmCXB+DKWazAe0YaCNHbxH5Qzt7AIhUzPD1ETg==",
+      "dev": true
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "dev": true,
@@ -12371,6 +12557,12 @@
       "version": "6.2.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/kasi": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/kasi/-/kasi-1.1.0.tgz",
+      "integrity": "sha512-SvmC8+vhkDariSTz2182qyQ+mhwZ4W8TWaIHJcz358bYBeccQ8WBYj7uTtzHoCmpPHaoCm3PaOhzRg7Z8F4Lww==",
+      "dev": true
     },
     "node_modules/keyboardevent-key-polyfill": {
       "version": "1.1.0",
@@ -13794,6 +13986,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/pioppo": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pioppo/-/pioppo-1.2.0.tgz",
+      "integrity": "sha512-Mze+UGMj6fGMq7KQQTtiTDQN1RrfXeQwUssaKRgzp3HLx8SS5B9cTFIqQLkr2t6cIWpefGTpwiOLN8Y+3IODBg==",
+      "dev": true,
+      "dependencies": {
+        "dettle": "^1.0.1",
+        "when-exit": "^2.1.1"
+      }
+    },
     "node_modules/pirates": {
       "version": "4.0.6",
       "dev": true,
@@ -14180,6 +14382,21 @@
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "license": "MIT"
+    },
+    "node_modules/promise-make-counter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-make-counter/-/promise-make-counter-1.0.1.tgz",
+      "integrity": "sha512-R1JGFIgSJDpNV/JXxytAx6K79noEpcBiZXWDa3ic9WEMpBZbUdVVQjlA266SCicJ9CGqd70iGbbzbjRKbGU1Jg==",
+      "dev": true,
+      "dependencies": {
+        "promise-make-naked": "^3.0.0"
+      }
+    },
+    "node_modules/promise-make-naked": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/promise-make-naked/-/promise-make-naked-3.0.0.tgz",
+      "integrity": "sha512-h71wwAMB2udFnlPmcxQMqKl6CckNLVKdk/ROtFivE6/VmW+rQKV0DWlGJ6VphRIoq22Tkonvdi3F+jlm5XDlow==",
+      "dev": true
     },
     "node_modules/promise-polyfill": {
       "version": "8.3.0",
@@ -15068,6 +15285,18 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/specialist": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/specialist/-/specialist-1.4.3.tgz",
+      "integrity": "sha512-ztiZ0Bug/psCCsIg3OW6d/GbeWs8z/qaVbnr6bz1MJAhDqh8bIDQobWQ16Fz8foXbBhAjIWanlXe6gLkMM/ClA==",
+      "dev": true,
+      "dependencies": {
+        "tiny-bin": "^1.10.2",
+        "tiny-colors": "^2.2.1",
+        "tiny-parse-argv": "^2.8.0",
+        "tiny-updater": "^3.5.2"
+      }
+    },
     "node_modules/spex": {
       "version": "3.3.0",
       "license": "MIT",
@@ -15169,6 +15398,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/stdin-blocker": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stdin-blocker/-/stdin-blocker-2.0.0.tgz",
+      "integrity": "sha512-fZ3txWyDSxOll6+ajX9akA5YzchyoEpVNsH8eWNY/ZnzlRoM0eW/zF8bm852KVpYutjNFQFvEF/RdZtlqxIZkQ==",
+      "dev": true
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.0.0",
       "dev": true,
@@ -15219,6 +15454,12 @@
     "node_modules/string_decoder/node_modules/safe-buffer": {
       "version": "5.1.2",
       "license": "MIT"
+    },
+    "node_modules/string-escape-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string-escape-regex/-/string-escape-regex-1.0.0.tgz",
+      "integrity": "sha512-41Uu0J545cU6Fe1str6GZKI8hf38nsJPfjkePF4npjhACIHSrrVFKMPYSe8hT0FAxIuss36wGuEM5syChVs/pQ==",
+      "dev": true
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -15414,6 +15655,12 @@
     "node_modules/strnum": {
       "version": "1.0.5",
       "license": "MIT"
+    },
+    "node_modules/stubborn-fs": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-1.2.5.tgz",
+      "integrity": "sha512-H2N9c26eXjzL/S/K+i/RHHcFanE74dptvvjM8iwzwbVcWY/zjBbgRqF3K0DY4+OD+uTTASTBvDoxPDaPN02D7g==",
+      "dev": true
     },
     "node_modules/style-to-js": {
       "version": "1.1.12",
@@ -15792,6 +16039,118 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
+    },
+    "node_modules/tiny-bin": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/tiny-bin/-/tiny-bin-1.10.2.tgz",
+      "integrity": "sha512-zsxzzGBJowuhDQ/QUTqCYNxBEurjILd3o6m0Wawxzfn64+XYo81hD8dv7u5pWg3fWn5Y1cn5PmltlqIvWzIysQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-purge": "^1.0.0",
+        "fast-string-width": "^1.0.5",
+        "get-current-package": "^1.0.0",
+        "tiny-colors": "^2.2.0",
+        "tiny-levenshtein": "^1.0.0",
+        "tiny-parse-argv": "^2.8.0",
+        "tiny-updater": "^3.5.2"
+      }
+    },
+    "node_modules/tiny-colors": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tiny-colors/-/tiny-colors-2.2.1.tgz",
+      "integrity": "sha512-TfI6HAOtUH6SEIDF8hlztirPlbGKShLhKmSf8Wne0M8bvVFdleHuVhBZkR3UqJKhKs9oIkJYigv4yRaxHnoATQ==",
+      "dev": true
+    },
+    "node_modules/tiny-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tiny-cursor/-/tiny-cursor-2.0.0.tgz",
+      "integrity": "sha512-6RKgFWBt6I1oYpaNZJvvp5x/jvzYDp+rjAVDam+7cmE0mrtlu8Lmpv81hQuvFuPa8Fuc/sd2shRWbdWTZqSNLg==",
+      "dev": true,
+      "dependencies": {
+        "when-exit": "^2.0.0"
+      }
+    },
+    "node_modules/tiny-editorconfig": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tiny-editorconfig/-/tiny-editorconfig-1.0.0.tgz",
+      "integrity": "sha512-rxpWaSurnvPUkL2/qydRH10llK7MD1XfE38zoWTsp/ZWWYnnwPBzGUePBOcXFaNA3cJQm8ItqrofGeRJ6AVaew==",
+      "dev": true,
+      "dependencies": {
+        "ini-simple-parser": "^1.0.0",
+        "zeptomatch": "^1.1.3"
+      }
+    },
+    "node_modules/tiny-jsonc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tiny-jsonc/-/tiny-jsonc-1.0.1.tgz",
+      "integrity": "sha512-ik6BCxzva9DoiEfDX/li0L2cWKPPENYvixUprFdl3YPi4bZZUhDnNI9YUkacrv+uIG90dnxR5mNqaoD6UhD6Bw==",
+      "dev": true
+    },
+    "node_modules/tiny-levenshtein": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tiny-levenshtein/-/tiny-levenshtein-1.0.0.tgz",
+      "integrity": "sha512-27KxXZhuXCP+xol3k4jMWms8+B6H2qEUlBMTmB5YT3uvFXFNft4Hw/MqurrHkDdC01nx1HIADcE1wR40byJf4Q==",
+      "dev": true
+    },
+    "node_modules/tiny-parse-argv": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/tiny-parse-argv/-/tiny-parse-argv-2.8.0.tgz",
+      "integrity": "sha512-bxojtQ3PvG1/l44u872hcqPVyR3hKLV+XsIviQCV5cr4weNjnkHNO+PGaz5y5pTZfmM5eqiArH+NFOChz2S3Qw==",
+      "dev": true
+    },
+    "node_modules/tiny-readdir": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/tiny-readdir/-/tiny-readdir-2.7.3.tgz",
+      "integrity": "sha512-ae1CPk7/MRhdaSIfjytuCoCjcykCNfSH36MsD2Qq8A27apaVUV0nthOcCEjiBTTloBObq2ffvm0BycUayMWh3A==",
+      "dev": true,
+      "dependencies": {
+        "promise-make-counter": "^1.0.1"
+      }
+    },
+    "node_modules/tiny-readdir-glob": {
+      "version": "1.22.24",
+      "resolved": "https://registry.npmjs.org/tiny-readdir-glob/-/tiny-readdir-glob-1.22.24.tgz",
+      "integrity": "sha512-HPDNMin7GoyPMesJNkAeT0ERU51ZWFby2RXEE2MHeVeO4c0i07679cuEMKzhKNBlBrBKoVjOmaie5y+FnRwL8g==",
+      "dev": true,
+      "dependencies": {
+        "tiny-readdir": "^2.7.0",
+        "zeptomatch": "^1.2.2",
+        "zeptomatch-explode": "^1.0.0",
+        "zeptomatch-is-static": "^1.0.0",
+        "zeptomatch-unescape": "^1.0.0"
+      }
+    },
+    "node_modules/tiny-spinner": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/tiny-spinner/-/tiny-spinner-2.0.4.tgz",
+      "integrity": "sha512-EQVPXe4JaGLj4zNMSssENpmriZ1y0MzKUOqhTO0be1TM9+hfakJ7Fe+f163gTsWPQO1cH3E05dV0l0IBVb0yBA==",
+      "dev": true,
+      "dependencies": {
+        "stdin-blocker": "^2.0.0",
+        "tiny-colors": "^2.1.2",
+        "tiny-cursor": "^2.0.0",
+        "tiny-truncate": "^1.0.2"
+      }
+    },
+    "node_modules/tiny-truncate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-truncate/-/tiny-truncate-1.0.2.tgz",
+      "integrity": "sha512-XR2fjChcOjuz8Eu56zGwacYTKUHlhuzQ3VpD79yUwvWlLY3gCWorzRfBNXkmbwFjxzfmYZrC00cA4s/ET6mogw==",
+      "dev": true,
+      "dependencies": {
+        "ansi-truncate": "^1.0.1"
+      }
+    },
+    "node_modules/tiny-updater": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/tiny-updater/-/tiny-updater-3.5.2.tgz",
+      "integrity": "sha512-5EjK01h0rvgv+Eb0XaiTZJZR+ujdjCDHZ1ZCVCu+1h4+MyOYZ+za8UKuKdNOOOSKhkkC9B08o6ZhF4JnQg7ZLg==",
+      "dev": true,
+      "dependencies": {
+        "ionstore": "^1.0.0",
+        "tiny-colors": "^2.0.2",
+        "when-exit": "^2.1.1"
+      }
     },
     "node_modules/tmp": {
       "version": "0.2.3",
@@ -16344,6 +16703,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/webworker-shim": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/webworker-shim/-/webworker-shim-1.1.0.tgz",
+      "integrity": "sha512-LhPJDED3cM0+K9w4JjIio+RYPqvr712b3lyM+JjMR/rSD9elrSYHrrwE9qu3inPSSf60xqePgFgEwuAg17AuhA==",
+      "dev": true
+    },
     "node_modules/whatwg-encoding": {
       "version": "2.0.0",
       "dev": true,
@@ -16374,6 +16739,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/when-exit": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.3.tgz",
+      "integrity": "sha512-uVieSTccFIr/SFQdFWN/fFaQYmV37OKtuaGphMAzi4DmmUlrvRBJW5WSLkHyjNQY/ePJMz3LoiX9R3yy1Su6Hw==",
+      "dev": true
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -16502,6 +16873,22 @@
       "version": "6.5.1",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/worktank": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/worktank/-/worktank-2.7.3.tgz",
+      "integrity": "sha512-M0fesnpttBPdvNYBdzRvLDsacN0na9RYWFxwmM/x1+/6mufjduv9/9vBObK8EXDqxRMX/SOYJabpo0UCYYBUdQ==",
+      "dev": true,
+      "dependencies": {
+        "promise-make-naked": "^2.0.0",
+        "webworker-shim": "^1.1.0"
+      }
+    },
+    "node_modules/worktank/node_modules/promise-make-naked": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/promise-make-naked/-/promise-make-naked-2.1.2.tgz",
+      "integrity": "sha512-y7s8ZuHIG56JYspB24be9GFkXA1zXL85Ur9u1DKrW/tvyUoPxWgBjnalK6Nc6l7wHBcAW0c3PO07+XOsWTRuhg==",
+      "dev": true
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
@@ -16748,6 +17135,33 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zeptomatch": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/zeptomatch/-/zeptomatch-1.2.2.tgz",
+      "integrity": "sha512-0ETdzEO0hdYmT8aXHHf5aMjpX+FHFE61sG4qKFAoJD2Umt3TWdCmH7ADxn2oUiWTlqBGC+SGr8sYMfr+37J8pQ==",
+      "dev": true,
+      "dependencies": {
+        "grammex": "^3.1.1"
+      }
+    },
+    "node_modules/zeptomatch-explode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/zeptomatch-explode/-/zeptomatch-explode-1.0.0.tgz",
+      "integrity": "sha512-2UDdxJqvrMixdwfYFA9cDGKetkVph8PPa1ooyUvmEoJJMs6w+0ijk1oA82Ff3wNs6yHeb849TjPvyrx9tgkZZg==",
+      "dev": true
+    },
+    "node_modules/zeptomatch-is-static": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/zeptomatch-is-static/-/zeptomatch-is-static-1.0.0.tgz",
+      "integrity": "sha512-QMFCeFADOkC8B3c1IAZCV6p34swn2UsgoGb1fP0F0G77YKb4oYEK/VL+e9mc0BLtme48V+YqDHJdwaHGFwoSXQ==",
+      "dev": true
+    },
+    "node_modules/zeptomatch-unescape": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/zeptomatch-unescape/-/zeptomatch-unescape-1.0.0.tgz",
+      "integrity": "sha512-YlbkzmjjWF092pbP2q9uf/ql34Np7HpfyBW7wibVCgRPyi8MF1EOAoSej1621r/lvzpmGF9BUJ6KIrNGiYE+jA==",
+      "dev": true
     },
     "node_modules/zip-stream": {
       "version": "4.1.1",


### PR DESCRIPTION
# PULL REQUEST

Bob got really annoyed that there were formatter misalignments between CI prettier and local prettier, so he attempted to fix it. Think this one setting is the main misalignment, but also did [an exact install of prettier against the CI version like they suggest](https://prettier.io/docs/en/install.html#:~:text=This%20makes%20sure%20that%20everyone,other's%20changes%20back%20and%20forth.)

Now hitting save on our TSX files (🤞) shouldn't generate a bunch of comma-related changes that will just get reverted by the CI linter. Can test by running `npx prettier --write src/app` and notice that there aren't changes to any of the typescript files 