### PR TITLE
update fhir-converter to .NET6

### DIFF
--- a/containers/fhir-converter/Dockerfile
+++ b/containers/fhir-converter/Dockerfile
@@ -1,7 +1,7 @@
-FROM mcr.microsoft.com/dotnet/sdk:3.1 as build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 as build
 
 # Download FHIR-Converter
-RUN git clone https://github.com/microsoft/FHIR-Converter.git --branch v5.0.4 --single-branch /build/FHIR-Converter
+RUN git clone https://github.com/nickbristow/FHIR-Converter.git --branch main --single-branch /build/FHIR-Converter
 COPY /CustomFhir/CustomFilters.cs /build/FHIR-Converter/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/
 
 WORKDIR /build/FHIR-Converter
@@ -17,7 +17,7 @@ RUN mkdir bin && \
 # Build Microsoft FHIR Converter
 RUN dotnet build -c Release -o output
 
-FROM mcr.microsoft.com/dotnet/runtime:3.1 as runtime
+FROM mcr.microsoft.com/dotnet/runtime:6.0 as runtime
 
 # Copy FHIR-Converter binary from build stage
 COPY --from=build /build/FHIR-Converter/output /build/FHIR-Converter/output
@@ -26,7 +26,7 @@ COPY --from=build /build/FHIR-Converter/data/Templates /build/FHIR-Converter/dat
 ENV PYTHONUNBUFFERED=1
 
 # Install python via pyenv
-RUN apt-get update && apt-get install -y curl git build-essential libreadline-gplv2-dev  libncursesw5-dev  libssl-dev  libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev libffi-dev zlib1g-dev
+RUN apt-get update && apt-get install -y curl git build-essential libreadline-dev libncursesw5-dev  libssl-dev  libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev libffi-dev zlib1g-dev
 RUN curl https://pyenv.run | bash
 RUN export PYENV_ROOT="$HOME/.pyenv"
 RUN export PATH="$PYENV_ROOT/bin:$PATH"

--- a/containers/fhir-converter/Dockerfile
+++ b/containers/fhir-converter/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:6.0 as build
 
 # Download FHIR-Converter
-RUN git clone https://github.com/nickbristow/FHIR-Converter.git --branch main --single-branch /build/FHIR-Converter
+RUN git clone https://github.com/skylight-hq/FHIR-Converter.git --branch main --single-branch /build/FHIR-Converter
 COPY /CustomFhir/CustomFilters.cs /build/FHIR-Converter/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/
 
 WORKDIR /build/FHIR-Converter

--- a/containers/fhir-converter/Makefile
+++ b/containers/fhir-converter/Makefile
@@ -6,12 +6,13 @@ include ../config.env
 
 help:
 	@echo "\033[1;32mDIBBs FHIR Converter Service Commands:\033[0m"
-	@select option in "run-docker" "run-python" "build-image" "docker-local" "build-loud" "test-dotnet" "exit"; do \
+	@select option in "run-docker" "run-python" "build-image" "docker-local" "docker-local-no-cache" "build-loud" "test-dotnet" "exit"; do \
 		case $$option in \
 			"run-docker") $(MAKE) run-docker; break;; \
 			"run-python") $(MAKE) run-python; break;; \
 			"build-image") $(MAKE) build-image; break;; \
 			"docker-local") $(MAKE) docker-local; break;; \
+			"docker-local-no-cache")  $(MAKE) docker-local-no-cache; break;; \
 			"build-loud") $(MAKE) build-loud; break;; \
 			"test-dotnet") $(MAKE) test-dotnet; break;; \
 			"exit") echo "Exiting..."; break;; \
@@ -34,9 +35,16 @@ run-python:
 docker-local:
 	$(MAKE) build-image && docker run -p $(FHIR_CONVERTER_PORT):8080 fhir-converter
 
+docker-local-no-cache:
+	$(MAKE) build-image-no-cache && docker run -p $(FHIR_CONVERTER_PORT):8080 fhir-converter
+
 build-image:
 	@echo "Building Docker image for the FHIR Converter service..."
 	docker buildx build --platform linux/amd64 -t fhir-converter .
+
+build-image-no-cache:
+	@echo "Building Docker image for the FHIR Converter service without cache..."
+	docker buildx build --no-cache --platform linux/amd64 -t fhir-converter .
 
 build-loud:
 	@echo "Building Docker image without cache..."


### PR DESCRIPTION
# PULL REQUEST

## Summary
In order to fix compliance issues, we need to run fhir converter with at least .NET6
## Related Issue
Fixes #

## Acceptance Criteria
Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information
Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
