### PR TITLE
[orchestration] instantiate HTTPException when service_response should not continue.

### DIFF
--- a/containers/orchestration/app/services.py
+++ b/containers/orchestration/app/services.py
@@ -247,7 +247,11 @@ async def call_apis(
 
             if not service_response.should_continue:
                 call_span.record_exception(
-                    HTTPException, attributes={"status_code": 400}
+                    HTTPException(
+                        status_code=400,
+                        detail=f"Service: {service} returned should_continue",
+                    ),
+                    attributes={"status_code": 400},
                 )
                 error_detail = f"Service {service} completed, but orchestration cannot continue: {service_response.msg_content}"
 


### PR DESCRIPTION
# PULL REQUEST

## Summary
- Fixes an issue with orchestration error handling where HttpException was not being instantiated giving a generic issue.

## Additional Information
Now:
![image](https://github.com/user-attachments/assets/442605cd-dbc7-4f34-b04e-c55d9e8089c0)

Before:
![image](https://github.com/user-attachments/assets/0c0df1c0-624e-4b3b-9a16-f813763c8009)

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
