### PR TITLE
Improve orchestration error messages

### DIFF
--- a/containers/orchestration/app/main.py
+++ b/containers/orchestration/app/main.py
@@ -319,7 +319,6 @@ async def apply_workflow_to_message(
             "rr_data": rr_content,
         }
         wf_span.add_event("sending params to `call_apis`")
-        # response, responses = await call_apis(config=processing_config, input=api_input)
         try:
             response, responses = await call_apis(config=processing_config, input=api_input)
         except HTTPException as error:

--- a/containers/orchestration/app/main.py
+++ b/containers/orchestration/app/main.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import traceback
 from pathlib import Path
 from typing import Annotated
 
@@ -8,6 +9,7 @@ from dibbs.base_service import BaseService
 from fastapi import Body
 from fastapi import File
 from fastapi import Form
+from fastapi import HTTPException
 from fastapi import Response
 from fastapi import status
 from fastapi import UploadFile
@@ -317,7 +319,26 @@ async def apply_workflow_to_message(
             "rr_data": rr_content,
         }
         wf_span.add_event("sending params to `call_apis`")
-        response, responses = await call_apis(config=processing_config, input=api_input)
+        # response, responses = await call_apis(config=processing_config, input=api_input)
+        try:
+            response, responses = await call_apis(config=processing_config, input=api_input)
+        except HTTPException as error:
+            # These exceptions are purposefully created in call_apis to surface service errors
+            raise error
+        except Exception as error:
+            # Handle internal exceptions
+            wf_span.record_exception(error)
+            return Response(
+                content=json.dumps(
+                    {
+                        "message": f"Orchestration service error: {error.__str__()}",
+                        "processed_values": {},
+                    }
+                ),
+                media_type="application/json",
+                status_code=500,
+            )
+            
         wf_span.add_event(
             "`call_apis` responded with computed result",
             attributes={"return_code": response.status_code},

--- a/containers/orchestration/app/main.py
+++ b/containers/orchestration/app/main.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import traceback
 from pathlib import Path
 from typing import Annotated
 

--- a/containers/orchestration/app/services.py
+++ b/containers/orchestration/app/services.py
@@ -249,10 +249,8 @@ async def call_apis(
                 call_span.record_exception(
                     HTTPException, attributes={"status_code": 400}
                 )
-                error_detail = (
-                    f"Service {service} completed, but orchestration cannot continue "
-                )
-                +f"{service_response.msg_content}"
+                error_detail = f"Service {service} completed, but orchestration cannot continue: {service_response.msg_content}"
+
                 call_span.set_status(StatusCode(2), error_detail)
                 raise HTTPException(
                     status_code=400,

--- a/containers/orchestration/tests/test_process_message_endpoint.py
+++ b/containers/orchestration/tests/test_process_message_endpoint.py
@@ -125,6 +125,23 @@ def test_process_message_success(patched_post_request):
     actual_response = client.post("/process-message", json=request)
     assert actual_response.status_code == 200
 
+@mock.patch("app.main.call_apis", side_effect=Exception("Fake Exception"))
+def test_process_message_orchestration_error(patched_call_apis):
+    message = open(Path(__file__).parent / "assets" / "hl7_with_msh_3_set.hl7").read()
+    request = {
+        "message_type": "elr",
+        "data_type": "hl7",
+        "config_file_name": "sample-orchestration-config.json",
+        "message": message,
+    }
+
+    actual_response = client.post("/process-message", json=request)
+    assert actual_response.status_code == 500
+    assert actual_response.json() == {
+        "message": "Orchestration service error: Fake Exception",
+        "processed_values": {},
+    }
+
 
 @mock.patch("app.services.post_request")
 def test_process_message_fhir_data(patched_post_request):


### PR DESCRIPTION
# PULL REQUEST

## Summary
Catches and surfaces orchestration service errors and fixes string concatenation bug when creating dependent service errors.

## Related Issue
Fixes #2467 

## Acceptance Criteria
Orchestration error message contains
- the service that failed
- the error message that service returned (without any pii)

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
