### PR TITLE
ecr-viewer: set url.hostname to x-forwarded-host

### DIFF
--- a/containers/ecr-viewer/src/middleware.ts
+++ b/containers/ecr-viewer/src/middleware.ts
@@ -50,6 +50,10 @@ export const config = {
 function set_auth_cookie(req: NextRequest) {
   const url = req.nextUrl.clone();
   const auth = url.searchParams.get("auth");
+  console.log(url);
+  console.log("==========");
+  console.log(req);
+  console.log("------");
   if (auth) {
     url.searchParams.delete("auth");
     url.hostname = req.headers.get("x-forwarded-host") ?? url.hostname;

--- a/containers/ecr-viewer/src/middleware.ts
+++ b/containers/ecr-viewer/src/middleware.ts
@@ -48,10 +48,11 @@ export const config = {
  *   "auth" parameter does not exist in the request.
  */
 function set_auth_cookie(req: NextRequest) {
-  const url = req.nextUrl;
+  const url = req.nextUrl.clone();
   const auth = url.searchParams.get("auth");
   if (auth) {
     url.searchParams.delete("auth");
+    url.hostname = req.headers.get("x-forwarded-host") ?? url.hostname;
     const response = NextResponse.redirect(url);
     response.cookies.set("auth-token", auth, { httpOnly: true });
     return response;


### PR DESCRIPTION
# PULL REQUEST

## Summary
What changes are being proposed?
- Set hostname to be x-forwarded-host

## Related Issue
- Should resolve an issue in AWS where auth is redirecting to localhost:3000
- Example -> http://dibbs-ce-skylight-prod-635704096.us-east-1.elb.amazonaws.com/ecr-viewer/view-data?id=1.2.840.114350.1.13.478.3.7.8.688883.252732&auth=1234

