### PR TITLE
Back button fix and refactor

### DIFF
--- a/containers/ecr-viewer/src/app/tests/components/SideNav.test.tsx
+++ b/containers/ecr-viewer/src/app/tests/components/SideNav.test.tsx
@@ -3,7 +3,7 @@ import SideNav, {
   sortHeadings,
   countObjects,
 } from "@/app/view-data/components/SideNav";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
 
 describe("SectionConfig", () => {
@@ -54,7 +54,10 @@ describe("SectionConfig", () => {
 
   it("should have no accessibility violations", async () => {
     const { container } = render(<SideNav />);
-    const results = await axe(container);
+    let results;
+    await act(async () => {
+      results = await axe(container);
+    });
     expect(results).toHaveNoViolations();
   });
 

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/LoadingComponent.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/LoadingComponent.test.tsx.snap
@@ -50,32 +50,32 @@ exports[`Snapshot test for EcrLoadingSkeleton should match snapshot 1`] = `
         >
           <div>
             <div
-              class="display-flex back-button-wrapper"
-            >
-              <a
-                class="back-button display-flex"
-                href="/"
-              >
-                <svg
-                  aria-label="Back Arrow"
-                  class="usa-icon usa-icon--size-3"
-                  focusable="false"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 24 24"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
-                  />
-                </svg>
-                Back to eCR Library
-              </a>
-            </div>
-            <div
               class="nav-wrapper"
             >
+              <div
+                class="display-flex back-button-wrapper"
+              >
+                <a
+                  class="back-button display-flex"
+                  href="/"
+                >
+                  <svg
+                    aria-label="Back Arrow"
+                    class="usa-icon usa-icon--size-3"
+                    focusable="false"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
+                    />
+                  </svg>
+                  Back to eCR Library
+                </a>
+              </div>
               <nav
                 class="sticky-nav top-550"
               >

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/LoadingComponent.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/LoadingComponent.test.tsx.snap
@@ -46,232 +46,234 @@ exports[`Snapshot test for EcrLoadingSkeleton should match snapshot 1`] = `
         class="width-main padding-main"
       >
         <div
-          class="back-button-wrapper"
-        >
-          <button
-            class="usa-button usa-button--unstyled display-flex"
-            data-testid="button"
-            type="button"
-          >
-            <svg
-              class="usa-icon usa-icon--size-3"
-              focusable="false"
-              height="1em"
-              role="img"
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
-              />
-            </svg>
-            Back to eCR Library
-          </button>
-        </div>
-        <div
           class="content-wrapper"
         >
-          <div
-            class="nav-wrapper padding-top-1-25"
-          >
-            <nav
-              class="sticky-nav top-550"
+          <div>
+            <div
+              class="display-flex back-button-wrapper"
             >
-              <ul
-                class="usa-sidenav"
-                data-testid="sidenav"
+              <a
+                class="back-button display-flex"
+                href="/"
               >
-                <li
-                  class="usa-sidenav__item"
+                <svg
+                  aria-label="Back Arrow"
+                  class="usa-icon usa-icon--size-3"
+                  focusable="false"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  <a>
-                    eCR Summary
-                  </a>
-                </li>
-                <li
-                  class="usa-sidenav__item"
+                  <path
+                    d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
+                  />
+                </svg>
+                Back to eCR Library
+              </a>
+            </div>
+            <div
+              class="nav-wrapper"
+            >
+              <nav
+                class="sticky-nav top-550"
+              >
+                <ul
+                  class="usa-sidenav"
+                  data-testid="sidenav"
                 >
-                  <a>
-                    eCR Document
-                  </a>
-                </li>
-                <li
-                  class="usa-sidenav__item"
-                >
-                  <ul
-                    class="usa-sidenav__sublist"
-                    data-testid="sidenav"
+                  <li
+                    class="usa-sidenav__item"
                   >
-                    <li
-                      class="usa-sidenav__item"
+                    <a>
+                      eCR Summary
+                    </a>
+                  </li>
+                  <li
+                    class="usa-sidenav__item"
+                  >
+                    <a>
+                      eCR Document
+                    </a>
+                  </li>
+                  <li
+                    class="usa-sidenav__item"
+                  >
+                    <ul
+                      class="usa-sidenav__sublist"
+                      data-testid="sidenav"
                     >
-                      <a>
-                        Patient Info
-                      </a>
-                    </li>
-                    <li
-                      class="usa-sidenav__item"
-                    >
-                      <ul
-                        class="usa-sidenav__sublist"
-                        data-testid="sidenav"
+                      <li
+                        class="usa-sidenav__item"
                       >
-                        <li
-                          class="usa-sidenav__item"
+                        <a>
+                          Patient Info
+                        </a>
+                      </li>
+                      <li
+                        class="usa-sidenav__item"
+                      >
+                        <ul
+                          class="usa-sidenav__sublist"
+                          data-testid="sidenav"
                         >
-                          <a>
-                            <div>
-                              <div
-                                class="grid-row"
-                              >
+                          <li
+                            class="usa-sidenav__item"
+                          >
+                            <a>
+                              <div>
                                 <div
-                                  class="loading-blob grid-col-8 loading-blob-gray-big width-full"
+                                  class="grid-row"
                                 >
-                                   
+                                  <div
+                                    class="loading-blob grid-col-8 loading-blob-gray-big width-full"
+                                  >
+                                     
+                                  </div>
                                 </div>
                               </div>
-                            </div>
-                          </a>
-                        </li>
-                      </ul>
-                    </li>
-                    <li
-                      class="usa-sidenav__item"
-                    >
-                      <a>
-                        Clinical Info
-                      </a>
-                    </li>
-                    <li
-                      class="usa-sidenav__item"
-                    >
-                      <ul
-                        class="usa-sidenav__sublist"
-                        data-testid="sidenav"
+                            </a>
+                          </li>
+                        </ul>
+                      </li>
+                      <li
+                        class="usa-sidenav__item"
                       >
-                        <li
-                          class="usa-sidenav__item"
+                        <a>
+                          Clinical Info
+                        </a>
+                      </li>
+                      <li
+                        class="usa-sidenav__item"
+                      >
+                        <ul
+                          class="usa-sidenav__sublist"
+                          data-testid="sidenav"
                         >
-                          <a>
-                            <div>
-                              <div
-                                class="grid-row"
-                              >
+                          <li
+                            class="usa-sidenav__item"
+                          >
+                            <a>
+                              <div>
                                 <div
-                                  class="loading-blob grid-col-8 loading-blob-gray-big width-full"
+                                  class="grid-row"
                                 >
-                                   
+                                  <div
+                                    class="loading-blob grid-col-8 loading-blob-gray-big width-full"
+                                  >
+                                     
+                                  </div>
                                 </div>
                               </div>
-                            </div>
-                          </a>
-                        </li>
-                      </ul>
-                    </li>
-                    <li
-                      class="usa-sidenav__item"
-                    >
-                      <a>
-                        Lab Info
-                      </a>
-                    </li>
-                    <li
-                      class="usa-sidenav__item"
-                    >
-                      <ul
-                        class="usa-sidenav__sublist"
-                        data-testid="sidenav"
+                            </a>
+                          </li>
+                        </ul>
+                      </li>
+                      <li
+                        class="usa-sidenav__item"
                       >
-                        <li
-                          class="usa-sidenav__item"
+                        <a>
+                          Lab Info
+                        </a>
+                      </li>
+                      <li
+                        class="usa-sidenav__item"
+                      >
+                        <ul
+                          class="usa-sidenav__sublist"
+                          data-testid="sidenav"
                         >
-                          <a>
-                            <div>
-                              <div
-                                class="grid-row"
-                              >
+                          <li
+                            class="usa-sidenav__item"
+                          >
+                            <a>
+                              <div>
                                 <div
-                                  class="loading-blob grid-col-8 loading-blob-gray-big width-full"
+                                  class="grid-row"
                                 >
-                                   
+                                  <div
+                                    class="loading-blob grid-col-8 loading-blob-gray-big width-full"
+                                  >
+                                     
+                                  </div>
                                 </div>
                               </div>
-                            </div>
-                          </a>
-                        </li>
-                      </ul>
-                    </li>
-                    <li
-                      class="usa-sidenav__item"
-                    >
-                      <a>
-                        eCR Metadata
-                      </a>
-                    </li>
-                    <li
-                      class="usa-sidenav__item"
-                    >
-                      <ul
-                        class="usa-sidenav__sublist"
-                        data-testid="sidenav"
+                            </a>
+                          </li>
+                        </ul>
+                      </li>
+                      <li
+                        class="usa-sidenav__item"
                       >
-                        <li
-                          class="usa-sidenav__item"
+                        <a>
+                          eCR Metadata
+                        </a>
+                      </li>
+                      <li
+                        class="usa-sidenav__item"
+                      >
+                        <ul
+                          class="usa-sidenav__sublist"
+                          data-testid="sidenav"
                         >
-                          <a>
-                            <div>
-                              <div
-                                class="grid-row"
-                              >
+                          <li
+                            class="usa-sidenav__item"
+                          >
+                            <a>
+                              <div>
                                 <div
-                                  class="loading-blob grid-col-8 loading-blob-gray-big width-full"
+                                  class="grid-row"
                                 >
-                                   
+                                  <div
+                                    class="loading-blob grid-col-8 loading-blob-gray-big width-full"
+                                  >
+                                     
+                                  </div>
                                 </div>
                               </div>
-                            </div>
-                          </a>
-                        </li>
-                      </ul>
-                    </li>
-                    <li
-                      class="usa-sidenav__item"
-                    >
-                      <a>
-                        Unavailable Info
-                      </a>
-                    </li>
-                    <li
-                      class="usa-sidenav__item"
-                    >
-                      <ul
-                        class="usa-sidenav__sublist"
-                        data-testid="sidenav"
+                            </a>
+                          </li>
+                        </ul>
+                      </li>
+                      <li
+                        class="usa-sidenav__item"
                       >
-                        <li
-                          class="usa-sidenav__item"
+                        <a>
+                          Unavailable Info
+                        </a>
+                      </li>
+                      <li
+                        class="usa-sidenav__item"
+                      >
+                        <ul
+                          class="usa-sidenav__sublist"
+                          data-testid="sidenav"
                         >
-                          <a>
-                            <div>
-                              <div
-                                class="grid-row"
-                              >
+                          <li
+                            class="usa-sidenav__item"
+                          >
+                            <a>
+                              <div>
                                 <div
-                                  class="loading-blob grid-col-8 loading-blob-gray-big width-full"
+                                  class="grid-row"
                                 >
-                                   
+                                  <div
+                                    class="loading-blob grid-col-8 loading-blob-gray-big width-full"
+                                  >
+                                     
+                                  </div>
                                 </div>
                               </div>
-                            </div>
-                          </a>
-                        </li>
-                      </ul>
-                    </li>
-                  </ul>
-                </li>
-              </ul>
-            </nav>
+                            </a>
+                          </li>
+                        </ul>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+              </nav>
+            </div>
           </div>
           <div
             class="ecr-viewer-container"
@@ -280,7 +282,7 @@ exports[`Snapshot test for EcrLoadingSkeleton should match snapshot 1`] = `
               class="margin-bottom-3"
             >
               <h2
-                class="margin-bottom-05"
+                class="margin-bottom-05 margin-top-3"
                 id="ecr-summary"
               >
                 eCR Summary

--- a/containers/ecr-viewer/src/app/tests/components/__snapshots__/SideNav.test.tsx.snap
+++ b/containers/ecr-viewer/src/app/tests/components/__snapshots__/SideNav.test.tsx.snap
@@ -3,11 +3,35 @@
 exports[`SectionConfig should match the snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="nav-wrapper padding-top-1-25"
+    class="nav-wrapper"
   >
     <nav
       class="sticky-nav top-550"
     >
+      <div
+        class="display-flex back-button-wrapper"
+      >
+        <a
+          class="back-button display-flex"
+          href="/"
+        >
+          <svg
+            aria-label="Back Arrow"
+            class="usa-icon usa-icon--size-3"
+            focusable="false"
+            height="1em"
+            role="img"
+            viewBox="0 0 24 24"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
+            />
+          </svg>
+          Back to eCR Library
+        </a>
+      </div>
       <ul
         class="usa-sidenav"
         data-testid="sidenav"

--- a/containers/ecr-viewer/src/app/view-data/components/BackButton.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/BackButton.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Icon } from "@trussworks/react-uswds";
+import Link from "next/link";
+
+/**
+ * Back button component for returning users from the eCR Viewer page to the eCR Library home page
+ * @returns <BackButton/> a react component back button
+ */
+export const BackButton = () => {
+  const isNonIntegratedViewer =
+    process.env.NEXT_PUBLIC_NON_INTEGRATED_VIEWER === "true";
+
+  return (
+    <div className="display-flex back-button-wrapper">
+      {isNonIntegratedViewer ? (
+        <Link href={"/"} className={"back-button display-flex"}>
+          <Icon.ArrowBack aria-label={"Back Arrow"} size={3} />
+          Back to eCR Library
+        </Link>
+      ) : (
+        ""
+      )}
+    </div>
+  );
+};

--- a/containers/ecr-viewer/src/app/view-data/components/LoadingComponent.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/LoadingComponent.tsx
@@ -112,6 +112,7 @@ const SideNavLoadingSkeleton = ({
 
   return (
     <div className="nav-wrapper">
+      <BackButton />
       <nav
         className={classNames("sticky-nav", {
           "top-0": !isNonIntegratedViewer,
@@ -254,7 +255,6 @@ export const EcrLoadingSkeleton = () => {
         <div className={"width-main padding-main"}>
           <div className="content-wrapper">
             <div>
-              <BackButton />
               <SideNavLoadingSkeleton
                 isNonIntegratedViewer={_isNonIntegratedViewer ? true : false}
               />

--- a/containers/ecr-viewer/src/app/view-data/components/LoadingComponent.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/LoadingComponent.tsx
@@ -1,10 +1,8 @@
 "use client";
 import {
   Accordion,
-  Button,
   Grid,
   GridContainer,
-  Icon,
   SideNav,
 } from "@trussworks/react-uswds";
 import { ExpandCollapseButtons } from "./ExpandCollapseButtons";
@@ -16,6 +14,7 @@ import {
 import Header from "@/app/Header";
 import classNames from "classnames";
 import PatientBanner from "./PatientBanner";
+import { BackButton } from "./BackButton";
 
 /**
  * Renders the loading blobs in gray or in blue
@@ -112,7 +111,7 @@ const SideNavLoadingSkeleton = ({
   ];
 
   return (
-    <div className="nav-wrapper padding-top-1-25">
+    <div className="nav-wrapper">
       <nav
         className={classNames("sticky-nav", {
           "top-0": !isNonIntegratedViewer,
@@ -253,29 +252,16 @@ export const EcrLoadingSkeleton = () => {
       )}
       <div className="main-container">
         <div className={"width-main padding-main"}>
-          <div className="back-button-wrapper">
-            {_isNonIntegratedViewer ? (
-              <Button
-                unstyled={true}
-                type="button"
-                className={"display-flex"}
-                onClick={() => window.history.back()}
-              >
-                <Icon.ArrowBack size={3} />
-                Back to eCR Library
-              </Button>
-            ) : (
-              ""
-            )}
-          </div>
           <div className="content-wrapper">
-            <SideNavLoadingSkeleton
-              isNonIntegratedViewer={_isNonIntegratedViewer ? true : false}
-            />
-            {/* <SideNav /> */}
+            <div>
+              <BackButton />
+              <SideNavLoadingSkeleton
+                isNonIntegratedViewer={_isNonIntegratedViewer ? true : false}
+              />
+            </div>
             <div className={"ecr-viewer-container"}>
               <div className="margin-bottom-3">
-                <h2 className="margin-bottom-05" id="ecr-summary">
+                <h2 className="margin-bottom-05 margin-top-3" id="ecr-summary">
                   eCR Summary
                 </h2>
                 <div className="text-base-darker line-height-sans-5">

--- a/containers/ecr-viewer/src/app/view-data/components/SideNav.tsx
+++ b/containers/ecr-viewer/src/app/view-data/components/SideNav.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { SideNav as UswdsSideNav } from "@trussworks/react-uswds";
 import { formatString } from "@/app/services/formatService";
 import classNames from "classnames";
+import { BackButton } from "./BackButton";
 
 export class SectionConfig {
   title: string;
@@ -217,13 +218,14 @@ const SideNav: React.FC = () => {
   let sideNavItems = buildSideNav(sectionConfigs);
 
   return (
-    <div className="nav-wrapper padding-top-1-25">
+    <div className="nav-wrapper">
       <nav
         className={classNames("sticky-nav", {
           "top-0": !isNonIntegratedViewer,
           "top-550": isNonIntegratedViewer,
         })}
       >
+        <BackButton />
         <UswdsSideNav items={sideNavItems} />
       </nav>
     </div>

--- a/containers/ecr-viewer/src/app/view-data/page.tsx
+++ b/containers/ecr-viewer/src/app/view-data/page.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from "react";
 import { Bundle } from "fhir/r4";
 import { PathMappings } from "./utils/utils";
 import SideNav from "./components/SideNav";
-import { Grid, GridContainer, Icon, Button } from "@trussworks/react-uswds";
+import { Grid, GridContainer } from "@trussworks/react-uswds";
 import { ExpandCollapseButtons } from "@/app/view-data/components/ExpandCollapseButtons";
 import EcrSummary from "./components/EcrSummary";
 import {
@@ -27,10 +27,8 @@ const ECRViewerPage: React.FC = () => {
   const [mappings, setMappings] = useState<PathMappings>({});
   const [errors, setErrors] = useState<Error>();
   const searchParams = useSearchParams();
-  const fhirId = searchParams ? (searchParams.get("id") ?? "") : "";
-  const snomedCode = searchParams
-    ? (searchParams.get("snomed-code") ?? "")
-    : "";
+  const fhirId = searchParams ? searchParams.get("id") ?? "" : "";
+  const snomedCode = searchParams ? searchParams.get("snomed-code") ?? "" : "";
   const isNonIntegratedViewer =
     process.env.NEXT_PUBLIC_NON_INTEGRATED_VIEWER === "true";
 
@@ -92,26 +90,14 @@ const ECRViewerPage: React.FC = () => {
         )}
         <div className="main-container">
           <div className={"width-main padding-main"}>
-            <div className="back-button-wrapper">
-              {isNonIntegratedViewer ? (
-                <Button
-                  unstyled={true}
-                  type="button"
-                  className={"display-flex"}
-                  onClick={() => window.history.back()}
-                >
-                  <Icon.ArrowBack size={3} />
-                  Back to eCR Library
-                </Button>
-              ) : (
-                ""
-              )}
-            </div>
             <div className="content-wrapper">
               <SideNav />
               <div className={"ecr-viewer-container"}>
                 <div className="margin-bottom-3">
-                  <h2 className="margin-bottom-05" id="ecr-summary">
+                  <h2
+                    className="margin-bottom-05 margin-top-3"
+                    id="ecr-summary"
+                  >
                     eCR Summary
                   </h2>
                   <div className="text-base-darker line-height-sans-5">

--- a/containers/ecr-viewer/src/app/view-data/page.tsx
+++ b/containers/ecr-viewer/src/app/view-data/page.tsx
@@ -27,8 +27,10 @@ const ECRViewerPage: React.FC = () => {
   const [mappings, setMappings] = useState<PathMappings>({});
   const [errors, setErrors] = useState<Error>();
   const searchParams = useSearchParams();
-  const fhirId = searchParams ? searchParams.get("id") ?? "" : "";
-  const snomedCode = searchParams ? searchParams.get("snomed-code") ?? "" : "";
+  const fhirId = searchParams ? (searchParams.get("id") ?? "") : "";
+  const snomedCode = searchParams
+    ? (searchParams.get("snomed-code") ?? "")
+    : "";
   const isNonIntegratedViewer =
     process.env.NEXT_PUBLIC_NON_INTEGRATED_VIEWER === "true";
 

--- a/containers/ecr-viewer/src/styles/custom-styles.scss
+++ b/containers/ecr-viewer/src/styles/custom-styles.scss
@@ -284,8 +284,6 @@ td {
 }
 
 .back-button-wrapper {
-  margin-top: 1.5rem;
-  margin-bottom:1.5rem;
   display: flex;
   .usa-icon{
     color: #71767A;
@@ -297,6 +295,10 @@ td {
   }
 }
 
+.back-button {
+  margin-bottom:1.5rem;
+}
+
 .content-wrapper {
   display: flex;
   gap: $ecr-viewer-gap;
@@ -304,6 +306,8 @@ td {
 }
 
 .nav-wrapper {
+  margin-top: 1.5rem;
+  padding-top: .63rem;
   display: flex;
   flex-direction: column;
   align-items: flex-start;

--- a/containers/ecr-viewer/src/styles/custom-styles.scss
+++ b/containers/ecr-viewer/src/styles/custom-styles.scss
@@ -284,13 +284,14 @@ td {
 }
 
 .back-button-wrapper {
-  margin-top:1.5rem;
+  margin-top: 1.5rem;
+  margin-bottom:1.5rem;
   display: flex;
   .usa-icon{
     color: #71767A;
     margin-right: .5rem;
   }
-  .usa-button {
+  .usa-link {
     text-decoration-line: underline;
     align-items: center;
   }
@@ -300,7 +301,6 @@ td {
   display: flex;
   gap: $ecr-viewer-gap;
   overflow: visible;
-  margin-top: 1.5rem;
 }
 
 .nav-wrapper {


### PR DESCRIPTION
# PULL REQUEST

## Summary
Updates back button to always return to the eCR Library page and made it sticky. Also refactored the button into its own component and used that component for both the viewer and loading page. Tweaked a couple other bits of the loading styling to make things a bit less jumpy

## Related Issue
Fixes #2322

## Acceptance Criteria

- [x] Back to eCR Library button should always go back to the eCR Library.
- [ ] Back button should always be sticky to the top of the page.

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
