### PR TITLE
make golden sick patient for demo flow

### DIFF
--- a/containers/tefca-viewer/src/app/tests/assets/GoldenSickPatient.json
+++ b/containers/tefca-viewer/src/app/tests/assets/GoldenSickPatient.json
@@ -1,0 +1,10893 @@
+// Patient ID: f288c654-6885-4f48-999c-48d776dc06af
+// Practictioner ID: 8085737b-28ec-4b23-8604-83fd20076933
+
+{
+  "resourceType": "Bundle",
+  "id": "6cc4ca7f-f9bf-445f-999f-86eaa2e180ae",
+  "meta": {
+    "lastUpdated": "2024-10-04T15:52:02.656+00:00"
+  },
+  "type": "searchset",
+  "total": 6,
+  "link": [
+    {
+      "relation": "self",
+      "url": "https://gw.interop.community/HeliosConnectathonSa/open/Patient/f288c654-6885-4f48-999c-48d776dc06af/$everything"
+    }
+  ],
+  "entry": [
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Patient/f288c654-6885-4f48-999c-48d776dc06af",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "f288c654-6885-4f48-999c-48d776dc06af",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-01-16T15:08:24.000+00:00",
+          "source": "#Aolu2ZnQyoelPvRd",
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">This is a simple narrative with only plain text</div>"
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+            "extension": [
+              {
+                "url": "ombCategory",
+                "valueCoding": {
+                  "system": "urn:oid:2.16.840.1.113883.6.238",
+                  "code": "2106-3",
+                  "display": "White"
+                }
+              },
+              {
+                "url": "text",
+                "valueString": "Mixed"
+              }
+            ]
+          },
+          {
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+            "extension": [
+              {
+                "url": "ombCategory",
+                "valueCoding": {
+                  "system": "urn:oid:2.16.840.1.113883.6.238",
+                  "code": "2135-2",
+                  "display": "Hispanic or Latino"
+                }
+              },
+              {
+                "url": "text",
+                "valueString": "Hispanic or Latino"
+              }
+            ]
+          },
+          {
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+            "valueCode": "M"
+          }
+        ],
+        "identifier": [
+          {
+            "use": "usual",
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "MR",
+                  "display": "Medical Record Number"
+                }
+              ],
+              "text": "Medical Record Number"
+            },
+            "system": "http://hospital.smarthealthit.org",
+            "value": "8692756"
+          }
+        ],
+        "active": true,
+        "name": [
+          {
+            "family": "Unlucky",
+            "given": ["Hyper", "A."],
+            "period": {
+              "start": "1975-12-06",
+              "end": "2020-01-22"
+            }
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "517-425-1398",
+            "use": "home"
+          },
+          {
+            "system": "email",
+            "value": "hyper.unlucky@email.com"
+          }
+        ],
+        "gender": "male",
+        "birthDate": "1975-12-06",
+        "address": [
+          {
+            "line": ["49 Meadow St"],
+            "city": "Lansing",
+            "state": "MI",
+            "postalCode": "48864",
+            "country": "US",
+            "period": {
+              "start": "2016-12-06",
+              "end": "2020-07-22"
+            }
+          },
+          {
+            "line": ["183 Mountain View St"],
+            "city": "Lansing",
+            "state": "MI",
+            "postalCode": "48901",
+            "country": "US",
+            "period": {
+              "start": "2020-07-22"
+            }
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Condition/3C",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "3C",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-01-16T15:08:47.000+00:00",
+          "source": "#5CXIuBtjIkpukkFj",
+          "profile": [
+            "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-primary-cancer-condition"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">This is a simple narrative with only plain text</div>"
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+              "code": "active",
+              "display": "Active"
+            }
+          ]
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+              "code": "confirmed",
+              "display": "Confirmed"
+            }
+          ]
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "problem-list-item"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "92814006",
+              "display": "Chronic lymphoid leukemia, disease (disorder)"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "onsetDateTime": "2023-11-12",
+        "asserter": {
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933"
+        },
+        "stage": [
+          {
+            "summary": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/umls",
+                  "code": "C2698392",
+                  "display": "Binet Stage A"
+                }
+              ]
+            },
+            "assessment": [
+              {
+                "reference": "Observation/binet-stage-group-A"
+              }
+            ]
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/MedicationRequest/5C",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "5C",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-01-16T15:09:07.000+00:00",
+          "source": "#zAegsvYT7Rh5l8Qn",
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">This is a simple narrative with only plain text</div>"
+        },
+        "status": "active",
+        "intent": "order",
+        "medicationCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+              "code": "828265",
+              "display": "1 ML alemtuzumab 30 MG/ML Injection"
+            }
+          ],
+          "text": "1 ML alemtuzumab 30 MG/ML Injection"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "display": "Hyper Unlucky"
+        },
+        "authoredOn": "2023-11-18",
+        "requester": {
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
+          "display": "Hai Pocondriac"
+        },
+        "dosageInstruction": [
+          {
+            "text": "1 mL injection",
+            "timing": {
+              "repeat": {
+                "boundsPeriod": {
+                  "start": "2023-11-18"
+                }
+              }
+            }
+          }
+        ],
+        "dispenseRequest": {
+          "numberOfRepeatsAllowed": 1,
+          "quantity": {
+            "value": 1,
+            "unit": "mL",
+            "system": "http://unitsofmeasure.org",
+            "code": "mL"
+          },
+          "expectedSupplyDuration": {
+            "value": 1,
+            "unit": "days",
+            "system": "http://unitsofmeasure.org",
+            "code": "d"
+          }
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Encounter/7C",
+      "resource": {
+        "resourceType": "Encounter",
+        "id": "7C",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-01-16T15:09:31.000+00:00",
+          "source": "#60zMZpn6G60X5rNg",
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><p><b>id</b>: example-1</p><p><b>meta</b>: </p><p><b>status</b>: finished</p><p><b>class</b>: <span title=\"{http://terminology.hl7.org/CodeSystem/v3-ActCode AMB}\">ambulatory</span></p><p><b>type</b>: <span title=\"Codes: {http://www.ama-assn.org/go/cpt 99201}\">Office Visit</span></p><p><b>subject</b>: <a href=\"Patient-example.html\">Generated Summary: id: example; Medical Record Number: 1032702 (USUAL); active; Amy V. Shaw , Amy V. Baxter ; ph: 555-555-5555(HOME), amy.shaw@example.com; gender: female; birthDate: 1987-02-20</a></p><p><b>period</b>: 02/11/2015 9:00:14 AM --&gt; 02/11/2015 10:00:14 AM</p></div>"
+        },
+        "status": "finished",
+        "class": {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+          "code": "ACUTE",
+          "display": "inpatient acute"
+        },
+        "type": [
+          {
+            "coding": [
+              {
+                "system": "http://www.ama-assn.org/go/cpt",
+                "code": "15301000"
+              }
+            ],
+            "text": "Consultation in Chemotherapy"
+          }
+        ],
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "period": {
+          "start": "2023-11-17T17:00:14-05:00",
+          "end": "2023-11-17T18:00:14-05:00"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/MedicationAdministration/6C",
+      "resource": {
+        "resourceType": "MedicationAdministration",
+        "id": "6C",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-01-16T15:09:42.000+00:00",
+          "source": "#e8bKqR9G0wQ37Nzl"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">This is a simple narrative with only plain text</div>"
+        },
+        "contained": [
+          {
+            "resourceType": "Medication",
+            "id": "4C",
+            "code": {
+              "coding": [
+                {
+                  "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+                  "code": "828265",
+                  "display": "1 ML alemtuzumab 30 MG/ML Injection"
+                }
+              ]
+            }
+          }
+        ],
+        "status": "completed",
+        "medicationReference": {
+          "reference": "#4C"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "display": "Hyper Unlucky"
+        },
+        "context": {
+          "reference": "Encounter/7C",
+          "display": "encounter who leads to this prescription"
+        },
+        "effectivePeriod": {
+          "start": "2023-11-18T04:30:00+01:00",
+          "end": "2023-11-18T14:30:00+01:00"
+        },
+        "performer": [
+          {
+            "actor": {
+              "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
+              "display": "Hai Pocondriac"
+            }
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "Condition/3C"
+          }
+        ],
+        "request": {
+          "reference": "MedicationRequest/5C"
+        },
+        "dosage": {
+          "text": "Rapid daily-dose escalation, until tolerated, from 3 mg/d, and then 10 mg/d, to the recommended maintenance dose of 30 mg IV over 120 min, 3 times per wk on alternate days for up to 12 wk",
+          "route": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "47625008",
+                "display": "Intravenous route (qualifier value)"
+              }
+            ]
+          },
+          "method": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "422145002",
+                "display": "Inject - dosing instruction imperative (qualifier value)"
+              }
+            ]
+          },
+          "dose": {
+            "value": 3,
+            "unit": "mg",
+            "system": "http://unitsofmeasure.org",
+            "code": "mg"
+          }
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "8085737b-28ec-4b23-8604-83fd20076933",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-01-16T15:08:36.000+00:00",
+          "source": "#zOdodLUnhoAvr3zS",
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><p><b>id</b>: practitioner-1</p><p><b>meta</b>: </p><p><b>identifier</b>: id: 9941339108, id: 25456</p><p><b>name</b>: Ronald Bone </p><p><b>address</b>: 1003 Healthcare Drive Amherst MA 01002 (HOME)</p></div>"
+        },
+        "identifier": [
+          {
+            "system": "http://hl7.org.fhir/sid/us-npi",
+            "value": "1948792758"
+          },
+          {
+            "system": "http://www.acme.org/practitioners",
+            "value": "25647"
+          }
+        ],
+        "name": [
+          {
+            "family": "Pocondriac",
+            "given": ["Hai"],
+            "prefix": ["Dr"]
+          }
+        ],
+        "address": [
+          {
+            "use": "home",
+            "line": ["4531 Marketplace Drive"],
+            "city": "Lansing",
+            "state": "MI",
+            "postalCode": "48893"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Coverage/claim-1788c921",
+      "resource": {
+        "resourceType": "Coverage",
+        "id": "claim-1788c921",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2022-01-06T03:11:43.000+00:00",
+          "source": "#c64259dfad10ca17"
+        },
+        "identifier": [
+          {
+            "system": "http://better.health.insurance.com/plan",
+            "value": "d96030446269cb1e0a862d36237"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/v3/ActCode",
+              "code": "PPO",
+              "display": "preferred provider organization policy"
+            }
+          ]
+        },
+        "policyHolder": {
+          "display": "Cayden Abbott"
+        },
+        "subscriber": {
+          "display": "Cayden Abbott"
+        },
+        "beneficiary": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "relationship": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/policyholder-relationship",
+              "code": "self",
+              "display": "Self"
+            }
+          ]
+        },
+        "period": {
+          "start": "2018-11-04",
+          "end": "2019-11-04"
+        },
+        "payor": [
+          {
+            "reference": "Organization/claim-8c651f04",
+            "type": "Organization"
+          }
+        ],
+        "order": 1
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Condition/claim-52cadc42",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "claim-52cadc42",
+        "meta": {
+          "versionId": "2",
+          "lastUpdated": "2024-04-11T22:15:00.000+00:00",
+          "source": "#Umx1H5WaIl3nutB8"
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "encounter-diagnosis",
+                "display": "Encounter Diagnosis"
+              }
+            ],
+            "text": "Encounter Diagnosis"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://id.who.int/icd/release/10/2019",
+              "code": "A74.9",
+              "display": "Chlamydial infection, unspecified"
+            }
+          ],
+          "text": "Chlamydial infection, unspecified"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Account/claim-244ca37a",
+      "resource": {
+        "resourceType": "Account",
+        "id": "claim-244ca37a",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2022-01-06T13:57:52.000+00:00",
+          "source": "#84caf125c9ce2e7d"
+        },
+        "identifier": [
+          {
+            "system": "http://iol.health.com/Account",
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+              "code": "PBILLACCT",
+              "display": "Patient Billing Acount"
+            }
+          ]
+        },
+        "subject": [
+          {
+            "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+            "type": "Patient"
+          }
+        ],
+        "servicePeriod": {
+          "start": "2020-03-04",
+          "end": "2020-03-04"
+        },
+        "coverage": [
+          {
+            "priority": 6
+          }
+        ],
+        "owner": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "guarantor": [
+          {
+            "party": {
+              "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+              "type": "Patient"
+            },
+            "period": {
+              "start": "2020-03-04",
+              "end": "2020-03-08"
+            }
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Account/claim-169db2e3",
+      "resource": {
+        "resourceType": "Account",
+        "id": "claim-169db2e3",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2022-01-06T14:00:16.000+00:00",
+          "source": "#06ac9085f9272c72"
+        },
+        "identifier": [
+          {
+            "system": "http://iol.health.com/Account",
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+              "code": "PBILLACCT",
+              "display": "Patient Billing Acount"
+            }
+          ]
+        },
+        "subject": [
+          {
+            "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+            "type": "Patient"
+          }
+        ],
+        "servicePeriod": {
+          "start": "2020-03-04",
+          "end": "2020-03-04"
+        },
+        "coverage": [
+          {
+            "priority": 5
+          }
+        ],
+        "owner": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "guarantor": [
+          {
+            "party": {
+              "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+              "type": "Patient"
+            },
+            "period": {
+              "start": "2020-03-04",
+              "end": "2020-03-08"
+            }
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Account/claim-46eced41",
+      "resource": {
+        "resourceType": "Account",
+        "id": "claim-46eced41",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2022-01-06T14:00:45.000+00:00",
+          "source": "#d953e9e0f4bd8a67"
+        },
+        "identifier": [
+          {
+            "system": "http://iol.health.com/Account",
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+              "code": "PBILLACCT",
+              "display": "Patient Billing Acount"
+            }
+          ]
+        },
+        "subject": [
+          {
+            "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+            "type": "Patient"
+          }
+        ],
+        "servicePeriod": {
+          "start": "2020-03-02",
+          "end": "2020-03-03"
+        },
+        "coverage": [
+          {
+            "priority": 2
+          }
+        ],
+        "owner": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "guarantor": [
+          {
+            "party": {
+              "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+              "type": "Patient"
+            },
+            "period": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Account/claim-b3adf1d0",
+      "resource": {
+        "resourceType": "Account",
+        "id": "claim-b3adf1d0",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2022-01-06T14:02:45.000+00:00",
+          "source": "#2a0706a058188286"
+        },
+        "identifier": [
+          {
+            "system": "http://iol.health.com/Account",
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+              "code": "PBILLACCT",
+              "display": "Patient Billing Acount"
+            }
+          ]
+        },
+        "subject": [
+          {
+            "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+            "type": "Patient"
+          }
+        ],
+        "servicePeriod": {
+          "start": "2019-05-02",
+          "end": "2019-05-02"
+        },
+        "coverage": [
+          {
+            "priority": 6
+          }
+        ],
+        "owner": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "guarantor": [
+          {
+            "party": {
+              "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+              "type": "Patient"
+            },
+            "period": {
+              "end": "2019-05-07"
+            }
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Account/claim-4b5a64cc",
+      "resource": {
+        "resourceType": "Account",
+        "id": "claim-4b5a64cc",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2022-01-06T14:04:53.000+00:00",
+          "source": "#124943d0c5608988"
+        },
+        "identifier": [
+          {
+            "system": "http://iol.health.com/Account",
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+              "code": "PBILLACCT",
+              "display": "Patient Billing Acount"
+            }
+          ]
+        },
+        "subject": [
+          {
+            "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+            "type": "Patient"
+          }
+        ],
+        "coverage": [
+          {
+            "priority": 2
+          }
+        ],
+        "owner": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "guarantor": [
+          {
+            "party": {
+              "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+              "type": "Patient"
+            }
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Encounter/d96030446269cb1e0a862d",
+      "resource": {
+        "resourceType": "Encounter",
+        "id": "d96030446269cb1e0a862d",
+        "meta": {
+          "versionId": "14",
+          "lastUpdated": "2024-04-11T22:06:33.000+00:00",
+          "source": "#tiG9A1ye7499UPBA"
+        },
+        "identifier": [
+          {
+            "system": "http://better.health.insurance.com/Encounter",
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "in-progress",
+        "class": {
+          "system": "https://hl7.org/fhir/R4/codesystem-service-type.html",
+          "code": "441",
+          "display": "Sexually Transmitted"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "participant": [
+          {
+            "period": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            },
+            "individual": {
+              "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+              "type": "Practitioner"
+            }
+          }
+        ],
+        "period": {
+          "start": "2024-03-11",
+          "end": "2024-04-11"
+        },
+        "reasonCode": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "2339001",
+                "display": "Sexual overexposure"
+              }
+            ],
+            "text": "Sexual overexposure"
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "Condition/claim-52cadc42",
+            "type": "Condition"
+          }
+        ],
+        "diagnosis": [
+          {
+            "condition": {
+              "reference": "Condition/claim-52cadc42",
+              "type": "Condition"
+            }
+          }
+        ],
+        "account": [
+          {
+            "reference": "Account/claim-169db2e3",
+            "type": "Account"
+          },
+          {
+            "reference": "Account/claim-46eced41",
+            "type": "Account"
+          },
+          {
+            "reference": "Account/claim-b3adf1d0",
+            "type": "Account"
+          },
+          {
+            "reference": "Account/claim-4b5a64cc",
+            "type": "Account"
+          }
+        ],
+        "partOf": {
+          "reference": "Encounter/d96030446269cb1e0a862d"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-c21b87d3",
+      "resource": {
+        "resourceType": "Procedure",
+        "id": "claim-c21b87d3",
+        "meta": {
+          "versionId": "4",
+          "lastUpdated": "2022-01-06T18:36:45.000+00:00",
+          "source": "#9a84933aa8eb99fb"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "completed",
+        "code": {
+          "coding": [
+            {
+              "system": "https://clinicaltables.nlm.nih.gov/apidoc/hcpcs/v3/doc.html",
+              "code": "90471",
+              "display": "Immunization admin"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "encounter": {
+          "reference": "Encounter/d96030446269cb1e0a862d",
+          "type": "Encounter"
+        },
+        "recorder": {
+          "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "asserter": {
+          "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "performer": [
+          {
+            "actor": {
+              "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+              "type": "Practitioner"
+            }
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "Condition/claim-52cadc42",
+            "type": "Condition"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-c93e82d0",
+      "resource": {
+        "resourceType": "Procedure",
+        "id": "claim-c93e82d0",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2022-01-06T18:36:46.000+00:00",
+          "source": "#9a84933aa8eb99fb"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "completed",
+        "code": {
+          "coding": [
+            {
+              "system": "https://clinicaltables.nlm.nih.gov/apidoc/hcpcs/v3/doc.html",
+              "code": "90687",
+              "display": "Vaccines, Toxoids"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "encounter": {
+          "reference": "Encounter/d96030446269cb1e0a862d",
+          "type": "Encounter"
+        },
+        "recorder": {
+          "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "asserter": {
+          "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "performer": [
+          {
+            "actor": {
+              "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+              "type": "Practitioner"
+            }
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "Condition/claim-52cadc42",
+            "type": "Condition"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-406f2882",
+      "resource": {
+        "resourceType": "Procedure",
+        "id": "claim-406f2882",
+        "meta": {
+          "versionId": "4",
+          "lastUpdated": "2022-01-06T18:36:46.000+00:00",
+          "source": "#9a84933aa8eb99fb"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "completed",
+        "code": {
+          "coding": [
+            {
+              "system": "https://clinicaltables.nlm.nih.gov/apidoc/hcpcs/v3/doc.html",
+              "code": "99392",
+              "display": "Prev visit, est, age 1-4"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "encounter": {
+          "reference": "Encounter/d96030446269cb1e0a862d",
+          "type": "Encounter"
+        },
+        "recorder": {
+          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "asserter": {
+          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "performer": [
+          {
+            "actor": {
+              "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+              "type": "Practitioner"
+            }
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "Condition/claim-52cadc42",
+            "type": "Condition"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-81b6ac78",
+      "resource": {
+        "resourceType": "Procedure",
+        "id": "claim-81b6ac78",
+        "meta": {
+          "versionId": "4",
+          "lastUpdated": "2022-01-06T18:36:46.000+00:00",
+          "source": "#9a84933aa8eb99fb"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "completed",
+        "code": {
+          "coding": [
+            {
+              "system": "https://clinicaltables.nlm.nih.gov/apidoc/hcpcs/v3/doc.html",
+              "code": "90749",
+              "display": "Vaccine toxoid"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "encounter": {
+          "reference": "Encounter/d96030446269cb1e0a862d",
+          "type": "Encounter"
+        },
+        "recorder": {
+          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "asserter": {
+          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "performer": [
+          {
+            "actor": {
+              "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+              "type": "Practitioner"
+            }
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "Condition/claim-52cadc42",
+            "type": "Condition"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-dcd50a48",
+      "resource": {
+        "resourceType": "Procedure",
+        "id": "claim-dcd50a48",
+        "meta": {
+          "versionId": "4",
+          "lastUpdated": "2022-01-06T18:36:47.000+00:00",
+          "source": "#9a84933aa8eb99fb"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "completed",
+        "code": {
+          "coding": [
+            {
+              "system": "https://clinicaltables.nlm.nih.gov/apidoc/hcpcs/v3/doc.html",
+              "code": "99213",
+              "display": "Office/outpatient visit, est"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "encounter": {
+          "reference": "Encounter/d96030446269cb1e0a862d",
+          "type": "Encounter"
+        },
+        "recorder": {
+          "reference": "Practitioner/1346205721d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "asserter": {
+          "reference": "Practitioner/1346205721d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "performer": [
+          {
+            "actor": {
+              "reference": "Practitioner/1346205721d96030446269cb1e0a862d",
+              "type": "Practitioner"
+            }
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "Condition/claim-52cadc42",
+            "type": "Condition"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-9acfed3b",
+      "resource": {
+        "resourceType": "Procedure",
+        "id": "claim-9acfed3b",
+        "meta": {
+          "versionId": "4",
+          "lastUpdated": "2022-01-06T18:37:28.000+00:00",
+          "source": "#64262b65dc752d6a"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "completed",
+        "code": {
+          "coding": [
+            {
+              "system": "https://clinicaltables.nlm.nih.gov/apidoc/hcpcs/v3/doc.html",
+              "code": "90698",
+              "display": "Dtap-hib-ip vaccine, im"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "encounter": {
+          "reference": "Encounter/d96030446269cb1e0a862d",
+          "type": "Encounter"
+        },
+        "recorder": {
+          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "asserter": {
+          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "performer": [
+          {
+            "actor": {
+              "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+              "type": "Practitioner"
+            }
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "Condition/claim-52cadc42",
+            "type": "Condition"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-0f2c37d1",
+      "resource": {
+        "resourceType": "Procedure",
+        "id": "claim-0f2c37d1",
+        "meta": {
+          "versionId": "4",
+          "lastUpdated": "2022-01-06T18:37:28.000+00:00",
+          "source": "#64262b65dc752d6a"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "completed",
+        "code": {
+          "coding": [
+            {
+              "system": "https://clinicaltables.nlm.nih.gov/apidoc/hcpcs/v3/doc.html",
+              "code": "99222",
+              "display": "Initial hospital care"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "encounter": {
+          "reference": "Encounter/d96030446269cb1e0a862d",
+          "type": "Encounter"
+        },
+        "recorder": {
+          "reference": "Practitioner/1447213657d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "asserter": {
+          "reference": "Practitioner/1447213657d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "performer": [
+          {
+            "actor": {
+              "reference": "Practitioner/1447213657d96030446269cb1e0a862d",
+              "type": "Practitioner"
+            }
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "Condition/claim-52cadc42",
+            "type": "Condition"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-ed483d11",
+      "resource": {
+        "resourceType": "Procedure",
+        "id": "claim-ed483d11",
+        "meta": {
+          "versionId": "4",
+          "lastUpdated": "2022-01-06T18:37:28.000+00:00",
+          "source": "#64262b65dc752d6a"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "completed",
+        "code": {
+          "coding": [
+            {
+              "system": "https://clinicaltables.nlm.nih.gov/apidoc/hcpcs/v3/doc.html",
+              "code": "J1100 ",
+              "display": "Dexamethasone sodium phos"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "encounter": {
+          "reference": "Encounter/d96030446269cb1e0a862d",
+          "type": "Encounter"
+        },
+        "recorder": {
+          "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "asserter": {
+          "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "performer": [
+          {
+            "actor": {
+              "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+              "type": "Practitioner"
+            }
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "Condition/claim-52cadc42",
+            "type": "Condition"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-9374adbd",
+      "resource": {
+        "resourceType": "Procedure",
+        "id": "claim-9374adbd",
+        "meta": {
+          "versionId": "4",
+          "lastUpdated": "2022-01-06T18:37:28.000+00:00",
+          "source": "#64262b65dc752d6a"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "completed",
+        "code": {
+          "coding": [
+            {
+              "system": "https://clinicaltables.nlm.nih.gov/apidoc/hcpcs/v3/doc.html",
+              "code": "70360",
+              "display": "X-ray exam of neck"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "encounter": {
+          "reference": "Encounter/d96030446269cb1e0a862d",
+          "type": "Encounter"
+        },
+        "recorder": {
+          "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "asserter": {
+          "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "performer": [
+          {
+            "actor": {
+              "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+              "type": "Practitioner"
+            }
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "Condition/claim-52cadc42",
+            "type": "Condition"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-a725b307",
+      "resource": {
+        "resourceType": "Procedure",
+        "id": "claim-a725b307",
+        "meta": {
+          "versionId": "4",
+          "lastUpdated": "2022-01-06T18:37:28.000+00:00",
+          "source": "#64262b65dc752d6a"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "completed",
+        "code": {
+          "coding": [
+            {
+              "system": "https://clinicaltables.nlm.nih.gov/apidoc/hcpcs/v3/doc.html",
+              "code": "99284",
+              "display": "Emergency dept visit"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "encounter": {
+          "reference": "Encounter/d96030446269cb1e0a862d",
+          "type": "Encounter"
+        },
+        "recorder": {
+          "reference": "Practitioner/1629377890d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "asserter": {
+          "reference": "Practitioner/1629377890d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "performer": [
+          {
+            "actor": {
+              "reference": "Practitioner/1629377890d96030446269cb1e0a862d",
+              "type": "Practitioner"
+            }
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "Condition/claim-52cadc42",
+            "type": "Condition"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-59e90339",
+      "resource": {
+        "resourceType": "Procedure",
+        "id": "claim-59e90339",
+        "meta": {
+          "versionId": "4",
+          "lastUpdated": "2022-01-06T18:37:29.000+00:00",
+          "source": "#64262b65dc752d6a"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "completed",
+        "code": {
+          "coding": [
+            {
+              "system": "https://clinicaltables.nlm.nih.gov/apidoc/hcpcs/v3/doc.html",
+              "code": "99239",
+              "display": "Hospital discharge day"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "encounter": {
+          "reference": "Encounter/d96030446269cb1e0a862d",
+          "type": "Encounter"
+        },
+        "recorder": {
+          "reference": "Practitioner/1326321084d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "asserter": {
+          "reference": "Practitioner/1326321084d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "performer": [
+          {
+            "actor": {
+              "reference": "Practitioner/1326321084d96030446269cb1e0a862d",
+              "type": "Practitioner"
+            }
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "Condition/claim-52cadc42",
+            "type": "Condition"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-4565d08e",
+      "resource": {
+        "resourceType": "Procedure",
+        "id": "claim-4565d08e",
+        "meta": {
+          "versionId": "4",
+          "lastUpdated": "2022-01-06T18:37:29.000+00:00",
+          "source": "#64262b65dc752d6a"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "completed",
+        "code": {
+          "coding": [
+            {
+              "system": "https://clinicaltables.nlm.nih.gov/apidoc/hcpcs/v3/doc.html",
+              "code": "99203",
+              "display": "Office/outpatient visit, new"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "encounter": {
+          "reference": "Encounter/d96030446269cb1e0a862d",
+          "type": "Encounter"
+        },
+        "recorder": {
+          "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "asserter": {
+          "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "performer": [
+          {
+            "actor": {
+              "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+              "type": "Practitioner"
+            }
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "Condition/claim-52cadc42",
+            "type": "Condition"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-56ba375e",
+      "resource": {
+        "resourceType": "Procedure",
+        "id": "claim-56ba375e",
+        "meta": {
+          "versionId": "4",
+          "lastUpdated": "2022-01-06T18:37:29.000+00:00",
+          "source": "#64262b65dc752d6a"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "completed",
+        "code": {
+          "coding": [
+            {
+              "system": "https://clinicaltables.nlm.nih.gov/apidoc/hcpcs/v3/doc.html",
+              "code": "99214",
+              "display": "Office/outpatient visit, est"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "encounter": {
+          "reference": "Encounter/d96030446269cb1e0a862d",
+          "type": "Encounter"
+        },
+        "recorder": {
+          "reference": "Practitioner/1275598047d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "asserter": {
+          "reference": "Practitioner/1275598047d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "performer": [
+          {
+            "actor": {
+              "reference": "Practitioner/1275598047d96030446269cb1e0a862d",
+              "type": "Practitioner"
+            }
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "Condition/claim-52cadc42",
+            "type": "Condition"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-79583fe4",
+      "resource": {
+        "resourceType": "Procedure",
+        "id": "claim-79583fe4",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2022-01-06T18:49:57.000+00:00",
+          "source": "#3b0387fa3576821c"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "completed",
+        "code": {
+          "coding": [
+            {
+              "system": "https://clinicaltables.nlm.nih.gov/apidoc/hcpcs/v3/doc.html"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "encounter": {
+          "reference": "Encounter/d96030446269cb1e0a862d",
+          "type": "Encounter"
+        },
+        "performedPeriod": {
+          "start": "2020-03-02",
+          "end": "2020-03-03"
+        },
+        "recorder": {
+          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "asserter": {
+          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "performer": [
+          {
+            "actor": {
+              "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+              "type": "Practitioner"
+            }
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "Condition/claim-52cadc42",
+            "type": "Condition"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-f70ab607",
+      "resource": {
+        "resourceType": "Procedure",
+        "id": "claim-f70ab607",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2022-01-06T18:49:59.000+00:00",
+          "source": "#3b0387fa3576821c"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "completed",
+        "code": {
+          "coding": [
+            {
+              "system": "https://clinicaltables.nlm.nih.gov/apidoc/hcpcs/v3/doc.html"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "encounter": {
+          "reference": "Encounter/d96030446269cb1e0a862d",
+          "type": "Encounter"
+        },
+        "performedPeriod": {
+          "start": "2020-03-02",
+          "end": "2020-03-03"
+        },
+        "recorder": {
+          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "asserter": {
+          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "performer": [
+          {
+            "actor": {
+              "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+              "type": "Practitioner"
+            }
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "Condition/claim-52cadc42",
+            "type": "Condition"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-dd27652b",
+      "resource": {
+        "resourceType": "Claim",
+        "id": "claim-dd27652b",
+        "meta": {
+          "versionId": "5",
+          "lastUpdated": "2022-04-07T21:32:32.000+00:00",
+          "source": "#a371171990e52a2e"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "institutional",
+              "display": "Institutional"
+            }
+          ]
+        },
+        "use": "claim",
+        "patient": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "billablePeriod": {
+          "start": "2020-03-02",
+          "end": "2020-03-03"
+        },
+        "created": "2020-03-10",
+        "enterer": {
+          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "insurer": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "provider": {
+          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "payee": {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/payeetype",
+                "code": "provider",
+                "display": "Provider"
+              }
+            ]
+          },
+          "party": {
+            "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+            "type": "Practitioner"
+          }
+        },
+        "diagnosis": [
+          {
+            "sequence": 1,
+            "diagnosisReference": {
+              "reference": "Condition/claim-52cadc42",
+              "type": "Condition"
+            },
+            "onAdmission": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/ex-diagnosis-on-admission",
+                  "code": "y",
+                  "display": "Yes"
+                }
+              ]
+            }
+          }
+        ],
+        "procedure": [
+          {
+            "sequence": 1,
+            "date": "2020-03-02"
+          }
+        ],
+        "insurance": [
+          {
+            "sequence": 1,
+            "coverage": {
+              "reference": "Coverage/claim-1788c921",
+              "type": "Coverage"
+            }
+          }
+        ],
+        "item": [
+          {
+            "sequence": 1,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "450",
+                  "display": "Emergency Room"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          },
+          {
+            "sequence": 2,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "123",
+                  "display": "Pediatric"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          },
+          {
+            "sequence": 3,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "410",
+                  "display": "Respiratory Services"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          },
+          {
+            "sequence": 4,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "250",
+                  "display": "Pharmacy (Also see 063X, an extension of 250X)"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          },
+          {
+            "sequence": 5,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "252",
+                  "display": "Nongeneric drugs"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          }
+        ],
+        "total": {
+          "value": 3344,
+          "currency": "USD"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-f029ba5c",
+      "resource": {
+        "resourceType": "Claim",
+        "id": "claim-f029ba5c",
+        "meta": {
+          "versionId": "5",
+          "lastUpdated": "2022-04-07T21:32:32.000+00:00",
+          "source": "#a371171990e52a2e"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "institutional",
+              "display": "Institutional"
+            }
+          ]
+        },
+        "use": "claim",
+        "patient": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "billablePeriod": {
+          "start": "2020-03-02",
+          "end": "2020-03-03"
+        },
+        "created": "2020-03-10",
+        "enterer": {
+          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "insurer": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "provider": {
+          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "payee": {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/payeetype",
+                "code": "provider",
+                "display": "Provider"
+              }
+            ]
+          },
+          "party": {
+            "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+            "type": "Practitioner"
+          }
+        },
+        "diagnosis": [
+          {
+            "sequence": 1,
+            "diagnosisReference": {
+              "reference": "Condition/claim-52cadc42",
+              "type": "Condition"
+            },
+            "onAdmission": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/ex-diagnosis-on-admission",
+                  "code": "y",
+                  "display": "Yes"
+                }
+              ]
+            }
+          }
+        ],
+        "procedure": [
+          {
+            "sequence": 1,
+            "date": "2020-03-02"
+          }
+        ],
+        "insurance": [
+          {
+            "sequence": 1,
+            "coverage": {
+              "reference": "Coverage/claim-1788c921",
+              "type": "Coverage"
+            }
+          }
+        ],
+        "item": [
+          {
+            "sequence": 1,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "450",
+                  "display": "Emergency Room"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          },
+          {
+            "sequence": 2,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "123",
+                  "display": "Pediatric"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          },
+          {
+            "sequence": 3,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "410",
+                  "display": "Respiratory Services"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          },
+          {
+            "sequence": 4,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "250",
+                  "display": "Pharmacy (Also see 063X, an extension of 250X)"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          },
+          {
+            "sequence": 5,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "252",
+                  "display": "Nongeneric drugs"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          }
+        ],
+        "total": {
+          "value": 3294,
+          "currency": "USD"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-5bf6f7d8",
+      "resource": {
+        "resourceType": "Claim",
+        "id": "claim-5bf6f7d8",
+        "meta": {
+          "versionId": "5",
+          "lastUpdated": "2022-04-07T21:32:32.000+00:00",
+          "source": "#a371171990e52a2e"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "institutional",
+              "display": "Institutional"
+            }
+          ]
+        },
+        "use": "claim",
+        "patient": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "billablePeriod": {
+          "start": "2020-03-02",
+          "end": "2020-03-03"
+        },
+        "created": "2020-03-10",
+        "enterer": {
+          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "insurer": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "provider": {
+          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "payee": {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/payeetype",
+                "code": "provider",
+                "display": "Provider"
+              }
+            ]
+          },
+          "party": {
+            "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+            "type": "Practitioner"
+          }
+        },
+        "diagnosis": [
+          {
+            "sequence": 1,
+            "diagnosisReference": {
+              "reference": "Condition/claim-52cadc42",
+              "type": "Condition"
+            },
+            "onAdmission": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/ex-diagnosis-on-admission",
+                  "code": "y",
+                  "display": "Yes"
+                }
+              ]
+            }
+          }
+        ],
+        "procedure": [
+          {
+            "sequence": 1,
+            "date": "2020-03-02"
+          }
+        ],
+        "insurance": [
+          {
+            "sequence": 1,
+            "coverage": {
+              "reference": "Coverage/claim-1788c921",
+              "type": "Coverage"
+            }
+          }
+        ],
+        "item": [
+          {
+            "sequence": 1,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "450",
+                  "display": "Emergency Room"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          },
+          {
+            "sequence": 2,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "123",
+                  "display": "Pediatric"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          },
+          {
+            "sequence": 3,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "410",
+                  "display": "Respiratory Services"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          },
+          {
+            "sequence": 4,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "250",
+                  "display": "Pharmacy (Also see 063X, an extension of 250X)"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          },
+          {
+            "sequence": 5,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "252",
+                  "display": "Nongeneric drugs"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          }
+        ],
+        "total": {
+          "value": 684,
+          "currency": "USD"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-96dbab39",
+      "resource": {
+        "resourceType": "Claim",
+        "id": "claim-96dbab39",
+        "meta": {
+          "versionId": "5",
+          "lastUpdated": "2022-04-07T21:32:32.000+00:00",
+          "source": "#a371171990e52a2e"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "institutional",
+              "display": "Institutional"
+            }
+          ]
+        },
+        "use": "claim",
+        "patient": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "billablePeriod": {
+          "start": "2020-03-02",
+          "end": "2020-03-03"
+        },
+        "created": "2020-03-10",
+        "enterer": {
+          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "insurer": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "provider": {
+          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "payee": {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/payeetype",
+                "code": "provider",
+                "display": "Provider"
+              }
+            ]
+          },
+          "party": {
+            "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+            "type": "Practitioner"
+          }
+        },
+        "diagnosis": [
+          {
+            "sequence": 1,
+            "diagnosisReference": {
+              "reference": "Condition/claim-52cadc42",
+              "type": "Condition"
+            },
+            "onAdmission": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/ex-diagnosis-on-admission",
+                  "code": "y",
+                  "display": "Yes"
+                }
+              ]
+            }
+          }
+        ],
+        "procedure": [
+          {
+            "sequence": 1,
+            "date": "2020-03-02"
+          }
+        ],
+        "insurance": [
+          {
+            "sequence": 1,
+            "coverage": {
+              "reference": "Coverage/claim-1788c921",
+              "type": "Coverage"
+            }
+          }
+        ],
+        "item": [
+          {
+            "sequence": 1,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "450",
+                  "display": "Emergency Room"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          },
+          {
+            "sequence": 2,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "123",
+                  "display": "Pediatric"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          },
+          {
+            "sequence": 3,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "410",
+                  "display": "Respiratory Services"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          },
+          {
+            "sequence": 4,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "250",
+                  "display": "Pharmacy (Also see 063X, an extension of 250X)"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          },
+          {
+            "sequence": 5,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "252",
+                  "display": "Nongeneric drugs"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          }
+        ],
+        "total": {
+          "value": 31,
+          "currency": "USD"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-dac4f593",
+      "resource": {
+        "resourceType": "Claim",
+        "id": "claim-dac4f593",
+        "meta": {
+          "versionId": "5",
+          "lastUpdated": "2022-04-07T21:32:33.000+00:00",
+          "source": "#a371171990e52a2e"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "institutional",
+              "display": "Institutional"
+            }
+          ]
+        },
+        "use": "claim",
+        "patient": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "billablePeriod": {
+          "start": "2020-03-02",
+          "end": "2020-03-03"
+        },
+        "created": "2020-03-10",
+        "enterer": {
+          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "insurer": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "provider": {
+          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "payee": {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/payeetype",
+                "code": "provider",
+                "display": "Provider"
+              }
+            ]
+          },
+          "party": {
+            "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+            "type": "Practitioner"
+          }
+        },
+        "diagnosis": [
+          {
+            "sequence": 1,
+            "diagnosisReference": {
+              "reference": "Condition/claim-52cadc42",
+              "type": "Condition"
+            },
+            "onAdmission": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/ex-diagnosis-on-admission",
+                  "code": "y",
+                  "display": "Yes"
+                }
+              ]
+            }
+          }
+        ],
+        "procedure": [
+          {
+            "sequence": 1,
+            "date": "2020-03-02"
+          }
+        ],
+        "insurance": [
+          {
+            "sequence": 1,
+            "coverage": {
+              "reference": "Coverage/claim-1788c921",
+              "type": "Coverage"
+            }
+          }
+        ],
+        "item": [
+          {
+            "sequence": 1,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "450",
+                  "display": "Emergency Room"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          },
+          {
+            "sequence": 2,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "123",
+                  "display": "Pediatric"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          },
+          {
+            "sequence": 3,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "410",
+                  "display": "Respiratory Services"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          },
+          {
+            "sequence": 4,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "250",
+                  "display": "Pharmacy (Also see 063X, an extension of 250X)"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          },
+          {
+            "sequence": 5,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "252",
+                  "display": "Nongeneric drugs"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          }
+        ],
+        "total": {
+          "value": 33,
+          "currency": "USD"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-009b92b4",
+      "resource": {
+        "resourceType": "Claim",
+        "id": "claim-009b92b4",
+        "meta": {
+          "versionId": "3",
+          "lastUpdated": "2022-02-22T18:15:50.000+00:00",
+          "source": "#ca5bebfe66e79eee"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "professional",
+              "display": "Professional"
+            }
+          ]
+        },
+        "use": "claim",
+        "patient": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "billablePeriod": {
+          "end": "2019-05-07"
+        },
+        "enterer": {
+          "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "insurer": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "provider": {
+          "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "payee": {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/payeetype",
+                "code": "provider",
+                "display": "Provider"
+              }
+            ]
+          },
+          "party": {
+            "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+            "type": "Practitioner"
+          }
+        },
+        "diagnosis": [
+          {
+            "sequence": 1,
+            "diagnosisReference": {
+              "reference": "Condition/claim-52cadc42",
+              "type": "Condition"
+            },
+            "onAdmission": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/ex-diagnosis-on-admission"
+                }
+              ]
+            }
+          }
+        ],
+        "procedure": [
+          {
+            "sequence": 1
+          }
+        ],
+        "insurance": [
+          {
+            "sequence": 1,
+            "coverage": {
+              "reference": "Coverage/claim-1788c921",
+              "type": "Coverage"
+            }
+          }
+        ],
+        "total": {
+          "value": 31,
+          "currency": "USD"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-a479f532",
+      "resource": {
+        "resourceType": "Claim",
+        "id": "claim-a479f532",
+        "meta": {
+          "versionId": "3",
+          "lastUpdated": "2022-02-22T18:15:50.000+00:00",
+          "source": "#ca5bebfe66e79eee"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "professional",
+              "display": "Professional"
+            }
+          ]
+        },
+        "use": "claim",
+        "patient": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "billablePeriod": {
+          "end": "2019-05-07"
+        },
+        "enterer": {
+          "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "insurer": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "provider": {
+          "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "payee": {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/payeetype",
+                "code": "provider",
+                "display": "Provider"
+              }
+            ]
+          },
+          "party": {
+            "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+            "type": "Practitioner"
+          }
+        },
+        "diagnosis": [
+          {
+            "sequence": 1,
+            "diagnosisReference": {
+              "reference": "Condition/claim-52cadc42",
+              "type": "Condition"
+            },
+            "onAdmission": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/ex-diagnosis-on-admission"
+                }
+              ]
+            }
+          }
+        ],
+        "procedure": [
+          {
+            "sequence": 1
+          }
+        ],
+        "insurance": [
+          {
+            "sequence": 1,
+            "coverage": {
+              "reference": "Coverage/claim-1788c921",
+              "type": "Coverage"
+            }
+          }
+        ],
+        "total": {
+          "value": 15,
+          "currency": "USD"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-31d41fe3",
+      "resource": {
+        "resourceType": "Claim",
+        "id": "claim-31d41fe3",
+        "meta": {
+          "versionId": "3",
+          "lastUpdated": "2022-02-22T18:15:51.000+00:00",
+          "source": "#ca5bebfe66e79eee"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "professional",
+              "display": "Professional"
+            }
+          ]
+        },
+        "use": "claim",
+        "patient": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "billablePeriod": {
+          "end": "2019-08-20"
+        },
+        "enterer": {
+          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "insurer": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "provider": {
+          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "payee": {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/payeetype",
+                "code": "provider",
+                "display": "Provider"
+              }
+            ]
+          },
+          "party": {
+            "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+            "type": "Practitioner"
+          }
+        },
+        "diagnosis": [
+          {
+            "sequence": 1,
+            "diagnosisReference": {
+              "reference": "Condition/claim-52cadc42",
+              "type": "Condition"
+            },
+            "onAdmission": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/ex-diagnosis-on-admission"
+                }
+              ]
+            }
+          }
+        ],
+        "procedure": [
+          {
+            "sequence": 1
+          }
+        ],
+        "insurance": [
+          {
+            "sequence": 1,
+            "coverage": {
+              "reference": "Coverage/claim-1788c921",
+              "type": "Coverage"
+            }
+          }
+        ],
+        "total": {
+          "value": 31,
+          "currency": "USD"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-049b4d31",
+      "resource": {
+        "resourceType": "Claim",
+        "id": "claim-049b4d31",
+        "meta": {
+          "versionId": "3",
+          "lastUpdated": "2022-02-22T18:15:51.000+00:00",
+          "source": "#ca5bebfe66e79eee"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "professional",
+              "display": "Professional"
+            }
+          ]
+        },
+        "use": "claim",
+        "patient": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "billablePeriod": {
+          "end": "2019-08-20"
+        },
+        "enterer": {
+          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "insurer": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "provider": {
+          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "payee": {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/payeetype",
+                "code": "provider",
+                "display": "Provider"
+              }
+            ]
+          },
+          "party": {
+            "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+            "type": "Practitioner"
+          }
+        },
+        "diagnosis": [
+          {
+            "sequence": 1,
+            "diagnosisReference": {
+              "reference": "Condition/claim-52cadc42",
+              "type": "Condition"
+            },
+            "onAdmission": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/ex-diagnosis-on-admission"
+                }
+              ]
+            }
+          }
+        ],
+        "procedure": [
+          {
+            "sequence": 1
+          }
+        ],
+        "insurance": [
+          {
+            "sequence": 1,
+            "coverage": {
+              "reference": "Coverage/claim-1788c921",
+              "type": "Coverage"
+            }
+          }
+        ],
+        "total": {
+          "value": 110,
+          "currency": "USD"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-559003bb",
+      "resource": {
+        "resourceType": "Claim",
+        "id": "claim-559003bb",
+        "meta": {
+          "versionId": "3",
+          "lastUpdated": "2022-02-22T18:15:51.000+00:00",
+          "source": "#ca5bebfe66e79eee"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "professional",
+              "display": "Professional"
+            }
+          ]
+        },
+        "use": "claim",
+        "patient": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "billablePeriod": {
+          "end": "2019-08-20"
+        },
+        "enterer": {
+          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "insurer": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "provider": {
+          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "payee": {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/payeetype",
+                "code": "provider",
+                "display": "Provider"
+              }
+            ]
+          },
+          "party": {
+            "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+            "type": "Practitioner"
+          }
+        },
+        "diagnosis": [
+          {
+            "sequence": 1,
+            "diagnosisReference": {
+              "reference": "Condition/claim-52cadc42",
+              "type": "Condition"
+            },
+            "onAdmission": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/ex-diagnosis-on-admission"
+                }
+              ]
+            }
+          }
+        ],
+        "procedure": [
+          {
+            "sequence": 1
+          }
+        ],
+        "insurance": [
+          {
+            "sequence": 1,
+            "coverage": {
+              "reference": "Coverage/claim-1788c921",
+              "type": "Coverage"
+            }
+          }
+        ],
+        "total": {
+          "value": 50,
+          "currency": "USD"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-95176e6f",
+      "resource": {
+        "resourceType": "Claim",
+        "id": "claim-95176e6f",
+        "meta": {
+          "versionId": "3",
+          "lastUpdated": "2022-02-22T18:15:52.000+00:00",
+          "source": "#ca5bebfe66e79eee"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "professional",
+              "display": "Professional"
+            }
+          ]
+        },
+        "use": "claim",
+        "patient": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "billablePeriod": {
+          "end": "2019-09-24"
+        },
+        "enterer": {
+          "reference": "Practitioner/1346205721d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "insurer": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "provider": {
+          "reference": "Practitioner/1346205721d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "payee": {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/payeetype",
+                "code": "provider",
+                "display": "Provider"
+              }
+            ]
+          },
+          "party": {
+            "reference": "Practitioner/1346205721d96030446269cb1e0a862d",
+            "type": "Practitioner"
+          }
+        },
+        "diagnosis": [
+          {
+            "sequence": 1,
+            "diagnosisReference": {
+              "reference": "Condition/claim-52cadc42",
+              "type": "Condition"
+            },
+            "onAdmission": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/ex-diagnosis-on-admission"
+                }
+              ]
+            }
+          }
+        ],
+        "procedure": [
+          {
+            "sequence": 1
+          }
+        ],
+        "insurance": [
+          {
+            "sequence": 1,
+            "coverage": {
+              "reference": "Coverage/claim-1788c921",
+              "type": "Coverage"
+            }
+          }
+        ],
+        "total": {
+          "value": 81,
+          "currency": "USD"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-878351bb",
+      "resource": {
+        "resourceType": "Claim",
+        "id": "claim-878351bb",
+        "meta": {
+          "versionId": "3",
+          "lastUpdated": "2022-02-22T18:16:31.000+00:00",
+          "source": "#6887754e6c17d120"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "professional",
+              "display": "Professional"
+            }
+          ]
+        },
+        "use": "claim",
+        "patient": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "billablePeriod": {
+          "end": "2019-02-26"
+        },
+        "enterer": {
+          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "insurer": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "provider": {
+          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "payee": {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/payeetype",
+                "code": "provider",
+                "display": "Provider"
+              }
+            ]
+          },
+          "party": {
+            "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+            "type": "Practitioner"
+          }
+        },
+        "diagnosis": [
+          {
+            "sequence": 1,
+            "diagnosisReference": {
+              "reference": "Condition/claim-52cadc42",
+              "type": "Condition"
+            },
+            "onAdmission": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/ex-diagnosis-on-admission"
+                }
+              ]
+            }
+          }
+        ],
+        "procedure": [
+          {
+            "sequence": 1
+          }
+        ],
+        "insurance": [
+          {
+            "sequence": 1,
+            "coverage": {
+              "reference": "Coverage/claim-1788c921",
+              "type": "Coverage"
+            }
+          }
+        ],
+        "total": {
+          "value": 31,
+          "currency": "USD"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-f4d216fb",
+      "resource": {
+        "resourceType": "Claim",
+        "id": "claim-f4d216fb",
+        "meta": {
+          "versionId": "3",
+          "lastUpdated": "2022-02-22T18:16:31.000+00:00",
+          "source": "#6887754e6c17d120"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "professional",
+              "display": "Professional"
+            }
+          ]
+        },
+        "use": "claim",
+        "patient": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "billablePeriod": {
+          "end": "2019-02-26"
+        },
+        "enterer": {
+          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "insurer": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "provider": {
+          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "payee": {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/payeetype",
+                "code": "provider",
+                "display": "Provider"
+              }
+            ]
+          },
+          "party": {
+            "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+            "type": "Practitioner"
+          }
+        },
+        "diagnosis": [
+          {
+            "sequence": 1,
+            "diagnosisReference": {
+              "reference": "Condition/claim-52cadc42",
+              "type": "Condition"
+            },
+            "onAdmission": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/ex-diagnosis-on-admission"
+                }
+              ]
+            }
+          }
+        ],
+        "procedure": [
+          {
+            "sequence": 1
+          }
+        ],
+        "insurance": [
+          {
+            "sequence": 1,
+            "coverage": {
+              "reference": "Coverage/claim-1788c921",
+              "type": "Coverage"
+            }
+          }
+        ],
+        "total": {
+          "value": 141,
+          "currency": "USD"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-6105bcdc",
+      "resource": {
+        "resourceType": "Claim",
+        "id": "claim-6105bcdc",
+        "meta": {
+          "versionId": "3",
+          "lastUpdated": "2022-02-22T18:16:31.000+00:00",
+          "source": "#6887754e6c17d120"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "professional",
+              "display": "Professional"
+            }
+          ]
+        },
+        "use": "claim",
+        "patient": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "billablePeriod": {
+          "end": "2019-02-26"
+        },
+        "enterer": {
+          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "insurer": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "provider": {
+          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "payee": {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/payeetype",
+                "code": "provider",
+                "display": "Provider"
+              }
+            ]
+          },
+          "party": {
+            "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+            "type": "Practitioner"
+          }
+        },
+        "diagnosis": [
+          {
+            "sequence": 1,
+            "diagnosisReference": {
+              "reference": "Condition/claim-52cadc42",
+              "type": "Condition"
+            },
+            "onAdmission": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/ex-diagnosis-on-admission"
+                }
+              ]
+            }
+          }
+        ],
+        "procedure": [
+          {
+            "sequence": 1
+          }
+        ],
+        "insurance": [
+          {
+            "sequence": 1,
+            "coverage": {
+              "reference": "Coverage/claim-1788c921",
+              "type": "Coverage"
+            }
+          }
+        ],
+        "total": {
+          "value": 110,
+          "currency": "USD"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-198c6388",
+      "resource": {
+        "resourceType": "Claim",
+        "id": "claim-198c6388",
+        "meta": {
+          "versionId": "3",
+          "lastUpdated": "2022-02-22T18:16:31.000+00:00",
+          "source": "#6887754e6c17d120"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "professional",
+              "display": "Professional"
+            }
+          ]
+        },
+        "use": "claim",
+        "patient": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "billablePeriod": {
+          "end": "2020-03-14"
+        },
+        "enterer": {
+          "reference": "Practitioner/1447213657d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "insurer": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "provider": {
+          "reference": "Practitioner/1447213657d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "payee": {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/payeetype",
+                "code": "provider",
+                "display": "Provider"
+              }
+            ]
+          },
+          "party": {
+            "reference": "Practitioner/1447213657d96030446269cb1e0a862d",
+            "type": "Practitioner"
+          }
+        },
+        "diagnosis": [
+          {
+            "sequence": 1,
+            "diagnosisReference": {
+              "reference": "Condition/claim-52cadc42",
+              "type": "Condition"
+            },
+            "onAdmission": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/ex-diagnosis-on-admission"
+                }
+              ]
+            }
+          }
+        ],
+        "procedure": [
+          {
+            "sequence": 1
+          }
+        ],
+        "insurance": [
+          {
+            "sequence": 1,
+            "coverage": {
+              "reference": "Coverage/claim-1788c921",
+              "type": "Coverage"
+            }
+          }
+        ],
+        "total": {
+          "value": 418,
+          "currency": "USD"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-dd21bf4b",
+      "resource": {
+        "resourceType": "Claim",
+        "id": "claim-dd21bf4b",
+        "meta": {
+          "versionId": "3",
+          "lastUpdated": "2022-02-22T18:16:31.000+00:00",
+          "source": "#6887754e6c17d120"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "professional",
+              "display": "Professional"
+            }
+          ]
+        },
+        "use": "claim",
+        "patient": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "billablePeriod": {
+          "end": "2020-03-11"
+        },
+        "enterer": {
+          "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "insurer": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "provider": {
+          "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "payee": {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/payeetype",
+                "code": "provider",
+                "display": "Provider"
+              }
+            ]
+          },
+          "party": {
+            "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+            "type": "Practitioner"
+          }
+        },
+        "diagnosis": [
+          {
+            "sequence": 1,
+            "diagnosisReference": {
+              "reference": "Condition/claim-52cadc42",
+              "type": "Condition"
+            },
+            "onAdmission": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/ex-diagnosis-on-admission"
+                }
+              ]
+            }
+          }
+        ],
+        "procedure": [
+          {
+            "sequence": 1
+          }
+        ],
+        "insurance": [
+          {
+            "sequence": 1,
+            "coverage": {
+              "reference": "Coverage/claim-1788c921",
+              "type": "Coverage"
+            }
+          }
+        ],
+        "total": {
+          "value": 20,
+          "currency": "USD"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-bc77c262",
+      "resource": {
+        "resourceType": "Claim",
+        "id": "claim-bc77c262",
+        "meta": {
+          "versionId": "3",
+          "lastUpdated": "2022-02-22T18:16:31.000+00:00",
+          "source": "#6887754e6c17d120"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "professional",
+              "display": "Professional"
+            }
+          ]
+        },
+        "use": "claim",
+        "patient": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "billablePeriod": {
+          "end": "2020-03-11"
+        },
+        "enterer": {
+          "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "insurer": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "provider": {
+          "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "payee": {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/payeetype",
+                "code": "provider",
+                "display": "Provider"
+              }
+            ]
+          },
+          "party": {
+            "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+            "type": "Practitioner"
+          }
+        },
+        "diagnosis": [
+          {
+            "sequence": 1,
+            "diagnosisReference": {
+              "reference": "Condition/claim-52cadc42",
+              "type": "Condition"
+            },
+            "onAdmission": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/ex-diagnosis-on-admission"
+                }
+              ]
+            }
+          }
+        ],
+        "procedure": [
+          {
+            "sequence": 1
+          }
+        ],
+        "insurance": [
+          {
+            "sequence": 1,
+            "coverage": {
+              "reference": "Coverage/claim-1788c921",
+              "type": "Coverage"
+            }
+          }
+        ],
+        "total": {
+          "value": 109,
+          "currency": "USD"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-66b6525b",
+      "resource": {
+        "resourceType": "Claim",
+        "id": "claim-66b6525b",
+        "meta": {
+          "versionId": "3",
+          "lastUpdated": "2022-02-22T18:16:31.000+00:00",
+          "source": "#6887754e6c17d120"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "professional",
+              "display": "Professional"
+            }
+          ]
+        },
+        "use": "claim",
+        "patient": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "billablePeriod": {
+          "end": "2020-03-11"
+        },
+        "enterer": {
+          "reference": "Practitioner/1629377890d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "insurer": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "provider": {
+          "reference": "Practitioner/1629377890d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "payee": {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/payeetype",
+                "code": "provider",
+                "display": "Provider"
+              }
+            ]
+          },
+          "party": {
+            "reference": "Practitioner/1629377890d96030446269cb1e0a862d",
+            "type": "Practitioner"
+          }
+        },
+        "diagnosis": [
+          {
+            "sequence": 1,
+            "diagnosisReference": {
+              "reference": "Condition/claim-52cadc42",
+              "type": "Condition"
+            },
+            "onAdmission": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/ex-diagnosis-on-admission"
+                }
+              ]
+            }
+          }
+        ],
+        "procedure": [
+          {
+            "sequence": 1
+          }
+        ],
+        "insurance": [
+          {
+            "sequence": 1,
+            "coverage": {
+              "reference": "Coverage/claim-1788c921",
+              "type": "Coverage"
+            }
+          }
+        ],
+        "total": {
+          "value": 365,
+          "currency": "USD"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-f0d58db6",
+      "resource": {
+        "resourceType": "Claim",
+        "id": "claim-f0d58db6",
+        "meta": {
+          "versionId": "3",
+          "lastUpdated": "2022-02-22T18:16:31.000+00:00",
+          "source": "#6887754e6c17d120"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "professional",
+              "display": "Professional"
+            }
+          ]
+        },
+        "use": "claim",
+        "patient": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "billablePeriod": {
+          "end": "2020-03-11"
+        },
+        "enterer": {
+          "reference": "Practitioner/1326321084d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "insurer": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "provider": {
+          "reference": "Practitioner/1326321084d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "payee": {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/payeetype",
+                "code": "provider",
+                "display": "Provider"
+              }
+            ]
+          },
+          "party": {
+            "reference": "Practitioner/1326321084d96030446269cb1e0a862d",
+            "type": "Practitioner"
+          }
+        },
+        "diagnosis": [
+          {
+            "sequence": 1,
+            "diagnosisReference": {
+              "reference": "Condition/claim-52cadc42",
+              "type": "Condition"
+            },
+            "onAdmission": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/ex-diagnosis-on-admission"
+                }
+              ]
+            }
+          }
+        ],
+        "procedure": [
+          {
+            "sequence": 1
+          }
+        ],
+        "insurance": [
+          {
+            "sequence": 1,
+            "coverage": {
+              "reference": "Coverage/claim-1788c921",
+              "type": "Coverage"
+            }
+          }
+        ],
+        "total": {
+          "value": 329,
+          "currency": "USD"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-2d71acc4",
+      "resource": {
+        "resourceType": "Claim",
+        "id": "claim-2d71acc4",
+        "meta": {
+          "versionId": "3",
+          "lastUpdated": "2022-02-22T18:16:31.000+00:00",
+          "source": "#6887754e6c17d120"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "professional",
+              "display": "Professional"
+            }
+          ]
+        },
+        "use": "claim",
+        "patient": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "billablePeriod": {
+          "end": "2020-03-11"
+        },
+        "enterer": {
+          "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "insurer": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "provider": {
+          "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "payee": {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/payeetype",
+                "code": "provider",
+                "display": "Provider"
+              }
+            ]
+          },
+          "party": {
+            "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+            "type": "Practitioner"
+          }
+        },
+        "diagnosis": [
+          {
+            "sequence": 1,
+            "diagnosisReference": {
+              "reference": "Condition/claim-52cadc42",
+              "type": "Condition"
+            },
+            "onAdmission": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/ex-diagnosis-on-admission"
+                }
+              ]
+            }
+          }
+        ],
+        "procedure": [
+          {
+            "sequence": 1
+          }
+        ],
+        "insurance": [
+          {
+            "sequence": 1,
+            "coverage": {
+              "reference": "Coverage/claim-1788c921",
+              "type": "Coverage"
+            }
+          }
+        ],
+        "total": {
+          "value": 334,
+          "currency": "USD"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-c742a83f",
+      "resource": {
+        "resourceType": "Claim",
+        "id": "claim-c742a83f",
+        "meta": {
+          "versionId": "3",
+          "lastUpdated": "2022-02-22T18:16:32.000+00:00",
+          "source": "#6887754e6c17d120"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "professional",
+              "display": "Professional"
+            }
+          ]
+        },
+        "use": "claim",
+        "patient": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "billablePeriod": {
+          "end": "2020-03-13"
+        },
+        "enterer": {
+          "reference": "Practitioner/1801037239d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "insurer": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "provider": {
+          "reference": "Practitioner/1801037239d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "payee": {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/payeetype",
+                "code": "provider",
+                "display": "Provider"
+              }
+            ]
+          },
+          "party": {
+            "reference": "Practitioner/1801037239d96030446269cb1e0a862d",
+            "type": "Practitioner"
+          }
+        },
+        "diagnosis": [
+          {
+            "sequence": 1,
+            "diagnosisReference": {
+              "reference": "Condition/claim-52cadc42",
+              "type": "Condition"
+            },
+            "onAdmission": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/ex-diagnosis-on-admission"
+                }
+              ]
+            }
+          }
+        ],
+        "procedure": [
+          {
+            "sequence": 1
+          }
+        ],
+        "insurance": [
+          {
+            "sequence": 1,
+            "coverage": {
+              "reference": "Coverage/claim-1788c921",
+              "type": "Coverage"
+            }
+          }
+        ],
+        "total": {
+          "value": 33,
+          "currency": "USD"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-3330756b",
+      "resource": {
+        "resourceType": "Claim",
+        "id": "claim-3330756b",
+        "meta": {
+          "versionId": "3",
+          "lastUpdated": "2022-02-22T18:16:32.000+00:00",
+          "source": "#6887754e6c17d120"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "professional",
+              "display": "Professional"
+            }
+          ]
+        },
+        "use": "claim",
+        "patient": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "billablePeriod": {
+          "end": "2020-03-06"
+        },
+        "enterer": {
+          "reference": "Practitioner/1275598047d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "insurer": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "provider": {
+          "reference": "Practitioner/1275598047d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "payee": {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/payeetype",
+                "code": "provider",
+                "display": "Provider"
+              }
+            ]
+          },
+          "party": {
+            "reference": "Practitioner/1275598047d96030446269cb1e0a862d",
+            "type": "Practitioner"
+          }
+        },
+        "diagnosis": [
+          {
+            "sequence": 1,
+            "diagnosisReference": {
+              "reference": "Condition/claim-52cadc42",
+              "type": "Condition"
+            },
+            "onAdmission": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/ex-diagnosis-on-admission"
+                }
+              ]
+            }
+          }
+        ],
+        "procedure": [
+          {
+            "sequence": 1
+          }
+        ],
+        "insurance": [
+          {
+            "sequence": 1,
+            "coverage": {
+              "reference": "Coverage/claim-1788c921",
+              "type": "Coverage"
+            }
+          }
+        ],
+        "total": {
+          "value": 116,
+          "currency": "USD"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-9fa7d0cb",
+      "resource": {
+        "resourceType": "Claim",
+        "id": "claim-9fa7d0cb",
+        "meta": {
+          "versionId": "3",
+          "lastUpdated": "2022-02-22T18:16:33.000+00:00",
+          "source": "#6887754e6c17d120"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "professional",
+              "display": "Professional"
+            }
+          ]
+        },
+        "use": "claim",
+        "patient": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "billablePeriod": {
+          "end": "2020-07-18"
+        },
+        "enterer": {
+          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "insurer": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "provider": {
+          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "payee": {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/payeetype",
+                "code": "provider",
+                "display": "Provider"
+              }
+            ]
+          },
+          "party": {
+            "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+            "type": "Practitioner"
+          }
+        },
+        "diagnosis": [
+          {
+            "sequence": 1,
+            "diagnosisReference": {
+              "reference": "Condition/claim-52cadc42",
+              "type": "Condition"
+            },
+            "onAdmission": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/ex-diagnosis-on-admission"
+                }
+              ]
+            }
+          }
+        ],
+        "procedure": [
+          {
+            "sequence": 1
+          }
+        ],
+        "insurance": [
+          {
+            "sequence": 1,
+            "coverage": {
+              "reference": "Coverage/claim-1788c921",
+              "type": "Coverage"
+            }
+          }
+        ],
+        "total": {
+          "value": 15,
+          "currency": "USD"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-284321b7",
+      "resource": {
+        "resourceType": "Claim",
+        "id": "claim-284321b7",
+        "meta": {
+          "versionId": "3",
+          "lastUpdated": "2022-02-22T18:16:33.000+00:00",
+          "source": "#6887754e6c17d120"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "professional",
+              "display": "Professional"
+            }
+          ]
+        },
+        "use": "claim",
+        "patient": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "billablePeriod": {
+          "end": "2020-07-18"
+        },
+        "enterer": {
+          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "insurer": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "provider": {
+          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "payee": {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/payeetype",
+                "code": "provider",
+                "display": "Provider"
+              }
+            ]
+          },
+          "party": {
+            "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+            "type": "Practitioner"
+          }
+        },
+        "diagnosis": [
+          {
+            "sequence": 1,
+            "diagnosisReference": {
+              "reference": "Condition/claim-52cadc42",
+              "type": "Condition"
+            },
+            "onAdmission": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/ex-diagnosis-on-admission"
+                }
+              ]
+            }
+          }
+        ],
+        "procedure": [
+          {
+            "sequence": 1
+          }
+        ],
+        "insurance": [
+          {
+            "sequence": 1,
+            "coverage": {
+              "reference": "Coverage/claim-1788c921",
+              "type": "Coverage"
+            }
+          }
+        ],
+        "total": {
+          "value": 31,
+          "currency": "USD"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/ExplanationOfBenefit/claim-12185bf6",
+      "resource": {
+        "resourceType": "ExplanationOfBenefit",
+        "id": "claim-12185bf6",
+        "meta": {
+          "versionId": "4",
+          "lastUpdated": "2022-04-07T21:47:14.000+00:00",
+          "source": "#a72b33cd02c572b3"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "institutional",
+              "display": "Institutional"
+            }
+          ]
+        },
+        "use": "claim",
+        "patient": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "billablePeriod": {
+          "start": "2020-03-02",
+          "end": "2020-03-03"
+        },
+        "created": "2020-03-03",
+        "enterer": {
+          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "insurer": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "provider": {
+          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "priority": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/processpriority",
+              "code": "normal",
+              "display": "Normal"
+            }
+          ]
+        },
+        "payee": {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/payeetype",
+                "code": "provider",
+                "display": "Provider"
+              }
+            ]
+          },
+          "party": {
+            "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+            "type": "Practitioner"
+          }
+        },
+        "claim": {
+          "reference": "Claim/claim-dd27652b",
+          "type": "Claim"
+        },
+        "claimResponse": {
+          "reference": "ClaimResponse/claim-ba84f494",
+          "type": "ClaimResponse"
+        },
+        "outcome": "complete",
+        "diagnosis": [
+          {
+            "sequence": 1,
+            "diagnosisReference": {
+              "reference": "Condition/claim-52cadc42",
+              "type": "Condition"
+            },
+            "onAdmission": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/ex-diagnosis-on-admission",
+                  "code": "y",
+                  "display": "Yes"
+                }
+              ]
+            }
+          }
+        ],
+        "procedure": [
+          {
+            "sequence": 1,
+            "date": "2020-03-02",
+            "procedureReference": {
+              "reference": "Procedure/claim-c21b87d3",
+              "type": "Procedure"
+            }
+          }
+        ],
+        "insurance": [
+          {
+            "focal": true,
+            "coverage": {
+              "reference": "Coverage/claim-1788c921",
+              "type": "Coverage"
+            }
+          }
+        ],
+        "item": [
+          {
+            "sequence": 1,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "450",
+                  "display": "Emergency Room"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          },
+          {
+            "sequence": 2,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "123",
+                  "display": "Pediatric"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          },
+          {
+            "sequence": 3,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "410",
+                  "display": "Respiratory Services"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          },
+          {
+            "sequence": 4,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "250",
+                  "display": "Pharmacy (Also see 063X, an extension of 250X)"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          },
+          {
+            "sequence": 5,
+            "revenue": {
+              "coding": [
+                {
+                  "system": "https://build.fhir.org/ig/HL7/carin-bb/ValueSet-AHANUBCRevenueCodes.html",
+                  "code": "252",
+                  "display": "Nongeneric drugs"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://id.who.int/icd/release/10/2019,https://clinicaltables.nlm.nih.gov/api/hcpcs"
+                }
+              ]
+            },
+            "modifier": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/modifiers"
+                  }
+                ]
+              }
+            ],
+            "servicedPeriod": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            }
+          }
+        ],
+        "payment": {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/ex-paymenttype",
+                "code": "complete",
+                "display": "Complete"
+              }
+            ]
+          },
+          "date": "2020-03-13",
+          "amount": {
+            "value": 3260.4,
+            "currency": "USD"
+          },
+          "identifier": {
+            "system": "http://better.health.insurance.com/fhir/paymentidentifier",
+            "value": "080633-1216-1962925"
+          }
+        },
+        "benefitPeriod": {
+          "start": "2018-11-04",
+          "end": "2019-11-04"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/ExplanationOfBenefit/claim-fa1bd3e1",
+      "resource": {
+        "resourceType": "ExplanationOfBenefit",
+        "id": "claim-fa1bd3e1",
+        "meta": {
+          "versionId": "3",
+          "lastUpdated": "2022-02-22T20:53:55.000+00:00",
+          "source": "#cf885f7cffb3771b"
+        },
+        "identifier": [
+          {
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "professional",
+              "display": "Professional"
+            }
+          ]
+        },
+        "use": "claim",
+        "patient": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "billablePeriod": {
+          "start": "2019-05-02",
+          "end": "2019-05-02"
+        },
+        "created": "2019-05-02",
+        "enterer": {
+          "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "insurer": {
+          "reference": "Organization/claim-8c651f04",
+          "type": "Organization"
+        },
+        "provider": {
+          "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+          "type": "Practitioner"
+        },
+        "priority": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/processpriority",
+              "code": "normal",
+              "display": "Normal"
+            }
+          ]
+        },
+        "payee": {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/payeetype",
+                "code": "provider",
+                "display": "Provider"
+              }
+            ]
+          },
+          "party": {
+            "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+            "type": "Practitioner"
+          }
+        },
+        "claim": {
+          "reference": "Claim/claim-dd27652b",
+          "type": "Claim"
+        },
+        "claimResponse": {
+          "reference": "ClaimResponse/claim-ba84f494",
+          "type": "ClaimResponse"
+        },
+        "outcome": "complete",
+        "diagnosis": [
+          {
+            "sequence": 1,
+            "diagnosisReference": {
+              "reference": "Condition/claim-52cadc42",
+              "type": "Condition"
+            },
+            "onAdmission": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/ex-diagnosis-on-admission"
+                }
+              ]
+            }
+          }
+        ],
+        "procedure": [
+          {
+            "sequence": 1,
+            "procedureReference": {
+              "reference": "Procedure/claim-c21b87d3",
+              "type": "Procedure"
+            }
+          }
+        ],
+        "insurance": [
+          {
+            "focal": true,
+            "coverage": {
+              "reference": "Coverage/claim-1788c921",
+              "type": "Coverage"
+            }
+          }
+        ],
+        "payment": {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/ex-paymenttype",
+                "code": "complete",
+                "display": "Complete"
+              }
+            ]
+          },
+          "date": "2019-05-07",
+          "amount": {
+            "value": 30.23,
+            "currency": "USD"
+          },
+          "identifier": {
+            "system": "http://better.health.insurance.com/fhir/paymentidentifier",
+            "value": "186694-6368-4563486"
+          }
+        },
+        "benefitPeriod": {
+          "start": "2018-11-04",
+          "end": "2019-11-04"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/4DD",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "4DD",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-07-15T17:57:43.000+00:00",
+          "source": "#A6Uw6xCU5HhRv1hw"
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "54109-4",
+              "display": "Newborn hearing screening of Ear – right"
+            }
+          ],
+          "text": "Newborn hearing screening of Ear – right"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2024-07-12T00:00:00Z",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "262008008",
+              "display": "Not Performed"
+            }
+          ],
+          "text": "Not Performed"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/8HH",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "8HH",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-07-15T17:57:43.000+00:00",
+          "source": "#A6Uw6xCU5HhRv1hw"
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "2571601129",
+              "display": "Body weight [Percentile] Per age"
+            }
+          ],
+          "text": "Body weight [Percentile] Per age"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2024-07-12T00:00:00Z",
+        "valueQuantity": {
+          "value": 80.05,
+          "unit": "percent",
+          "system": "http://unitsofmeasure.org",
+          "code": "%"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/5EE",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "5EE",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-07-15T17:57:43.000+00:00",
+          "source": "#A6Uw6xCU5HhRv1hw"
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "54108-6",
+              "display": "Newborn hearing screening of Ear – left"
+            }
+          ],
+          "text": "Newborn hearing screening of Ear – left"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2024-07-12T00:00:00Z",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "262008008",
+              "display": "Not Performed"
+            }
+          ],
+          "text": "Not Performed"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/9II",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "9II",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-07-15T17:57:43.000+00:00",
+          "source": "#A6Uw6xCU5HhRv1hw"
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "3623994",
+              "display": "SpO2"
+            }
+          ],
+          "text": "SpO2"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2024-07-12T00:00:00Z",
+        "valueQuantity": {
+          "value": 99,
+          "unit": "percent",
+          "system": "http://unitsofmeasure.org",
+          "code": "%"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/11KK",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "11KK",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-07-15T17:57:43.000+00:00",
+          "source": "#A6Uw6xCU5HhRv1hw"
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "57713-0",
+              "display": "Infant factors that affect newborn screening interpretation"
+            }
+          ],
+          "text": "Infant factors that affect newborn screening interpretation"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2024-07-12T00:00:00Z",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "LA12419-0",
+              "display": "Infant in ICU at time of specimen collection"
+            }
+          ],
+          "text": "Infant in ICU at time of specimen collection"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/6FF",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "6FF",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-07-15T17:57:43.000+00:00",
+          "source": "#A6Uw6xCU5HhRv1hw"
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "73742-9",
+              "display": "Newborn hearing screen reason not performed – right"
+            }
+          ],
+          "text": "Newborn hearing screen reason not performed – right"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2024-07-12T00:00:00Z",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "103709008",
+              "display": "Attempted but unsuccessful – technical fail"
+            }
+          ],
+          "text": "Attempted but unsuccessful – technical fail"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/10JJ",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "10JJ",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-07-15T17:57:43.000+00:00",
+          "source": "#A6Uw6xCU5HhRv1hw"
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "73700-7",
+              "display": "CCHD Newborn Screening Interpretation"
+            }
+          ],
+          "text": "CCHD Newborn Screening Interpretation"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2024-07-12T00:00:00Z",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "LA18593-6",
+              "display": "Out of Range"
+            }
+          ],
+          "text": "Out of Range"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/7GG",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "7GG",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-07-15T17:57:43.000+00:00",
+          "source": "#A6Uw6xCU5HhRv1hw"
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "73739-5",
+              "display": "Newborn hearing screen reason not performed – left"
+            }
+          ],
+          "text": "Newborn hearing screen reason not performed – left"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2024-07-12T00:00:00Z",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "103709008",
+              "display": "Attempted but unsuccessful – technical fail"
+            }
+          ],
+          "text": "Attempted but unsuccessful – technical fail"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/VS-PO-197323276",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "VS-PO-197323276",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-07-15T17:57:43.000+00:00",
+          "source": "#A6Uw6xCU5HhRv1hw"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Observation</b></p><p><b>Patient Id</b>: f288c654-6885-4f48-999c-48d776dc06af</p><p><b>Status</b>: Final</p><p><b>Categories</b>: Laboratory, Therapy, Vital Signs</p><p><b>Code</b>: SpO2</p><p><b>Result</b>: 99 %</p><p><b>Effective Date</b>: Sep  1, 2023 10:21 A.M. CDT</p></div>"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory",
+                "display": "Laboratory"
+              }
+            ],
+            "text": "Laboratory"
+          },
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "therapy",
+                "display": "Therapy"
+              }
+            ],
+            "text": "Therapy"
+          },
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "https://fhir.cerner.com/e8a84236-c258-4952-98b7-a6ff8a9c587a/codeSet/72",
+              "code": "3623994",
+              "display": "SpO2",
+              "userSelected": true
+            },
+            {
+              "system": "http://loinc.org",
+              "code": "2708-6"
+            },
+            {
+              "system": "http://loinc.org",
+              "code": "59408-5"
+            }
+          ],
+          "text": "SpO2"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2024-07-13T15:21:00.000Z",
+        "issued": "2024-07-13T15:30:25.000Z",
+        "valueQuantity": {
+          "value": 99,
+          "unit": "%",
+          "system": "http://unitsofmeasure.org",
+          "code": "%"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/L-197323272",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "L-197323272",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-07-15T17:57:43.000+00:00",
+          "source": "#A6Uw6xCU5HhRv1hw"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Observation</b></p><p><b>Patient Id</b>: f288c654-6885-4f48-999c-48d776dc06af</p><p><b>Status</b>: Final</p><p><b>Categories</b>: Vital Signs</p><p><b>Code</b>: Weight Percentile</p><p><b>Result</b>: 45.32</p><p><b>Effective Date</b>: Sep  1, 2023 10:21 A.M. CDT</p></div>"
+        },
+        "identifier": [
+          {
+            "system": "https://fhir.cerner.com/ceuuid",
+            "value": "CE87caf4b7-9397-4667-9897-702218017c9e-197323271-2023090115225900"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs",
+                "userSelected": false
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "https://fhir.cerner.com/e8a84236-c258-4952-98b7-a6ff8a9c587a/codeSet/72",
+              "code": "2571601129",
+              "display": "Weight Percentile",
+              "userSelected": true
+            },
+            {
+              "system": "http://loinc.org",
+              "code": "8336-0",
+              "userSelected": false
+            }
+          ],
+          "text": "Weight Percentile"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2024-07-13T15:21:00.000Z",
+        "issued": "2024-07-13T15:22:59.000Z",
+        "valueQuantity": {
+          "value": 45.32
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/2BB",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "2BB",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-07-15T17:57:43.000+00:00",
+          "source": "#A6Uw6xCU5HhRv1hw"
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "54109-4",
+              "display": "Newborn hearing screening of Ear – right"
+            }
+          ],
+          "text": "Newborn hearing screening of Ear – right"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2024-07-12T00:00:00Z",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "164059009",
+              "display": "Pass"
+            }
+          ],
+          "text": "Pass"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/3CC",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "3CC",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-07-15T17:57:43.000+00:00",
+          "source": "#A6Uw6xCU5HhRv1hw"
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "54108-6",
+              "display": "Newborn hearing screening of Ear – left"
+            }
+          ],
+          "text": "Newborn hearing screening of Ear – left"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2024-07-12T00:00:00Z",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "183924009",
+              "display": "Refer"
+            }
+          ],
+          "text": "Refer"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/8Z",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "8Z",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-07-15T17:57:43.000+00:00",
+          "source": "#A6Uw6xCU5HhRv1hw"
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "58232-0",
+              "display": "Hearing loss risk indicator"
+            }
+          ],
+          "text": "Hearing loss risk indicator"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2024-07-12T00:00:00Z",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "178280004",
+              "display": "Postnatal Infection"
+            }
+          ],
+          "text": "Postnatal Infection"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/VS-PO-197323275",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "VS-PO-197323275",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2023-09-01T15:30:25.000Z"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Observation</b></p><p><b>Patient Id</b>: f288c654-6885-4f48-999c-48d776dc06af</p><p><b>Status</b>: Final</p><p><b>Categories</b>: Laboratory, Therapy, Vital Signs</p><p><b>Code</b>: SpO2</p><p><b>Result</b>: 99 %</p><p><b>Effective Date</b>: Sep  1, 2023 10:21 A.M. CDT</p></div>"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory",
+                "display": "Laboratory"
+              }
+            ],
+            "text": "Laboratory"
+          },
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "therapy",
+                "display": "Therapy"
+              }
+            ],
+            "text": "Therapy"
+          },
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "https://fhir.cerner.com/e8a84236-c258-4952-98b7-a6ff8a9c587a/codeSet/72",
+              "code": "3623994",
+              "display": "SpO2",
+              "userSelected": true
+            },
+            {
+              "system": "http://loinc.org",
+              "code": "2708-6"
+            },
+            {
+              "system": "http://loinc.org",
+              "code": "59408-5"
+            }
+          ],
+          "text": "SpO2"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "encounter": {
+          "reference": "Encounter/97991794"
+        },
+        "effectiveDateTime": "2023-09-01T15:21:00.000Z",
+        "issued": "2023-09-01T15:30:25.000Z",
+        "performer": [
+          {
+            "extension": [
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "LA",
+                      "display": "legal authenticator"
+                    }
+                  ],
+                  "text": "legal authenticator"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              }
+            ],
+            "reference": "Practitioner/683925"
+          }
+        ],
+        "valueQuantity": {
+          "value": 99,
+          "unit": "%",
+          "system": "http://unitsofmeasure.org",
+          "code": "%"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/L-197323277",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "L-197323277",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2023-09-01T15:30:25.000Z"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Observation</b></p><p><b>Patient Id</b>: f288c654-6885-4f48-999c-48d776dc06af</p><p><b>Status</b>: Final</p><p><b>Categories</b>: Vital Signs, Therapy</p><p><b>Code</b>: SpO2 Location</p><p><b>Result</b>: Right hand</p><p><b>Effective Date</b>: Sep  1, 2023 10:21 A.M. CDT</p></div>"
+        },
+        "identifier": [
+          {
+            "system": "https://fhir.cerner.com/ceuuid",
+            "value": "CE87caf4b7-9397-4667-9897-702218017c9e-197323277-2023090115302500"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs",
+                "userSelected": false
+              }
+            ],
+            "text": "Vital Signs"
+          },
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "therapy",
+                "display": "Therapy",
+                "userSelected": false
+              }
+            ],
+            "text": "Therapy"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "https://fhir.cerner.com/e8a84236-c258-4952-98b7-a6ff8a9c587a/codeSet/72",
+              "code": "22831122",
+              "display": "SpO2 Location",
+              "userSelected": true
+            },
+            {
+              "system": "http://loinc.org",
+              "code": "20081-6",
+              "userSelected": false
+            }
+          ],
+          "text": "SpO2 Location"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "encounter": {
+          "reference": "Encounter/97991794"
+        },
+        "effectiveDateTime": "2023-09-01T15:21:00.000Z",
+        "issued": "2023-09-01T15:30:25.000Z",
+        "performer": [
+          {
+            "extension": [
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "PPRF",
+                      "display": "primary performer"
+                    }
+                  ],
+                  "text": "primary performer"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              },
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "LA",
+                      "display": "legal authenticator"
+                    }
+                  ],
+                  "text": "legal authenticator"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              }
+            ],
+            "reference": "Practitioner/683925"
+          }
+        ],
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "78791008",
+              "display": "Structure of right hand (body structure)",
+              "userSelected": false
+            }
+          ],
+          "text": "Right hand"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/L-197323273",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "L-197323273",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2023-09-01T15:23:01.000Z"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Observation</b></p><p><b>Patient Id</b>: f288c654-6885-4f48-999c-48d776dc06af</p><p><b>Status</b>: Final</p><p><b>Categories</b>: Vital Signs</p><p><b>Code</b>: Weight Z-Score</p><p><b>Result</b>: -0.12</p><p><b>Effective Date</b>: Sep  1, 2023 10:21 A.M. CDT</p></div>"
+        },
+        "identifier": [
+          {
+            "system": "https://fhir.cerner.com/ceuuid",
+            "value": "CE87caf4b7-9397-4667-9897-702218017c9e-197323273-2023090115225900"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs",
+                "userSelected": false
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "https://fhir.cerner.com/e8a84236-c258-4952-98b7-a6ff8a9c587a/codeSet/72",
+              "code": "2571601133",
+              "display": "Weight Z-Score",
+              "userSelected": true
+            }
+          ],
+          "text": "Weight Z-Score"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "encounter": {
+          "reference": "Encounter/97991794"
+        },
+        "effectiveDateTime": "2023-09-01T15:21:00.000Z",
+        "issued": "2023-09-01T15:22:59.000Z",
+        "performer": [
+          {
+            "extension": [
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "LA",
+                      "display": "legal authenticator"
+                    }
+                  ],
+                  "text": "legal authenticator"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              },
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "PPRF",
+                      "display": "primary performer"
+                    }
+                  ],
+                  "text": "primary performer"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              }
+            ],
+            "reference": "Practitioner/1"
+          }
+        ],
+        "valueQuantity": {
+          "value": -0.12
+        },
+        "note": [
+          {
+            "authorReference": {
+              "reference": "Practitioner/1"
+            },
+            "time": "2023-09-01T15:22:59Z",
+            "text": "^~:!ZScore Source -CDC-WHO"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/L-197323271",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "L-197323271",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2023-09-01T15:23:00.000Z"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Observation</b></p><p><b>Patient Id</b>: f288c654-6885-4f48-999c-48d776dc06af</p><p><b>Status</b>: Final</p><p><b>Categories</b>: Vital Signs</p><p><b>Code</b>: Weight Percentile</p><p><b>Result</b>: 45.32</p><p><b>Effective Date</b>: Sep  1, 2023 10:21 A.M. CDT</p></div>"
+        },
+        "identifier": [
+          {
+            "system": "https://fhir.cerner.com/ceuuid",
+            "value": "CE87caf4b7-9397-4667-9897-702218017c9e-197323271-2023090115225900"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs",
+                "userSelected": false
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "https://fhir.cerner.com/e8a84236-c258-4952-98b7-a6ff8a9c587a/codeSet/72",
+              "code": "2571601129",
+              "display": "Weight Percentile",
+              "userSelected": true
+            },
+            {
+              "system": "http://loinc.org",
+              "code": "8336-0",
+              "userSelected": false
+            }
+          ],
+          "text": "Weight Percentile"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "encounter": {
+          "reference": "Encounter/97991794"
+        },
+        "effectiveDateTime": "2023-09-01T15:21:00.000Z",
+        "issued": "2023-09-01T15:22:59.000Z",
+        "performer": [
+          {
+            "extension": [
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "LA",
+                      "display": "legal authenticator"
+                    }
+                  ],
+                  "text": "legal authenticator"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              },
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "PPRF",
+                      "display": "primary performer"
+                    }
+                  ],
+                  "text": "primary performer"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              }
+            ],
+            "reference": "Practitioner/1"
+          }
+        ],
+        "valueQuantity": {
+          "value": 45.32
+        },
+        "note": [
+          {
+            "authorReference": {
+              "reference": "Practitioner/1"
+            },
+            "time": "2023-09-01T15:22:59Z",
+            "text": "^~:!Percentile Source -CDC-WHO"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/L-197323269",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "L-197323269",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2023-09-01T15:22:59.000Z"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Observation</b></p><p><b>Patient Id</b>: f288c654-6885-4f48-999c-48d776dc06af</p><p><b>Status</b>: Final</p><p><b>Categories</b>: Vital Signs</p><p><b>Code</b>: Height Z-Score</p><p><b>Result</b>: -0.17</p><p><b>Effective Date</b>: Sep  1, 2023 10:21 A.M. CDT</p></div>"
+        },
+        "identifier": [
+          {
+            "system": "https://fhir.cerner.com/ceuuid",
+            "value": "CE87caf4b7-9397-4667-9897-702218017c9e-197323269-2023090115225900"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs",
+                "userSelected": false
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "https://fhir.cerner.com/e8a84236-c258-4952-98b7-a6ff8a9c587a/codeSet/72",
+              "code": "2571601141",
+              "display": "Height Z-Score",
+              "userSelected": true
+            }
+          ],
+          "text": "Height Z-Score"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "encounter": {
+          "reference": "Encounter/97991794"
+        },
+        "effectiveDateTime": "2023-09-01T15:21:00.000Z",
+        "issued": "2023-09-01T15:22:58.000Z",
+        "performer": [
+          {
+            "extension": [
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "LA",
+                      "display": "legal authenticator"
+                    }
+                  ],
+                  "text": "legal authenticator"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              },
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "PPRF",
+                      "display": "primary performer"
+                    }
+                  ],
+                  "text": "primary performer"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              }
+            ],
+            "reference": "Practitioner/1"
+          }
+        ],
+        "valueQuantity": {
+          "value": -0.17
+        },
+        "note": [
+          {
+            "authorReference": {
+              "reference": "Practitioner/1"
+            },
+            "time": "2023-09-01T15:22:58Z",
+            "text": "^~:!ZScore Source -CDC-WHO"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/L-197323267",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "L-197323267",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2023-09-01T15:22:58.000Z"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Observation</b></p><p><b>Patient Id</b>: f288c654-6885-4f48-999c-48d776dc06af</p><p><b>Status</b>: Final</p><p><b>Categories</b>: Vital Signs</p><p><b>Code</b>: Height Percentile</p><p><b>Result</b>: 43.16</p><p><b>Effective Date</b>: Sep  1, 2023 10:21 A.M. CDT</p></div>"
+        },
+        "identifier": [
+          {
+            "system": "https://fhir.cerner.com/ceuuid",
+            "value": "CE87caf4b7-9397-4667-9897-702218017c9e-197323267-2023090115225800"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs",
+                "userSelected": false
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "https://fhir.cerner.com/e8a84236-c258-4952-98b7-a6ff8a9c587a/codeSet/72",
+              "code": "2571601137",
+              "display": "Height Percentile",
+              "userSelected": true
+            },
+            {
+              "system": "http://loinc.org",
+              "code": "8303-0",
+              "userSelected": false
+            }
+          ],
+          "text": "Height Percentile"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "encounter": {
+          "reference": "Encounter/97991794"
+        },
+        "effectiveDateTime": "2023-09-01T15:21:00.000Z",
+        "issued": "2023-09-01T15:22:58.000Z",
+        "performer": [
+          {
+            "extension": [
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "LA",
+                      "display": "legal authenticator"
+                    }
+                  ],
+                  "text": "legal authenticator"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              },
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "PPRF",
+                      "display": "primary performer"
+                    }
+                  ],
+                  "text": "primary performer"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              }
+            ],
+            "reference": "Practitioner/1"
+          }
+        ],
+        "valueQuantity": {
+          "value": 43.16
+        },
+        "note": [
+          {
+            "authorReference": {
+              "reference": "Practitioner/1"
+            },
+            "time": "2023-09-01T15:22:58Z",
+            "text": "^~:!Percentile Source -CDC-WHO"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/L-197323265",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "L-197323265",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2023-09-01T15:22:57.000Z"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Observation</b></p><p><b>Patient Id</b>: f288c654-6885-4f48-999c-48d776dc06af</p><p><b>Status</b>: Final</p><p><b>Categories</b>: Vital Signs</p><p><b>Code</b>: Cumulative Weight Gain</p><p><b>Result</b>: 1 kg</p><p><b>Effective Date</b>: Sep  1, 2023 10:21 A.M. CDT</p></div>"
+        },
+        "identifier": [
+          {
+            "system": "https://fhir.cerner.com/ceuuid",
+            "value": "CE87caf4b7-9397-4667-9897-702218017c9e-197323265-2023090115225700"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs",
+                "userSelected": false
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "https://fhir.cerner.com/e8a84236-c258-4952-98b7-a6ff8a9c587a/codeSet/72",
+              "code": "711303",
+              "display": "Cumulative Weight Gain",
+              "userSelected": true
+            },
+            {
+              "system": "http://snomed.info/sct",
+              "code": "363805003",
+              "display": "Weight gain (amount) (observable entity)",
+              "userSelected": false
+            }
+          ],
+          "text": "Cumulative Weight Gain"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "encounter": {
+          "reference": "Encounter/97991794"
+        },
+        "effectiveDateTime": "2023-09-01T15:21:00.000Z",
+        "issued": "2023-09-01T15:22:57.000Z",
+        "performer": [
+          {
+            "extension": [
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "PPRF",
+                      "display": "primary performer"
+                    }
+                  ],
+                  "text": "primary performer"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              },
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "LA",
+                      "display": "legal authenticator"
+                    }
+                  ],
+                  "text": "legal authenticator"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              }
+            ],
+            "reference": "Practitioner/683925"
+          }
+        ],
+        "valueQuantity": {
+          "value": 1,
+          "unit": "kg",
+          "system": "http://unitsofmeasure.org",
+          "code": "kg"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/L-197323263",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "L-197323263",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2023-09-01T15:22:57.000Z"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Observation</b></p><p><b>Patient Id</b>: f288c654-6885-4f48-999c-48d776dc06af</p><p><b>Status</b>: Final</p><p><b>Categories</b>: Vital Signs</p><p><b>Code</b>: Pre-Pregnancy Weight</p><p><b>Result</b>: 2.3 kg</p><p><b>Effective Date</b>: Sep  1, 2023 10:21 A.M. CDT</p></div>"
+        },
+        "identifier": [
+          {
+            "system": "https://fhir.cerner.com/ceuuid",
+            "value": "CE87caf4b7-9397-4667-9897-702218017c9e-197323263-2023090115225700"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs",
+                "userSelected": false
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "https://fhir.cerner.com/e8a84236-c258-4952-98b7-a6ff8a9c587a/codeSet/72",
+              "code": "711300",
+              "display": "Pre-Pregnancy Weight",
+              "userSelected": true
+            },
+            {
+              "system": "http://loinc.org",
+              "code": "29463-7",
+              "userSelected": false
+            },
+            {
+              "system": "http://loinc.org",
+              "code": "8348-5",
+              "userSelected": false
+            }
+          ],
+          "text": "Pre-Pregnancy Weight"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "encounter": {
+          "reference": "Encounter/97991794"
+        },
+        "effectiveDateTime": "2023-09-01T15:21:00.000Z",
+        "issued": "2023-09-01T15:22:57.000Z",
+        "performer": [
+          {
+            "extension": [
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "PPRF",
+                      "display": "primary performer"
+                    }
+                  ],
+                  "text": "primary performer"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              },
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "LA",
+                      "display": "legal authenticator"
+                    }
+                  ],
+                  "text": "legal authenticator"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              }
+            ],
+            "reference": "Practitioner/683925"
+          }
+        ],
+        "valueQuantity": {
+          "value": 2.3,
+          "unit": "kg",
+          "system": "http://unitsofmeasure.org",
+          "code": "kg"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/VS-197323261",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "VS-197323261",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2023-09-01T15:22:57.000Z"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Observation</b></p><p><b>Patient Id</b>: f288c654-6885-4f48-999c-48d776dc06af</p><p><b>Status</b>: Final</p><p><b>Categories</b>: Vital Signs</p><p><b>Code</b>: Weight Measured</p><p><b>Result</b>: 3.2 kg</p><p><b>Effective Date</b>: Sep  1, 2023 10:21 A.M. CDT</p></div>"
+        },
+        "identifier": [
+          {
+            "system": "https://fhir.cerner.com/ceuuid",
+            "value": "CE87caf4b7-9397-4667-9897-702218017c9e-197323261-2023090115225700"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "https://fhir.cerner.com/e8a84236-c258-4952-98b7-a6ff8a9c587a/codeSet/72",
+              "code": "4154120",
+              "display": "Weight Measured",
+              "userSelected": true
+            },
+            {
+              "system": "http://loinc.org",
+              "code": "29463-7"
+            },
+            {
+              "system": "http://loinc.org",
+              "code": "3141-9"
+            }
+          ],
+          "text": "Weight Measured"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "encounter": {
+          "reference": "Encounter/97991794"
+        },
+        "effectiveDateTime": "2023-09-01T15:21:00.000Z",
+        "issued": "2023-09-01T15:22:57.000Z",
+        "performer": [
+          {
+            "extension": [
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "LA",
+                      "display": "legal authenticator"
+                    }
+                  ],
+                  "text": "legal authenticator"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              }
+            ],
+            "reference": "Practitioner/683925"
+          }
+        ],
+        "valueQuantity": {
+          "extension": [
+            {
+              "valueQuantity": {
+                "value": 3200000000000.0,
+                "unit": "ng",
+                "system": "http://unitsofmeasure.org",
+                "code": "ng"
+              },
+              "url": "http://hl7.org/fhir/StructureDefinition/iso21090-PQ-translation"
+            },
+            {
+              "valueQuantity": {
+                "value": 3200000000.0,
+                "unit": "mcg",
+                "system": "http://unitsofmeasure.org",
+                "code": "ug"
+              },
+              "url": "http://hl7.org/fhir/StructureDefinition/iso21090-PQ-translation"
+            },
+            {
+              "valueQuantity": {
+                "value": 3200000.0,
+                "unit": "mg",
+                "system": "http://unitsofmeasure.org",
+                "code": "mg"
+              },
+              "url": "http://hl7.org/fhir/StructureDefinition/iso21090-PQ-translation"
+            },
+            {
+              "valueQuantity": {
+                "value": 320000.0,
+                "unit": "cg",
+                "system": "http://unitsofmeasure.org",
+                "code": "cg"
+              },
+              "url": "http://hl7.org/fhir/StructureDefinition/iso21090-PQ-translation"
+            },
+            {
+              "valueQuantity": {
+                "value": 32000.0,
+                "unit": "dgm",
+                "system": "http://unitsofmeasure.org",
+                "code": "dg"
+              },
+              "url": "http://hl7.org/fhir/StructureDefinition/iso21090-PQ-translation"
+            },
+            {
+              "valueQuantity": {
+                "value": 3200.0,
+                "unit": "g",
+                "system": "http://unitsofmeasure.org",
+                "code": "g"
+              },
+              "url": "http://hl7.org/fhir/StructureDefinition/iso21090-PQ-translation"
+            },
+            {
+              "valueQuantity": {
+                "value": 112.877,
+                "unit": "oz",
+                "system": "http://unitsofmeasure.org",
+                "code": "[oz_av]"
+              },
+              "url": "http://hl7.org/fhir/StructureDefinition/iso21090-PQ-translation"
+            },
+            {
+              "valueQuantity": {
+                "value": 7.055,
+                "unit": "lb",
+                "system": "http://unitsofmeasure.org",
+                "code": "[lb_av]"
+              },
+              "url": "http://hl7.org/fhir/StructureDefinition/iso21090-PQ-translation"
+            }
+          ],
+          "value": 3.2,
+          "unit": "kg",
+          "system": "http://unitsofmeasure.org",
+          "code": "kg"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/VS-197323259",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "VS-197323259",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2023-09-01T15:22:57.000Z"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Observation</b></p><p><b>Patient Id</b>: f288c654-6885-4f48-999c-48d776dc06af</p><p><b>Status</b>: Final</p><p><b>Categories</b>: Procedure, Therapy, Vital Signs</p><p><b>Code</b>: Height/Length Measured</p><p><b>Result</b>: 49.5 cm</p><p><b>Effective Date</b>: Sep  1, 2023 10:21 A.M. CDT</p></div>"
+        },
+        "identifier": [
+          {
+            "system": "https://fhir.cerner.com/ceuuid",
+            "value": "CE87caf4b7-9397-4667-9897-702218017c9e-197323259-2023090115225700"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "procedure",
+                "display": "Procedure"
+              }
+            ],
+            "text": "Procedure"
+          },
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "therapy",
+                "display": "Therapy"
+              }
+            ],
+            "text": "Therapy"
+          },
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "https://fhir.cerner.com/e8a84236-c258-4952-98b7-a6ff8a9c587a/codeSet/72",
+              "code": "4154126",
+              "display": "Height/Length Measured",
+              "userSelected": true
+            },
+            {
+              "system": "http://loinc.org",
+              "code": "3137-7"
+            },
+            {
+              "system": "http://loinc.org",
+              "code": "8302-2"
+            }
+          ],
+          "text": "Height/Length Measured"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "encounter": {
+          "reference": "Encounter/97991794"
+        },
+        "effectiveDateTime": "2023-09-01T15:21:00.000Z",
+        "issued": "2023-09-01T15:22:57.000Z",
+        "performer": [
+          {
+            "extension": [
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "LA",
+                      "display": "legal authenticator"
+                    }
+                  ],
+                  "text": "legal authenticator"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              }
+            ],
+            "reference": "Practitioner/683925"
+          }
+        ],
+        "valueQuantity": {
+          "extension": [
+            {
+              "valueQuantity": {
+                "value": 495.0,
+                "unit": "mm",
+                "system": "http://unitsofmeasure.org",
+                "code": "mm"
+              },
+              "url": "http://hl7.org/fhir/StructureDefinition/iso21090-PQ-translation"
+            },
+            {
+              "valueQuantity": {
+                "value": 4.95,
+                "unit": "dm",
+                "system": "http://unitsofmeasure.org",
+                "code": "dm"
+              },
+              "url": "http://hl7.org/fhir/StructureDefinition/iso21090-PQ-translation"
+            },
+            {
+              "valueQuantity": {
+                "value": 0.5,
+                "unit": "m",
+                "system": "http://unitsofmeasure.org",
+                "code": "m"
+              },
+              "url": "http://hl7.org/fhir/StructureDefinition/iso21090-PQ-translation"
+            },
+            {
+              "valueQuantity": {
+                "value": 19.49,
+                "unit": "in",
+                "system": "http://unitsofmeasure.org",
+                "code": "[in_i]"
+              },
+              "url": "http://hl7.org/fhir/StructureDefinition/iso21090-PQ-translation"
+            },
+            {
+              "valueQuantity": {
+                "value": 1.62,
+                "unit": "ft",
+                "system": "http://unitsofmeasure.org",
+                "code": "[ft_i]"
+              },
+              "url": "http://hl7.org/fhir/StructureDefinition/iso21090-PQ-translation"
+            }
+          ],
+          "value": 49.5,
+          "unit": "cm",
+          "system": "http://unitsofmeasure.org",
+          "code": "cm"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/L-197323257",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "L-197323257",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2023-09-01T15:18:19.000Z"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Observation</b></p><p><b>Patient Id</b>: f288c654-6885-4f48-999c-48d776dc06af</p><p><b>Status</b>: Final</p><p><b>Code</b>: Audiological Referral Date</p><p><b>Result</b>: Sep 23, 2023</p><p><b>Effective Date</b>: Sep  1, 2023 10:17 A.M. CDT</p></div>"
+        },
+        "identifier": [
+          {
+            "system": "https://fhir.cerner.com/ceuuid",
+            "value": "CE87caf4b7-9397-4667-9897-702218017c9e-197323257-2023090115182000"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "extension": [
+              {
+                "valueCode": "unknown",
+                "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "https://fhir.cerner.com/e8a84236-c258-4952-98b7-a6ff8a9c587a/codeSet/72",
+              "code": "2568875925",
+              "display": "Audiological Referral Date",
+              "userSelected": true
+            }
+          ],
+          "text": "Audiological Referral Date"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "encounter": {
+          "reference": "Encounter/97991794"
+        },
+        "effectiveDateTime": "2023-09-01T15:17:00.000Z",
+        "issued": "2023-09-01T15:18:19.000Z",
+        "performer": [
+          {
+            "extension": [
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "PPRF",
+                      "display": "primary performer"
+                    }
+                  ],
+                  "text": "primary performer"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              },
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "LA",
+                      "display": "legal authenticator"
+                    }
+                  ],
+                  "text": "legal authenticator"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              }
+            ],
+            "reference": "Practitioner/683925"
+          }
+        ],
+        "valueDateTime": "2023-09-23"
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/L-197323255",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "L-197323255",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2023-09-01T15:18:19.000Z"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Observation</b></p><p><b>Patient Id</b>: f288c654-6885-4f48-999c-48d776dc06af</p><p><b>Status</b>: Final</p><p><b>Code</b>: Audiological Referral Scheduled</p><p><b>Result</b>: Yes</p><p><b>Effective Date</b>: Sep  1, 2023 10:17 A.M. CDT</p></div>"
+        },
+        "identifier": [
+          {
+            "system": "https://fhir.cerner.com/ceuuid",
+            "value": "CE87caf4b7-9397-4667-9897-702218017c9e-197323255-2023090115182000"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "extension": [
+              {
+                "valueCode": "unknown",
+                "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "https://fhir.cerner.com/e8a84236-c258-4952-98b7-a6ff8a9c587a/codeSet/72",
+              "code": "2568875915",
+              "display": "Audiological Referral Scheduled",
+              "userSelected": true
+            }
+          ],
+          "text": "Audiological Referral Scheduled"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "encounter": {
+          "reference": "Encounter/97991794"
+        },
+        "effectiveDateTime": "2023-09-01T15:17:00.000Z",
+        "issued": "2023-09-01T15:18:19.000Z",
+        "performer": [
+          {
+            "extension": [
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "PPRF",
+                      "display": "primary performer"
+                    }
+                  ],
+                  "text": "primary performer"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              },
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "LA",
+                      "display": "legal authenticator"
+                    }
+                  ],
+                  "text": "legal authenticator"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              }
+            ],
+            "reference": "Practitioner/683925"
+          }
+        ],
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "373066001",
+              "display": "Yes (qualifier value)",
+              "userSelected": false
+            }
+          ],
+          "text": "Yes"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/L-197323253",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "L-197323253",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2023-09-01T15:18:19.000Z"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Observation</b></p><p><b>Patient Id</b>: f288c654-6885-4f48-999c-48d776dc06af</p><p><b>Status</b>: Final</p><p><b>Code</b>: Parent, Guardian Notified of Result</p><p><b>Result</b>: Yes</p><p><b>Effective Date</b>: Sep  1, 2023 10:17 A.M. CDT</p></div>"
+        },
+        "identifier": [
+          {
+            "system": "https://fhir.cerner.com/ceuuid",
+            "value": "CE87caf4b7-9397-4667-9897-702218017c9e-197323253-2023090115182000"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "extension": [
+              {
+                "valueCode": "unknown",
+                "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "https://fhir.cerner.com/e8a84236-c258-4952-98b7-a6ff8a9c587a/codeSet/72",
+              "code": "18752033",
+              "display": "Parent, Guardian Notified of Result",
+              "userSelected": true
+            }
+          ],
+          "text": "Parent, Guardian Notified of Result"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "encounter": {
+          "reference": "Encounter/97991794"
+        },
+        "effectiveDateTime": "2023-09-01T15:17:00.000Z",
+        "issued": "2023-09-01T15:18:19.000Z",
+        "performer": [
+          {
+            "extension": [
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "PPRF",
+                      "display": "primary performer"
+                    }
+                  ],
+                  "text": "primary performer"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              },
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "LA",
+                      "display": "legal authenticator"
+                    }
+                  ],
+                  "text": "legal authenticator"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              }
+            ],
+            "reference": "Practitioner/683925"
+          }
+        ],
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "373066001",
+              "display": "Yes (qualifier value)",
+              "userSelected": false
+            }
+          ],
+          "text": "Yes"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/L-197323251",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "L-197323251",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2023-09-01T15:18:19.000Z"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Observation</b></p><p><b>Patient Id</b>: f288c654-6885-4f48-999c-48d776dc06af</p><p><b>Status</b>: Final</p><p><b>Code</b>: Hearing Test Performed Date, Time</p><p><b>Result</b>: Sep  1, 2023 10:18 A.M. CDT</p><p><b>Effective Date</b>: Sep  1, 2023 10:17 A.M. CDT</p></div>"
+        },
+        "identifier": [
+          {
+            "system": "https://fhir.cerner.com/ceuuid",
+            "value": "CE87caf4b7-9397-4667-9897-702218017c9e-197323251-2023090115182000"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "extension": [
+              {
+                "valueCode": "unknown",
+                "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "https://fhir.cerner.com/e8a84236-c258-4952-98b7-a6ff8a9c587a/codeSet/72",
+              "code": "2568875905",
+              "display": "Hearing Test Performed Date, Time",
+              "userSelected": true
+            }
+          ],
+          "text": "Hearing Test Performed Date, Time"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "encounter": {
+          "reference": "Encounter/97991794"
+        },
+        "effectiveDateTime": "2023-09-01T15:17:00.000Z",
+        "issued": "2023-09-01T15:18:19.000Z",
+        "performer": [
+          {
+            "extension": [
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "PPRF",
+                      "display": "primary performer"
+                    }
+                  ],
+                  "text": "primary performer"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              },
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "LA",
+                      "display": "legal authenticator"
+                    }
+                  ],
+                  "text": "legal authenticator"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              }
+            ],
+            "reference": "Practitioner/683925"
+          }
+        ],
+        "valueDateTime": "2023-09-01T10:18:00-05:00"
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/L-197323249",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "L-197323249",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2023-09-01T15:18:19.000Z"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Observation</b></p><p><b>Patient Id</b>: f288c654-6885-4f48-999c-48d776dc06af</p><p><b>Status</b>: Final</p><p><b>Code</b>: Able to complete hearing test</p><p><b>Result</b>: Yes</p><p><b>Effective Date</b>: Sep  1, 2023 10:17 A.M. CDT</p></div>"
+        },
+        "identifier": [
+          {
+            "system": "https://fhir.cerner.com/ceuuid",
+            "value": "CE87caf4b7-9397-4667-9897-702218017c9e-197323249-2023090115182000"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "extension": [
+              {
+                "valueCode": "unknown",
+                "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "https://fhir.cerner.com/e8a84236-c258-4952-98b7-a6ff8a9c587a/codeSet/72",
+              "code": "27782121",
+              "display": "Able to complete hearing test",
+              "userSelected": true
+            }
+          ],
+          "text": "Able to complete hearing test"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "encounter": {
+          "reference": "Encounter/97991794"
+        },
+        "effectiveDateTime": "2023-09-01T15:17:00.000Z",
+        "issued": "2023-09-01T15:18:19.000Z",
+        "performer": [
+          {
+            "extension": [
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "PPRF",
+                      "display": "primary performer"
+                    }
+                  ],
+                  "text": "primary performer"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              },
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "LA",
+                      "display": "legal authenticator"
+                    }
+                  ],
+                  "text": "legal authenticator"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              }
+            ],
+            "reference": "Practitioner/683925"
+          }
+        ],
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "373066001",
+              "display": "Yes (qualifier value)",
+              "userSelected": false
+            }
+          ],
+          "text": "Yes"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/L-197323247",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "L-197323247",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2023-09-01T15:18:19.000Z"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Observation</b></p><p><b>Patient Id</b>: f288c654-6885-4f48-999c-48d776dc06af</p><p><b>Status</b>: Final</p><p><b>Code</b>: Otoacoustic Emissions Result</p><p><b>Result</b>: Pass left, Fail right</p><p><b>Effective Date</b>: Sep  1, 2023 10:17 A.M. CDT</p></div>"
+        },
+        "identifier": [
+          {
+            "system": "https://fhir.cerner.com/ceuuid",
+            "value": "CE87caf4b7-9397-4667-9897-702218017c9e-197323247-2023090115182000"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "extension": [
+              {
+                "valueCode": "unknown",
+                "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "https://fhir.cerner.com/e8a84236-c258-4952-98b7-a6ff8a9c587a/codeSet/72",
+              "code": "18752019",
+              "display": "Otoacoustic Emissions Result",
+              "userSelected": true
+            }
+          ],
+          "text": "Otoacoustic Emissions Result"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "encounter": {
+          "reference": "Encounter/97991794"
+        },
+        "effectiveDateTime": "2023-09-01T15:17:00.000Z",
+        "issued": "2023-09-01T15:18:19.000Z",
+        "performer": [
+          {
+            "extension": [
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "PPRF",
+                      "display": "primary performer"
+                    }
+                  ],
+                  "text": "primary performer"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              },
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "LA",
+                      "display": "legal authenticator"
+                    }
+                  ],
+                  "text": "legal authenticator"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              }
+            ],
+            "reference": "Practitioner/683925"
+          }
+        ],
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "https://fhir.cerner.com/e8a84236-c258-4952-98b7-a6ff8a9c587a/codeSet/72",
+                  "code": "18752019",
+                  "display": "Otoacoustic Emissions Result",
+                  "userSelected": true
+                }
+              ],
+              "text": "Otoacoustic Emissions Result"
+            },
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "LA10392-1",
+                  "userSelected": false
+                }
+              ],
+              "text": "Pass left"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "https://fhir.cerner.com/e8a84236-c258-4952-98b7-a6ff8a9c587a/codeSet/72",
+                  "code": "18752019",
+                  "display": "Otoacoustic Emissions Result",
+                  "userSelected": true
+                }
+              ],
+              "text": "Otoacoustic Emissions Result"
+            },
+            "valueCodeableConcept": {
+              "text": "Fail right"
+            }
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/L-197323245",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "L-197323245",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2023-09-01T15:18:19.000Z"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Observation</b></p><p><b>Patient Id</b>: f288c654-6885-4f48-999c-48d776dc06af</p><p><b>Status</b>: Final</p><p><b>Code</b>: Newborn Hearing Test Type</p><p><b>Result</b>: Otoacoustic emissions</p><p><b>Effective Date</b>: Sep  1, 2023 10:17 A.M. CDT</p></div>"
+        },
+        "identifier": [
+          {
+            "system": "https://fhir.cerner.com/ceuuid",
+            "value": "CE87caf4b7-9397-4667-9897-702218017c9e-197323245-2023090115182000"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "extension": [
+              {
+                "valueCode": "unknown",
+                "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "https://fhir.cerner.com/e8a84236-c258-4952-98b7-a6ff8a9c587a/codeSet/72",
+              "code": "18752012",
+              "display": "Newborn Hearing Test Type",
+              "userSelected": true
+            }
+          ],
+          "text": "Newborn Hearing Test Type"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "encounter": {
+          "reference": "Encounter/97991794"
+        },
+        "effectiveDateTime": "2023-09-01T15:17:00.000Z",
+        "issued": "2023-09-01T15:18:19.000Z",
+        "performer": [
+          {
+            "extension": [
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "PPRF",
+                      "display": "primary performer"
+                    }
+                  ],
+                  "text": "primary performer"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              },
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                      "code": "LA",
+                      "display": "legal authenticator"
+                    }
+                  ],
+                  "text": "legal authenticator"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
+              }
+            ],
+            "reference": "Practitioner/683925"
+          }
+        ],
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "252623004",
+              "display": "Oto-acoustic emission test (procedure)",
+              "userSelected": false
+            }
+          ],
+          "text": "Otoacoustic emissions"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Condition/104H",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "104H",
+        "meta": {
+          "versionId": "2",
+          "lastUpdated": "2024-07-15T17:57:43.000+00:00",
+          "source": "#A6Uw6xCU5HhRv1hw",
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">This is a simple narrative with only plain text</div>"
+        },
+        "extension": [
+          {
+            "url": "http://mihin.org/extension/copyright",
+            "valueString": "Copyright 2014-2023 Michigan Health Information Network Shared Services. Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0.  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
+          }
+        ],
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+              "code": "active",
+              "display": "Active"
+            }
+          ],
+          "text": "Active"
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+              "code": "confirmed",
+              "display": "Confirmed"
+            }
+          ],
+          "text": "Confirmed"
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "problem-list-item",
+                "display": "Problem List Item"
+              }
+            ],
+            "text": "Problem"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "77386006",
+              "display": "Pregnancy (finding)"
+            }
+          ],
+          "text": "Pregnancy (finding)"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "display": "Hyper A Unlucky"
+        },
+        "onsetDateTime": "2023-09-05"
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Condition/105H",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "105H",
+        "meta": {
+          "versionId": "2",
+          "lastUpdated": "2024-07-15T17:57:43.000+00:00",
+          "source": "#A6Uw6xCU5HhRv1hw",
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">This is a simple narrative with only plain text</div>"
+        },
+        "extension": [
+          {
+            "url": "http://mihin.org/extension/copyright",
+            "valueString": "Copyright 2014-2023 Michigan Health Information Network Shared Services. Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0.  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
+          }
+        ],
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+              "code": "active",
+              "display": "Active"
+            }
+          ],
+          "text": "Active"
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+              "code": "confirmed",
+              "display": "Confirmed"
+            }
+          ],
+          "text": "Confirmed"
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "encounter-diagnosis",
+                "display": "Encounter Diagnosis"
+              }
+            ],
+            "text": "Encounter Diagnosis"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "76272004",
+              "display": "Syphilis (disorder)"
+            }
+          ],
+          "text": "Syphilis (disorder)"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "display": "Hyper A Unlucky"
+        },
+        "onsetDateTime": "2023-12-15"
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/DiagnosticReport/108H",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "108H",
+        "meta": {
+          "versionId": "3",
+          "lastUpdated": "2024-07-15T17:57:43.000+00:00",
+          "source": "#A6Uw6xCU5HhRv1hw",
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">This is a simple narrative with only plain text</div>"
+        },
+        "extension": [
+          {
+            "url": "http://mihin.org/extension/copyright",
+            "valueString": "Copyright 2014-2023 Michigan Health Information Network Shared Services. Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0.  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                "code": "LAB",
+                "display": "Laboratory"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "LP70657-9",
+              "display": "RPR"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "display": "Hyper A Unlucky"
+        },
+        "effectiveDateTime": "2020-12-15",
+        "issued": "2023-12-15T14:09:35-05:00",
+        "performer": [
+          {
+            "reference": "Organization/103H",
+            "display": "Better Health Community Medical Center"
+          }
+        ],
+        "result": [
+          {
+            "reference": "Observation/109H",
+            "display": "RPR Result"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/109H",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "109H",
+        "meta": {
+          "versionId": "2",
+          "lastUpdated": "2024-07-15T17:57:43.000+00:00",
+          "source": "#A6Uw6xCU5HhRv1hw"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">This is a simple narrative with only plain text</div>"
+        },
+        "extension": [
+          {
+            "url": "http://mihin.org/extension/copyright",
+            "valueString": "Copyright 2014-2023 Michigan Health Information Network Shared Services. Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0.  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
+          }
+        ],
+        "identifier": [
+          {
+            "use": "official",
+            "system": "http://www.bmc.nl/zorgportal/identifiers/observations",
+            "value": "6327"
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "LP70657-9",
+              "display": "RPR"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "display": "Hyper A Unlucky"
+        },
+        "issued": "2023-12-15T14:09:35-05:00",
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                "code": "A",
+                "display": "Abnormal"
+              }
+            ]
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/MedicationRequest/122M",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "122M",
+        "meta": {
+          "versionId": "2",
+          "lastUpdated": "2024-07-15T17:57:43.000+00:00",
+          "source": "#A6Uw6xCU5HhRv1hw",
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">This is a simple narrative with only plain text</div>"
+        },
+        "extension": [
+          {
+            "url": "http://mihin.org/extension/copyright",
+            "valueString": "Copyright 2014-2023 Michigan Health Information Network Shared Services. Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0.  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
+          }
+        ],
+        "status": "completed",
+        "intent": "order",
+        "medicationCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+              "code": "2671695",
+              "display": "penicillin G benzathine 2400000 UNT Injection"
+            },
+            {
+              "display": "penicillin G benzathine 2400000 UNT Injection"
+            }
+          ],
+          "text": "penicillin G benzathine 2400000 UNT Injection"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "display": "Hyper A Unlucky"
+        },
+        "authoredOn": "2023-12-15T15:24:55-05:00",
+        "requester": {
+          "reference": "Practitioner/102H",
+          "display": "Susan Miller MD"
+        },
+        "dosageInstruction": [
+          {
+            "text": "2.4 million units IM as a single dose"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/MedicationAdministration/123M",
+      "resource": {
+        "resourceType": "MedicationAdministration",
+        "id": "123M",
+        "meta": {
+          "versionId": "2",
+          "lastUpdated": "2024-07-15T17:57:43.000+00:00",
+          "source": "#A6Uw6xCU5HhRv1hw"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">This is a simple narrative with only plain text</div>"
+        },
+        "extension": [
+          {
+            "url": "http://mihin.org/extension/copyright",
+            "valueString": "Copyright 2014-2023 Michigan Health Information Network Shared Services. Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0.  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
+          }
+        ],
+        "status": "completed",
+        "medicationCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+              "code": "2671695",
+              "display": "penicillin G benzathine 2400000 UNT Injection"
+            },
+            {
+              "display": "penicillin G benzathine 2400000 UNT Injection"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "display": "Hyper A Unlucky"
+        },
+        "effectivePeriod": {
+          "start": "2023-12-15T15:47:03-05:00",
+          "end": "2023-12-15T15:47:03-05:00"
+        },
+        "performer": [
+          {
+            "actor": {
+              "reference": "Practitioner/102H",
+              "display": "Susan Miller MD"
+            }
+          }
+        ],
+        "request": {
+          "reference": "MedicationRequest/122M",
+          "display": "Medication order for penicillin G benzathine 2400000 UNT Injection"
+        },
+        "dosage": {
+          "text": "20 Units SC before breakfast",
+          "route": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "255559005",
+                "display": "Intramuscular (qualifier value)"
+              }
+            ]
+          },
+          "dose": {
+            "value": 2400000,
+            "unit": "U",
+            "system": "http://unitsofmeasure.org",
+            "code": "U"
+          }
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Encounter/106H",
+      "resource": {
+        "resourceType": "Encounter",
+        "id": "106H",
+        "meta": {
+          "versionId": "2",
+          "lastUpdated": "2024-07-15T17:57:43.000+00:00",
+          "source": "#A6Uw6xCU5HhRv1hw"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">This is a simple narrative with only plain text</div>"
+        },
+        "extension": [
+          {
+            "url": "http://mihin.org/extension/copyright",
+            "valueString": "Copyright 2014-2023 Michigan Health Information Network Shared Services. Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0.  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
+          }
+        ],
+        "identifier": [
+          {
+            "system": "http://better.health.insurance.com/Encounter",
+            "value": "8367c3d4c58524dc9cc40b"
+          }
+        ],
+        "status": "in-progress",
+        "class": {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "display": "Hyper A Unlucky"
+        },
+        "participant": [
+          {
+            "individual": {
+              "reference": "Practitioner/102H",
+              "display": "Susan Miller MD"
+            }
+          }
+        ],
+        "period": {
+          "start": "2023-12-15T10:14:36-05:00",
+          "end": "2023-12-15T16:07:59+00:00"
+        },
+        "reasonReference": [
+          {
+            "reference": "Condition/105H",
+            "display": "Suspected Syphilis"
+          }
+        ],
+        "serviceProvider": {
+          "reference": "Organization/103H",
+          "display": "Better Health Community Medical Center"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/115H",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "115H",
+        "meta": {
+          "versionId": "2",
+          "lastUpdated": "2024-07-15T17:57:43.000+00:00",
+          "source": "#A6Uw6xCU5HhRv1hw"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">This is a simple narrative with only plain text</div>"
+        },
+        "extension": [
+          {
+            "url": "http://mihin.org/extension/copyright",
+            "valueString": "Copyright 2014-2023 Michigan Health Information Network Shared Services. Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0.  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
+          }
+        ],
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "82810-3",
+              "display": "Pregnancy status"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "display": "Hyper A Unlucky"
+        },
+        "effectiveDateTime": "2023-09-05",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "LA15173-0",
+              "display": "Pregnant"
+            }
+          ]
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/QuestionnaireResponse/112H",
+      "resource": {
+        "resourceType": "QuestionnaireResponse",
+        "id": "112H",
+        "meta": {
+          "versionId": "2",
+          "lastUpdated": "2024-07-15T17:57:43.000+00:00",
+          "source": "#A6Uw6xCU5HhRv1hw",
+          "profile": [
+            "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaireresponse"
+          ]
+        },
+        "text": {
+          "status": "generated"
+        },
+        "questionnaire": "http://hl7.org/fhir/us/sdoh-clinicalcare/Questionnaire/SDOHCC-QuestionnairePRAPARE",
+        "_questionnaire": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/display",
+              "valueString": "IOI Modified SDOHCC Questionnaire PRAPARE"
+            }
+          ]
+        },
+        "status": "completed",
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "display": "Hyper A Unlucky"
+        },
+        "authored": "2023-12-15T13:13:33-05:00",
+        "item": [
+          {
+            "linkId": "/93042-0",
+            "item": [
+              {
+                "linkId": "/93042-0",
+                "text": "Family and home",
+                "item": [
+                  {
+                    "linkId": "/93042-0/63512-8",
+                    "text": "How many people are living or staying at this address?",
+                    "answer": [
+                      {
+                        "valueInteger": 2
+                      }
+                    ]
+                  },
+                  {
+                    "linkId": "/93042-0/71802-3",
+                    "text": "Housing status",
+                    "answer": [
+                      {
+                        "valueCoding": {
+                          "system": "http://loinc.org",
+                          "code": "LA30190-5",
+                          "display": "I do not have housing (staying with others, in a hotel, in a shelter, living outside on the street, on a beach, in a car, or in a park)"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "linkId": "/93042-0/93033-9",
+                    "text": "Are you worried about losing your housing?",
+                    "answer": [
+                      {
+                        "valueCoding": {
+                          "system": "http://loinc.org",
+                          "code": "LA30122-8",
+                          "display": "I choose not to answer this question"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "linkId": "/93041-2",
+                "text": "Money and resources",
+                "item": [
+                  {
+                    "linkId": "/93041-2/82589-3",
+                    "text": "Highest level of educ",
+                    "answer": [
+                      {
+                        "valueCoding": {
+                          "system": "http://loinc.org",
+                          "code": "LA30192-1",
+                          "display": "High school diploma or GED"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "linkId": "/93041-2/67875-5",
+                    "text": "Employment status current",
+                    "answer": [
+                      {
+                        "valueCoding": {
+                          "system": "http://loinc.org",
+                          "code": "LA17956-6",
+                          "display": "Unemployed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "linkId": "/93041-2/76437-3",
+                    "text": "Primary insurance",
+                    "answer": [
+                      {
+                        "valueCoding": {
+                          "system": "http://loinc.org",
+                          "code": "LA17849-3",
+                          "display": "Medicaid"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "linkId": "/93041-2/93030-5",
+                    "text": "Has lack of transportation kept you from medical appointments, meetings, work, or from getting things needed for daily living?",
+                    "answer": [
+                      {
+                        "valueCoding": {
+                          "system": "http://loinc.org",
+                          "code": "LA30134-3",
+                          "display": "Yes, it has kept me from non-medical meetings, appointments, work, or from getting things that I need"
+                        }
+                      },
+                      {
+                        "valueCoding": {
+                          "system": "http://loinc.org",
+                          "code": "LA30133-5",
+                          "display": "Yes, it has kept me from medical appointments or from getting my medications"
+                        }
+                      },
+                      {
+                        "id": "SDOHCC-QuestionnaireResponseHungerVitalSignExample"
+                      },
+                      {
+                        "id": "112H",
+                        "item": [
+                          {
+                            "linkId": "/93042-0",
+                            "item": [
+                              {
+                                "linkId": "/93042-0",
+                                "text": "Family and home",
+                                "item": [
+                                  {
+                                    "linkId": "/93042-0/63512-8",
+                                    "text": "How many people are living or staying at this address?",
+                                    "answer": [
+                                      {
+                                        "valueInteger": 2
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "linkId": "/93042-0/71802-3",
+                                    "text": "Housing status",
+                                    "answer": [
+                                      {
+                                        "valueCoding": {
+                                          "system": "http://loinc.org",
+                                          "code": "LA30190-5",
+                                          "display": "I do not have housing (staying with others, in a hotel, in a shelter, living outside on the street, on a beach, in a car, or in a park)"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "linkId": "/93042-0/93033-9",
+                                    "text": "Are you worried about losing your housing?",
+                                    "answer": [
+                                      {
+                                        "valueCoding": {
+                                          "system": "http://loinc.org",
+                                          "code": "LA30122-8",
+                                          "display": "I choose not to answer this question"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "linkId": "/93041-2",
+                                "text": "Money and resources",
+                                "item": [
+                                  {
+                                    "linkId": "/93041-2/82589-3",
+                                    "text": "Highest level of educ",
+                                    "answer": [
+                                      {
+                                        "valueCoding": {
+                                          "system": "http://loinc.org",
+                                          "code": "LA30192-1",
+                                          "display": "High school diploma or GED"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "linkId": "/93041-2/67875-5",
+                                    "text": "Employment status current",
+                                    "answer": [
+                                      {
+                                        "valueCoding": {
+                                          "system": "http://loinc.org",
+                                          "code": "LA17956-6",
+                                          "display": "Unemployed"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "linkId": "/93041-2/76437-3",
+                                    "text": "Primary insurance",
+                                    "answer": [
+                                      {
+                                        "valueCoding": {
+                                          "system": "http://loinc.org",
+                                          "code": "LA17849-3",
+                                          "display": "Medicaid"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "linkId": "/93041-2/93030-5",
+                                    "text": "Has lack of transportation kept you from medical appointments, meetings, work, or from getting things needed for daily living?",
+                                    "answer": [
+                                      {
+                                        "valueCoding": {
+                                          "system": "http://loinc.org",
+                                          "code": "LA30134-3",
+                                          "display": "Yes, it has kept me from non-medical meetings, appointments, work, or from getting things that I need"
+                                        }
+                                      },
+                                      {
+                                        "valueCoding": {
+                                          "system": "http://loinc.org",
+                                          "code": "LA30133-5",
+                                          "display": "Yes, it has kept me from medical appointments or from getting my medications"
+                                        },
+                                        "item": [
+                                          {
+                                            "linkId": "/88122-7",
+                                            "text": "(I/We) worried whether (my/our) food would run out before (I/we) got money to buy more.",
+                                            "answer": [
+                                              {
+                                                "valueCoding": {
+                                                  "system": "http://loinc.org",
+                                                  "code": "LA28397-0",
+                                                  "display": "Often true"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "linkId": "/88123-5",
+                                            "text": "The food that (I/we) bought just didn't last, and (I/we) didn't have money to get more.",
+                                            "answer": [
+                                              {
+                                                "valueCoding": {
+                                                  "system": "http://loinc.org",
+                                                  "code": "LA28397-0",
+                                                  "display": "Often true"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "linkId": "/88124-3",
+                                            "text": "Food insecurity risk",
+                                            "answer": [
+                                              {
+                                                "valueCoding": {
+                                                  "system": "http://loinc.org",
+                                                  "code": "LA19952-3",
+                                                  "display": "At risk"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/ServiceRequest/107H",
+      "resource": {
+        "resourceType": "ServiceRequest",
+        "id": "107H",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-01-16T15:16:09.000+00:00",
+          "source": "#X2DasMDiZjHcPMyb"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">This is a simple narrative with only plain text</div>"
+        },
+        "extension": [
+          {
+            "url": "http://mihin.org/extension/copyright",
+            "valueString": "Copyright 2014-2023 Michigan Health Information Network Shared Services. Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0.  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
+          }
+        ],
+        "identifier": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "PLAC"
+                }
+              ],
+              "text": "Placer"
+            },
+            "system": "urn:oid:1.3.4.5.6.7",
+            "value": "2345234234234"
+          }
+        ],
+        "status": "completed",
+        "intent": "original-order",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "98212-4",
+              "display": "Reagin Ab and Treponema pallidum IgG and IgM and total panel - Serum"
+            }
+          ],
+          "text": "Rapid Plasma Reagin test (RPR)"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "display": "Hyper A Unlucky"
+        },
+        "encounter": {
+          "reference": "Encounter/106H",
+          "display": "Encounter for symptoms of syphilis"
+        },
+        "authoredOn": "2023-12-15T11:56:15-05:00",
+        "requester": {
+          "reference": "Practitioner/102H",
+          "display": "Susan Miller MD"
+        },
+        "reasonReference": [
+          {
+            "reference": "Condition/105H",
+            "display": "Suspected Syphilis"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/113H",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "113H",
+        "meta": {
+          "versionId": "2",
+          "lastUpdated": "2024-07-15T17:57:43.000+00:00",
+          "source": "#A6Uw6xCU5HhRv1hw",
+          "profile": [
+            "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ObservationScreeningResponse"
+          ]
+        },
+        "text": {
+          "status": "generated"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "social-history"
+              }
+            ]
+          },
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "survey",
+                "display": "Survey"
+              }
+            ]
+          },
+          {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/us/sdoh-clinicalcare/CodeSystem/SDOHCC-CodeSystemTemporaryCodes",
+                "code": "homelessness",
+                "display": "Homelessness"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "71802-3",
+              "display": "Housing status"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "display": "Hyper A Unlucky"
+        },
+        "effectiveDateTime": "2023-12-15T13:13:33-05:00",
+        "issued": "2023-12-15T13:15:48-05:00",
+        "performer": [
+          {
+            "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+            "display": "Hyper A Unlucky"
+          }
+        ],
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "LA30190-5",
+              "display": "I do not have housing (staying with others, in a hotel, in a shelter, living outside on the street, on a beach, in a car, or in a park)"
+            }
+          ]
+        },
+        "derivedFrom": [
+          {
+            "reference": "QuestionnaireResponse/112H",
+            "display": "SDOH Questionnaire"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Condition/114H",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "114H",
+        "meta": {
+          "versionId": "2",
+          "lastUpdated": "2024-07-15T17:57:43.000+00:00",
+          "source": "#A6Uw6xCU5HhRv1hw",
+          "profile": [
+            "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-Condition"
+          ]
+        },
+        "text": {
+          "status": "generated"
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+              "code": "active",
+              "display": "Active"
+            }
+          ]
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+              "code": "confirmed",
+              "display": "Confirmed"
+            }
+          ]
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/us/core/CodeSystem/condition-category",
+                "code": "health-concern",
+                "display": "Health Concern"
+              }
+            ]
+          },
+          {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/us/sdoh-clinicalcare/CodeSystem/SDOHCC-CodeSystemTemporaryCodes",
+                "code": "homelessness",
+                "display": "Homelessness"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "32911000",
+              "display": "Homeless"
+            },
+            {
+              "system": "http://hl7.org/fhir/sid/icd-10-cm",
+              "code": "Z59.0",
+              "display": "Homelessness"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "display": "Hyper A Unlucky"
+        },
+        "onsetPeriod": {
+          "start": "2023-08-11T12:00:00-05:00"
+        },
+        "asserter": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "display": "Hyper A Unlucky"
+        },
+        "evidence": [
+          {
+            "detail": [
+              {
+                "reference": "Observation/113H",
+                "display": "Housing Status"
+              }
+            ]
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/3bc88f73-c57e-4c0f-b02b-89a46f5b6759",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "3bc88f73-c57e-4c0f-b02b-89a46f5b6759",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-06-07T17:18:51.000+00:00",
+          "source": "#PR5m6u7xH3dqXE8G"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory",
+                "display": "Laboratory"
+              }
+            ],
+            "text": "Laboratory"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "21613-5",
+              "display": "Chlamydia trachomatis DNA [Presence] in Specimen by NAA with probe detection"
+            }
+          ],
+          "text": "Chlamydia trachomatis DNA [Presence] in Specimen by NAA with probe detection"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2024-03-12",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "260373001",
+              "display": "Detected"
+            }
+          ],
+          "text": "Detected"
+        },
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "system": "Detected",
+                "code": "DET",
+                "display": "Detected"
+              }
+            ],
+            "text": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/MedicationRequest/3bc88f73-c57e-4c0f-b02b-89a46f5b6739",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "3bc88f73-c57e-4c0f-b02b-89a46f5b6739",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-06-07T17:24:21.000+00:00",
+          "source": "#GY51sIZnI7taN9Xe"
+        },
+        "status": "active",
+        "medicationCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+              "code": "434692",
+              "display": "azithromycin 1000 MG"
+            }
+          ],
+          "text": "azithromycin 1000 MG"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "authoredOn": "2024-03-12",
+        "reasonCode": [
+          {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/sid/icd-10-cm",
+                "code": "A74.9",
+                "display": "Chlamydial infection, unspecified"
+              }
+            ],
+            "text": "Chlamydial infection, unspecified"
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "Condition/claim-52cadc42"
+          }
+        ],
+        "dosageInstruction": [
+          {
+            "text": "Single oral dose"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Condition/3bc88fa3-c57e-4c0f-b02b-89a46f5b6739",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "3bc88fa3-c57e-4c0f-b02b-89a46f5b6739",
+        "meta": {
+          "versionId": "2",
+          "lastUpdated": "2024-06-07T17:50:23.000+00:00",
+          "source": "#O9Z2or109dlXFjvG"
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "encounter-diagnosis",
+                "display": "Encounter Diagnosis"
+              }
+            ],
+            "text": "Encounter Diagnosis"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://id.who.int/icd/release/10/2019",
+              "code": "A74.9",
+              "display": "Chlamydial infection, unspecified"
+            }
+          ],
+          "text": "Chlamydial infection, unspecified"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "onsetDateTime": "2024-03-12T17:43:27.663+00:00"
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Practitioner/102H",
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "102H",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-01-16T15:10:21.000+00:00",
+          "source": "#iStxdAp9atcGA86k",
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">This is a simple narrative with only plain text</div>"
+        },
+        "extension": [
+          {
+            "url": "http://mihin.org/extension/copyright",
+            "valueString": "Copyright 2014-2023 Michigan Health Information Network Shared Services. Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0.  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
+          }
+        ],
+        "identifier": [
+          {
+            "system": "http://hl7.org.fhir/sid/us-npi",
+            "value": "1679452846"
+          },
+          {
+            "system": "http://www.acme.org/practitioners",
+            "value": "3497201"
+          }
+        ],
+        "name": [
+          {
+            "family": "Miller",
+            "given": ["Susan"],
+            "prefix": ["Dr"]
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "937-555-4171",
+            "use": "work"
+          },
+          {
+            "system": "phone",
+            "value": "937-555-2838",
+            "use": "mobile"
+          }
+        ],
+        "address": [
+          {
+            "use": "work",
+            "line": ["210 Walnut St"],
+            "city": "Hamersville",
+            "state": "OH",
+            "postalCode": "45130"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Organization/103H",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "103H",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-01-16T15:10:33.000+00:00",
+          "source": "#bwuzbwMbMAdhDTk3",
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">This is a simple narrative with only plain text</div>"
+        },
+        "extension": [
+          {
+            "url": "http://mihin.org/extension/copyright",
+            "valueString": "Copyright 2014-2023 Michigan Health Information Network Shared Services. Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0.  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
+          }
+        ],
+        "identifier": [
+          {
+            "system": "http://hl7.org.fhir/sid/us-npi",
+            "value": "6497258403"
+          },
+          {
+            "system": "http://www.acme.org/organization",
+            "value": "3497521864"
+          }
+        ],
+        "active": true,
+        "type": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/organization-type",
+                "code": "prov",
+                "display": "Healthcare Provider"
+              }
+            ]
+          }
+        ],
+        "name": "Better Health Community Medical Center",
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "(+1) 734-677-7777"
+          },
+          {
+            "system": "email",
+            "value": "betterhealthcommunitymedicalcenter@acme.org"
+          }
+        ],
+        "address": [
+          {
+            "line": ["2034 West Main St"],
+            "city": "Hamersville",
+            "state": "OH",
+            "postalCode": "45130",
+            "country": "USA"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Observation/130980",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "130980",
+        "meta": {
+          "versionId": "2",
+          "lastUpdated": "2024-05-16T13:08:45.000+00:00",
+          "source": "#1MJU4oJaAKn2kaKf"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory",
+                "display": "Laboratory"
+              }
+            ],
+            "text": "Laboratory"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "21613-5",
+              "display": "Chlamydia trachomatis DNA [Presence] in Specimen by NAA with probe detection"
+            }
+          ],
+          "text": "Chlamydia trachomatis DNA [Presence] in Specimen by NAA with probe detection"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2000-04-04",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "260415000",
+              "display": "Not Detected"
+            }
+          ],
+          "text": "Not Detected"
+        },
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                "code": "N",
+                "display": "Normal"
+              }
+            ],
+            "text": "Normal"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Observation/130981",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "130981",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-04-22T22:53:54.000+00:00",
+          "source": "#7lUJerAf2or7SsCG"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory",
+                "display": "Laboratory"
+              }
+            ],
+            "text": "Laboratory"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "24111-7",
+              "display": "Neisseria gonorrhoeae DNA [Presence] in Specimen by NAA with probe detection"
+            }
+          ],
+          "text": "Neisseria gonorrhoeae DNA [Presence] in Specimen by NAA with probe detection"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2000-04-04",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "260373001",
+              "display": "Detected"
+            }
+          ],
+          "text": "Detected"
+        },
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "system": "Detected",
+                "code": "DET",
+                "display": "Detected"
+              }
+            ],
+            "text": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Observation/130982",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "130982",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-04-22T22:53:54.000+00:00",
+          "source": "#7lUJerAf2or7SsCG"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "https://hl7.org/fhir/R4/codesystem-observation-category.html#observation-category-social-history",
+                "code": "social-history",
+                "display": "Social History"
+              }
+            ],
+            "text": "Social History"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "11350-6",
+              "display": "History of Sexual behavior Narrative"
+            }
+          ],
+          "text": "History of Sexual behavior Narrative"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2000-04-01",
+        "valueString": "2 partners in past 6 months"
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Condition/130983",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "130983",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-04-22T22:53:54.000+00:00",
+          "source": "#7lUJerAf2or7SsCG"
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "encounter-diagnosis",
+                "display": "Encounter Diagnosis"
+              }
+            ],
+            "text": "Encounter Diagnosis"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://id.who.int/icd/release/10/2019",
+              "code": "A54.9",
+              "display": "Gonococcal infection, unspecified"
+            },
+            {
+              "system": "http://snomed.info/sct",
+              "code": "15628003",
+              "display": "Gonorrhea (disorder)"
+            }
+          ],
+          "text": "Gonorrhea infection"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Encounter/130984",
+      "resource": {
+        "resourceType": "Encounter",
+        "id": "130984",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-04-22T22:53:54.000+00:00",
+          "source": "#7lUJerAf2or7SsCG"
+        },
+        "status": "in-progress",
+        "class": {
+          "system": "https://hl7.org/fhir/R4/codesystem-service-type.html",
+          "code": "441",
+          "display": "Sexually Transmitted"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "participant": [
+          {
+            "period": {
+              "start": "2000-03-02",
+              "end": "2024-03-03"
+            },
+            "individual": {
+              "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+              "type": "Practitioner"
+            }
+          }
+        ],
+        "period": {
+          "start": "2000-04-01",
+          "end": "2000-05-01"
+        },
+        "reasonCode": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "2339001",
+                "display": "Sexual overexposure"
+              }
+            ],
+            "text": "Sexual overexposure"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/MedicationRequest/130985",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "130985",
+        "meta": {
+          "versionId": "2",
+          "lastUpdated": "2024-04-23T11:06:48.000+00:00",
+          "source": "#UsEE2f93mG3wMjbq"
+        },
+        "status": "active",
+        "medicationCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+              "code": "1665005",
+              "display": "ceftriaxone 500 MG Injection"
+            }
+          ],
+          "text": "ceftriaxone 500 MG Injection"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "authoredOn": "2000-04-05",
+        "reasonCode": [
+          {
+            "coding": [
+              {
+                "system": "http://id.who.int/icd/release/10/2019",
+                "code": "A54.9",
+                "display": "Gonococcal infection, unspecified"
+              },
+              {
+                "system": "http://snomed.info/sct",
+                "code": "15628003",
+                "display": "Gonorrhea (disorder)"
+              }
+            ],
+            "text": "Gonorrhea infection"
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "Condition/130983"
+          }
+        ],
+        "dosageInstruction": [
+          {
+            "text": "Ceftriaxone 500 mg injection as a single dose"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/DiagnosticReport/130986",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "130986",
+        "meta": {
+          "versionId": "3",
+          "lastUpdated": "2024-04-23T11:04:37.000+00:00",
+          "source": "#iDRoO1DrmsqLUIID"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><div class=\"hapiHeaderText\"> Chlamydia trachomatis and Neisseria gonorrhoeae DNA panel - Specimen </div><table class=\"hapiPropertyTable\"><tbody><tr><td>Status</td><td>FINAL</td></tr><tr><td>Issued</td><td> 04 April 2000 </td></tr></tbody></table></div>"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                "code": "LAB",
+                "display": "Laboratory"
+              }
+            ],
+            "text": "Laboratory"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "72828-7",
+              "display": "Chlamydia trachomatis and Neisseria gonorrhoeae DNA panel - Specimen"
+            }
+          ],
+          "text": "Chlamydia trachomatis and Neisseria gonorrhoeae DNA panel - Specimen"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2000-04-04",
+        "issued": "2000-04-04",
+        "result": [
+          {
+            "reference": "Observation/130980"
+          },
+          {
+            "reference": "Observation/130981"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Observation/131106",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "131106",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-05-15T14:43:43.000+00:00",
+          "source": "#cmpZS8Dn4KIrSyb1"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory",
+                "display": "Laboratory"
+              }
+            ],
+            "text": "Laboratory"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "24111-7",
+              "display": "Neisseria gonorrhoeae DNA [Presence] in Specimen by NAA with probe detection"
+            }
+          ],
+          "text": "Neisseria gonorrhoeae DNA [Presence] in Specimen by NAA with probe detection"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2000-01-04",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "260373001",
+              "display": "Detected"
+            }
+          ],
+          "text": "Detected"
+        },
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "system": "Detected",
+                "code": "DET",
+                "display": "Detected"
+              }
+            ],
+            "text": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Observation/131107",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "131107",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-05-15T14:43:43.000+00:00",
+          "source": "#cmpZS8Dn4KIrSyb1"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory",
+                "display": "Laboratory"
+              }
+            ],
+            "text": "Laboratory"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "21613-5",
+              "display": "Chlamydia trachomatis DNA [Presence] in Specimen by NAA with probe detection"
+            }
+          ],
+          "text": "Chlamydia trachomatis DNA [Presence] in Specimen by NAA with probe detection"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2000-01-04",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "260373001",
+              "display": "Detected"
+            }
+          ],
+          "text": "Detected"
+        },
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "system": "Detected",
+                "code": "DET",
+                "display": "Detected"
+              }
+            ],
+            "text": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Observation/131108",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "131108",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-05-15T14:43:44.000+00:00",
+          "source": "#cmpZS8Dn4KIrSyb1"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "https://hl7.org/fhir/R4/codesystem-observation-category.html#observation-category-social-history",
+                "code": "social-history",
+                "display": "Social History"
+              }
+            ],
+            "text": "Social History"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "11350-6",
+              "display": "History of Sexual behavior Narrative"
+            }
+          ],
+          "text": "History of Sexual behavior Narrative"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2000-01-01",
+        "valueString": "10 partners in past 6 months"
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Condition/131109",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "131109",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-05-15T14:43:44.000+00:00",
+          "source": "#cmpZS8Dn4KIrSyb1"
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "encounter-diagnosis",
+                "display": "Encounter Diagnosis"
+              }
+            ],
+            "text": "Encounter Diagnosis"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://id.who.int/icd/release/10/2019",
+              "code": "A54.9",
+              "display": "Gonococcal infection, unspecified"
+            },
+            {
+              "system": "http://snomed.info/sct",
+              "code": "15628003",
+              "display": "Gonorrhea (disorder)"
+            }
+          ],
+          "text": "Gonorrhea infection"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Condition/131110",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "131110",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-05-15T14:43:44.000+00:00",
+          "source": "#cmpZS8Dn4KIrSyb1"
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "encounter-diagnosis",
+                "display": "Encounter Diagnosis"
+              }
+            ],
+            "text": "Encounter Diagnosis"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://id.who.int/icd/release/10/2019",
+              "code": "A74.9",
+              "display": "Chlamydial infection, unspecified"
+            },
+            {
+              "system": "http://snomed.info/sct",
+              "code": "105629000",
+              "display": "Chlamydial infection (disorder)"
+            }
+          ],
+          "text": "Chlamydial infection"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Encounter/131111",
+      "resource": {
+        "resourceType": "Encounter",
+        "id": "131111",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-05-15T14:43:44.000+00:00",
+          "source": "#cmpZS8Dn4KIrSyb1"
+        },
+        "status": "in-progress",
+        "class": {
+          "system": "https://hl7.org/fhir/R4/codesystem-service-type.html",
+          "code": "441",
+          "display": "Sexually Transmitted"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "participant": [
+          {
+            "period": {
+              "start": "2000-03-02",
+              "end": "2024-05-03"
+            },
+            "individual": {
+              "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+              "type": "Practitioner"
+            }
+          }
+        ],
+        "period": {
+          "start": "2000-01-01",
+          "end": "2000-02-01"
+        },
+        "reasonCode": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "2339001",
+                "display": "Sexual overexposure"
+              }
+            ],
+            "text": "Sexual overexposure"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/MedicationRequest/131112",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "131112",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-05-15T14:43:44.000+00:00",
+          "source": "#cmpZS8Dn4KIrSyb1"
+        },
+        "status": "active",
+        "medicationCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+              "code": "1649987",
+              "display": "doxycycline hyclate 100 MG"
+            }
+          ],
+          "text": "doxycycline hyclate 100 MG"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "authoredOn": "2000-01-05",
+        "reasonCode": [
+          {
+            "coding": [
+              {
+                "system": "http://id.who.int/icd/release/10/2019",
+                "code": "A74.9",
+                "display": "Chlamydial infection, unspecified"
+              },
+              {
+                "system": "http://snomed.info/sct",
+                "code": "105629000",
+                "display": "Chlamydial infection (disorder)"
+              }
+            ],
+            "text": "Chlamydial infection"
+          }
+        ],
+        "dosageInstruction": [
+          {
+            "text": "Doxycycline 100 mg orally 2 times/day for 7 days"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/MedicationRequest/131113",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "131113",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-05-15T14:43:44.000+00:00",
+          "source": "#cmpZS8Dn4KIrSyb1"
+        },
+        "status": "active",
+        "medicationCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+              "code": "1665005",
+              "display": "ceftriaxone 500 MG Injection"
+            }
+          ],
+          "text": "ceftriaxone 500 MG Injection"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "authoredOn": "2000-01-05",
+        "reasonCode": [
+          {
+            "coding": [
+              {
+                "system": "http://id.who.int/icd/release/10/2019",
+                "code": "A54.9",
+                "display": "Gonococcal infection, unspecified"
+              },
+              {
+                "system": "http://snomed.info/sct",
+                "code": "15628003",
+                "display": "Gonorrhea (disorder)"
+              }
+            ],
+            "text": "Gonorrhea infection"
+          }
+        ],
+        "dosageInstruction": [
+          {
+            "text": "Ceftriaxone 500 mg injection as a single dose"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/DiagnosticReport/131114",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "131114",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-05-15T14:43:44.000+00:00",
+          "source": "#cmpZS8Dn4KIrSyb1"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><div class=\"hapiHeaderText\"> Chlamydia trachomatis and Neisseria gonorrhoeae DNA panel - Specimen </div><table class=\"hapiPropertyTable\"><tbody><tr><td>Status</td><td>FINAL</td></tr><tr><td>Issued</td><td> 04 January 2000 </td></tr></tbody></table></div>"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                "code": "LAB",
+                "display": "Laboratory"
+              }
+            ],
+            "text": "Laboratory"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "72828-7",
+              "display": "Chlamydia trachomatis and Neisseria gonorrhoeae DNA panel - Specimen"
+            }
+          ],
+          "text": "Chlamydia trachomatis and Neisseria gonorrhoeae DNA panel - Specimen"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2000-01-04",
+        "issued": "2000-01-04"
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Practitioner/1760480503d96030446269cb1e0a862d",
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "1760480503d96030446269cb1e0a862d",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2022-01-06T03:09:18.000+00:00",
+          "source": "#851299c0e07f2170"
+        },
+        "identifier": [
+          {
+            "system": "http://hl7.org/fhir/sid/us-npi",
+            "value": "1760480503d96030446269cb1e0a862d"
+          }
+        ],
+        "active": true,
+        "name": [
+          {
+            "family": "Squier",
+            "given": ["Wilma"]
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "943-962-8386"
+          }
+        ],
+        "address": [
+          {
+            "line": ["5489 Main Street"],
+            "district": "MARICOPA",
+            "state": "Arizona",
+            "postalCode": "85000",
+            "country": "USA"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Observation/131043",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "131043",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-04-23T11:56:09.000+00:00",
+          "source": "#TNcEW0QlEkhURiHm"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory",
+                "display": "Laboratory"
+              }
+            ],
+            "text": "Laboratory"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "21613-5",
+              "display": "Chlamydia trachomatis DNA [Presence] in Specimen by NAA with probe detection"
+            }
+          ],
+          "text": "Chlamydia trachomatis DNA [Presence] in Specimen by NAA with probe detection"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2022-11-30",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "260373001",
+              "display": "Detected"
+            }
+          ],
+          "text": "Detected"
+        },
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "system": "Detected",
+                "code": "DET",
+                "display": "Detected"
+              }
+            ],
+            "text": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Observation/131044",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "131044",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-04-23T11:56:10.000+00:00",
+          "source": "#TNcEW0QlEkhURiHm"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory",
+                "display": "Laboratory"
+              }
+            ],
+            "text": "Laboratory"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "24111-7",
+              "display": "Neisseria gonorrhoeae DNA [Presence] in Specimen by NAA with probe detection"
+            }
+          ],
+          "text": "Neisseria gonorrhoeae DNA [Presence] in Specimen by NAA with probe detection"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2022-11-30",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "260373001",
+              "display": "Detected"
+            }
+          ],
+          "text": "Detected"
+        },
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "system": "Detected",
+                "code": "DET",
+                "display": "Detected"
+              }
+            ],
+            "text": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Observation/131045",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "131045",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-04-23T11:56:10.000+00:00",
+          "source": "#TNcEW0QlEkhURiHm"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "https://hl7.org/fhir/R4/codesystem-observation-category.html#observation-category-social-history",
+                "code": "social-history",
+                "display": "Social History"
+              }
+            ],
+            "text": "Social History"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "82810-3",
+              "display": "Pregnancy status"
+            }
+          ],
+          "text": "Pregnancy status"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2022-11-21",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "102874004",
+              "display": "Possible pregnancy"
+            }
+          ],
+          "text": "Possible pregnancy"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Observation/131046",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "131046",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-04-23T11:56:10.000+00:00",
+          "source": "#TNcEW0QlEkhURiHm"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "https://hl7.org/fhir/R4/codesystem-observation-category.html#observation-category-social-history",
+                "code": "social-history",
+                "display": "Social History"
+              }
+            ],
+            "text": "Social History"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "83317-8",
+              "display": "Sexual activity with anonymous partner in the past year"
+            }
+          ],
+          "text": "Sexual activity with anonymous partner in the past year"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2022-11-21",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "373066001",
+              "display": "Yes"
+            }
+          ],
+          "text": "Yes"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Condition/131047",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "131047",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-04-23T11:56:10.000+00:00",
+          "source": "#TNcEW0QlEkhURiHm"
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "encounter-diagnosis",
+                "display": "Encounter Diagnosis"
+              }
+            ],
+            "text": "Encounter Diagnosis"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://id.who.int/icd/release/10/2019",
+              "code": "A54.9",
+              "display": "Gonococcal infection, unspecified"
+            },
+            {
+              "system": "http://snomed.info/sct",
+              "code": "15628003",
+              "display": "Gonorrhea (disorder)"
+            }
+          ],
+          "text": "Gonorrhea infection"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Condition/131048",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "131048",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-04-23T11:56:10.000+00:00",
+          "source": "#TNcEW0QlEkhURiHm"
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "encounter-diagnosis",
+                "display": "Encounter Diagnosis"
+              }
+            ],
+            "text": "Encounter Diagnosis"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://id.who.int/icd/release/10/2019",
+              "code": "A74.9",
+              "display": "Chlamydial infection, unspecified"
+            },
+            {
+              "system": "http://snomed.info/sct",
+              "code": "105629000",
+              "display": "Chlamydial infection (disorder)"
+            }
+          ],
+          "text": "Chlamydia infection"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Encounter/131049",
+      "resource": {
+        "resourceType": "Encounter",
+        "id": "131049",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-04-23T11:56:10.000+00:00",
+          "source": "#TNcEW0QlEkhURiHm"
+        },
+        "status": "in-progress",
+        "class": {
+          "system": "https://hl7.org/fhir/R4/codesystem-service-type.html",
+          "code": "54",
+          "display": "Family Planning"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Family Planning"
+        },
+        "participant": [
+          {
+            "period": {
+              "start": "2022-11-21",
+              "end": "2022-12-15"
+            },
+            "individual": {
+              "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+              "type": "Practitioner"
+            }
+          }
+        ],
+        "period": {
+          "start": "2022-11-21",
+          "end": "2022-12-15"
+        },
+        "reasonCode": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "72531000052105",
+                "display": "Counseling for contraception (procedure)"
+              }
+            ],
+            "text": "Counseling for contraception (procedure)"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/MedicationRequest/131050",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "131050",
+        "meta": {
+          "versionId": "4",
+          "lastUpdated": "2024-04-23T12:08:27.000+00:00",
+          "source": "#TLk5YRsMSdJdG6dQ"
+        },
+        "status": "active",
+        "medicationCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+              "code": "1665005",
+              "display": "ceftriaxone 500 MG Injection"
+            }
+          ],
+          "text": "ceftriaxone 500 MG Injection"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "authoredOn": "2022-12-01",
+        "reasonCode": [
+          {
+            "coding": [
+              {
+                "system": "http://id.who.int/icd/release/10/2019",
+                "code": "A54.9",
+                "display": "Gonococcal infection, unspecified"
+              },
+              {
+                "system": "http://snomed.info/sct",
+                "code": "15628003",
+                "display": "Gonorrhea (disorder)"
+              }
+            ],
+            "text": "Gonorrhea infection"
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "Condition/131047"
+          }
+        ],
+        "dosageInstruction": [
+          {
+            "text": "Ceftriaxone 500 mg injection as a single dose"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/MedicationRequest/131051",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "131051",
+        "meta": {
+          "versionId": "4",
+          "lastUpdated": "2024-04-23T12:08:31.000+00:00",
+          "source": "#J6n4RJzHeLlQEEef"
+        },
+        "status": "active",
+        "medicationCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+              "code": "434692",
+              "display": "azithromycin 1000 MG"
+            }
+          ],
+          "text": "azithromycin 1000 MG"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "authoredOn": "2022-12-01",
+        "reasonCode": [
+          {
+            "coding": [
+              {
+                "system": "http://id.who.int/icd/release/10/2019",
+                "code": "A74.9",
+                "display": "Chlamydial infection, unspecified"
+              },
+              {
+                "system": "http://snomed.info/sct",
+                "code": "105629000",
+                "display": "Chlamydial infection (disorder)"
+              }
+            ],
+            "text": "Chlamydia infection"
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "Condition/131048"
+          }
+        ],
+        "dosageInstruction": [
+          {
+            "text": "1 gram azithromycin as a single oral dose"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/DiagnosticReport/131052",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "131052",
+        "meta": {
+          "versionId": "3",
+          "lastUpdated": "2024-04-23T12:06:17.000+00:00",
+          "source": "#S7z6BF8C83ddbGma"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><div class=\"hapiHeaderText\"> Chlamydia trachomatis and Neisseria gonorrhoeae DNA panel - Specimen </div><table class=\"hapiPropertyTable\"><tbody><tr><td>Status</td><td>FINAL</td></tr><tr><td>Issued</td><td> 30 November 2022 </td></tr></tbody></table></div>"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                "code": "LAB",
+                "display": "Laboratory"
+              }
+            ],
+            "text": "Laboratory"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "72828-7",
+              "display": "Chlamydia trachomatis and Neisseria gonorrhoeae DNA panel - Specimen"
+            }
+          ],
+          "text": "Chlamydia trachomatis and Neisseria gonorrhoeae DNA panel - Specimen"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2022-11-30",
+        "issued": "2022-11-30",
+        "result": [
+          {
+            "reference": "Observation/131043"
+          },
+          {
+            "reference": "Observation/131044"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/MedicationRequest/131115",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "131115",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-05-16T12:33:18.000+00:00",
+          "source": "#PUfKb1ZfSsgZB6UK"
+        },
+        "status": "active",
+        "medicationCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+              "code": "749880",
+              "display": "Brevicon 28 Day Pack"
+            }
+          ],
+          "text": "Brevicon 28 Day Pack"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "authoredOn": "2022-11-21",
+        "reasonCode": [
+          {
+            "coding": [
+              {
+                "system": "http://id.who.int/icd/release/10/2019",
+                "code": "Z30.01",
+                "display": "Encounter for initial prescription of contraceptives"
+              }
+            ],
+            "text": "Encounter for initial prescription of contraceptives"
+          }
+        ],
+        "dosageInstruction": [
+          {
+            "text": "Daily"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Practitioner/1760480503d96030446269cb1e0a862d",
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "1760480503d96030446269cb1e0a862d",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2022-01-06T03:09:18.000+00:00",
+          "source": "#851299c0e07f2170"
+        },
+        "identifier": [
+          {
+            "system": "http://hl7.org/fhir/sid/us-npi",
+            "value": "1760480503d96030446269cb1e0a862d"
+          }
+        ],
+        "active": true,
+        "name": [
+          {
+            "family": "Squier",
+            "given": ["Wilma"]
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "943-962-8386"
+          }
+        ],
+        "address": [
+          {
+            "line": ["5489 Main Street"],
+            "district": "MARICOPA",
+            "state": "Arizona",
+            "postalCode": "85000",
+            "country": "USA"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    }
+  ]
+}

--- a/containers/tefca-viewer/src/app/tests/assets/GoldenSickPatient.json
+++ b/containers/tefca-viewer/src/app/tests/assets/GoldenSickPatient.json
@@ -1,14 +1,10 @@
-// Patient ID: f288c654-6885-4f48-999c-48d776dc06af
-// Practictioner ID: 8085737b-28ec-4b23-8604-83fd20076933
-
 {
   "resourceType": "Bundle",
   "id": "6cc4ca7f-f9bf-445f-999f-86eaa2e180ae",
   "meta": {
     "lastUpdated": "2024-10-04T15:52:02.656+00:00"
   },
-  "type": "searchset",
-  "total": 6,
+  "type": "batch",
   "link": [
     {
       "relation": "self",
@@ -17,7 +13,7 @@
   ],
   "entry": [
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Patient/f288c654-6885-4f48-999c-48d776dc06af",
+      "fullUrl": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
       "resource": {
         "resourceType": "Patient",
         "id": "f288c654-6885-4f48-999c-48d776dc06af",
@@ -140,13 +136,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Condition/3C",
+      "fullUrl": "Condition/c989f4f5-8416-48ae-b8ba-e0505656b453",
       "resource": {
         "resourceType": "Condition",
-        "id": "3C",
+        "id": "c989f4f5-8416-48ae-b8ba-e0505656b453",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-01-16T15:08:47.000+00:00",
@@ -224,13 +224,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Condition/c989f4f5-8416-48ae-b8ba-e0505656b453"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/MedicationRequest/5C",
+      "fullUrl": "MedicationRequest/aedbbe7e-3496-4366-883e-34aab9841fa3",
       "resource": {
         "resourceType": "MedicationRequest",
-        "id": "5C",
+        "id": "aedbbe7e-3496-4366-883e-34aab9841fa3",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-01-16T15:09:07.000+00:00",
@@ -294,13 +298,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Condition/aedbbe7e-3496-4366-883e-34aab9841fa3"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Encounter/7C",
+      "fullUrl": "Encounter/60b85a79-8f6e-4fb3-ae37-b2ec79b34e82",
       "resource": {
         "resourceType": "Encounter",
-        "id": "7C",
+        "id": "60b85a79-8f6e-4fb3-ae37-b2ec79b34e82",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-01-16T15:09:31.000+00:00",
@@ -340,13 +348,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Encounter/60b85a79-8f6e-4fb3-ae37-b2ec79b34e82"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/MedicationAdministration/6C",
+      "fullUrl": "MedicationAdministration/dfa9a326-b056-4ec1-89bf-2a04a36af86b",
       "resource": {
         "resourceType": "MedicationAdministration",
-        "id": "6C",
+        "id": "dfa9a326-b056-4ec1-89bf-2a04a36af86b",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-01-16T15:09:42.000+00:00",
@@ -380,7 +392,7 @@
           "display": "Hyper Unlucky"
         },
         "context": {
-          "reference": "Encounter/7C",
+          "reference": "Encounter/60b85a79-8f6e-4fb3-ae37-b2ec79b34e82",
           "display": "encounter who leads to this prescription"
         },
         "effectivePeriod": {
@@ -433,10 +445,14 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "MedicationAdministration/dfa9a326-b056-4ec1-89bf-2a04a36af86b"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
+      "fullUrl": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
       "resource": {
         "resourceType": "Practitioner",
         "id": "8085737b-28ec-4b23-8604-83fd20076933",
@@ -481,13 +497,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Coverage/claim-1788c921",
+      "fullUrl": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
       "resource": {
         "resourceType": "Coverage",
-        "id": "claim-1788c921",
+        "id": "d91140ee-684a-487e-894f-2791f82e1888",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2022-01-06T03:11:43.000+00:00",
@@ -542,13 +562,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Coverage/d91140ee-684a-487e-894f-2791f82e1888"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Condition/claim-52cadc42",
+      "fullUrl": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
       "resource": {
         "resourceType": "Condition",
-        "id": "claim-52cadc42",
+        "id": "c7ae0606-d0df-4ffd-a535-91697eabf9d5",
         "meta": {
           "versionId": "2",
           "lastUpdated": "2024-04-11T22:15:00.000+00:00",
@@ -583,13 +607,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Account/claim-244ca37a",
+      "fullUrl": "Account/6443687a-442e-4737-a247-c08c7bb3179c",
       "resource": {
         "resourceType": "Account",
-        "id": "claim-244ca37a",
+        "id": "6443687a-442e-4737-a247-c08c7bb3179c",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2022-01-06T13:57:52.000+00:00",
@@ -645,13 +673,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Account/6443687a-442e-4737-a247-c08c7bb3179c"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Account/claim-169db2e3",
+      "fullUrl": "Account/54375c99-189d-4e4d-90c5-36cc4278a36c",
       "resource": {
         "resourceType": "Account",
-        "id": "claim-169db2e3",
+        "id": "54375c99-189d-4e4d-90c5-36cc4278a36c",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2022-01-06T14:00:16.000+00:00",
@@ -707,13 +739,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Account/54375c99-189d-4e4d-90c5-36cc4278a36c"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Account/claim-46eced41",
+      "fullUrl": "Account/10f8bd6b-1c50-4c98-aab2-62ae25376952",
       "resource": {
         "resourceType": "Account",
-        "id": "claim-46eced41",
+        "id": "10f8bd6b-1c50-4c98-aab2-62ae25376952",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2022-01-06T14:00:45.000+00:00",
@@ -769,13 +805,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Account/10f8bd6b-1c50-4c98-aab2-62ae25376952"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Account/claim-b3adf1d0",
+      "fullUrl": "Account/147bd32e-d3ee-45eb-8301-905b6f14b027",
       "resource": {
         "resourceType": "Account",
-        "id": "claim-b3adf1d0",
+        "id": "147bd32e-d3ee-45eb-8301-905b6f14b027 ",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2022-01-06T14:02:45.000+00:00",
@@ -830,13 +870,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Account/147bd32e-d3ee-45eb-8301-905b6f14b027"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Account/claim-4b5a64cc",
+      "fullUrl": "Account/c147bd32e-d3ee-45eb-8301-905b6f14b027",
       "resource": {
         "resourceType": "Account",
-        "id": "claim-4b5a64cc",
+        "id": "c147bd32e-d3ee-45eb-8301-905b6f14b027 ",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2022-01-06T14:04:53.000+00:00",
@@ -884,13 +928,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Account/c147bd32e-d3ee-45eb-8301-905b6f14b027"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Encounter/d96030446269cb1e0a862d",
+      "fullUrl": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464",
       "resource": {
         "resourceType": "Encounter",
-        "id": "d96030446269cb1e0a862d",
+        "id": "42eede74-6328-44e4-8dcf-fd9f4057b464",
         "meta": {
           "versionId": "14",
           "lastUpdated": "2024-04-11T22:06:33.000+00:00",
@@ -919,7 +967,7 @@
               "end": "2020-03-03"
             },
             "individual": {
-              "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+              "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
               "type": "Practitioner"
             }
           }
@@ -942,14 +990,14 @@
         ],
         "reasonReference": [
           {
-            "reference": "Condition/claim-52cadc42",
+            "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
             "type": "Condition"
           }
         ],
         "diagnosis": [
           {
             "condition": {
-              "reference": "Condition/claim-52cadc42",
+              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
               "type": "Condition"
             }
           }
@@ -964,11 +1012,11 @@
             "type": "Account"
           },
           {
-            "reference": "Account/claim-b3adf1d0",
+            "reference": "Account/147bd32e-d3ee-45eb-8301-905b6f14b027 ",
             "type": "Account"
           },
           {
-            "reference": "Account/claim-4b5a64cc",
+            "reference": "Account/c147bd32e-d3ee-45eb-8301-905b6f14b027 ",
             "type": "Account"
           }
         ],
@@ -978,13 +1026,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-c21b87d3",
+      "fullUrl": "Procedure/8b9a9a37-4d83-4400-b32f-48f681fc2f88",
       "resource": {
         "resourceType": "Procedure",
-        "id": "claim-c21b87d3",
+        "id": "8b9a9a37-4d83-4400-b32f-48f681fc2f88",
         "meta": {
           "versionId": "4",
           "lastUpdated": "2022-01-06T18:36:45.000+00:00",
@@ -1031,20 +1083,24 @@
         ],
         "reasonReference": [
           {
-            "reference": "Condition/claim-52cadc42",
+            "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
             "type": "Condition"
           }
         ]
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Procedure/8b9a9a37-4d83-4400-b32f-48f681fc2f88"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-c93e82d0",
+      "fullUrl": "Procedure/111aba60-cbb9-4ed2-881f-95c3c151851f",
       "resource": {
         "resourceType": "Procedure",
-        "id": "claim-c93e82d0",
+        "id": "111aba60-cbb9-4ed2-881f-95c3c151851f",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2022-01-06T18:36:46.000+00:00",
@@ -1091,20 +1147,24 @@
         ],
         "reasonReference": [
           {
-            "reference": "Condition/claim-52cadc42",
+            "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
             "type": "Condition"
           }
         ]
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Procedure/111aba60-cbb9-4ed2-881f-95c3c151851f"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-406f2882",
+      "fullUrl": "Procedure/7c91296f-9417-45c2-b209-33850d3c3ffb",
       "resource": {
         "resourceType": "Procedure",
-        "id": "claim-406f2882",
+        "id": "7c91296f-9417-45c2-b209-33850d3c3ffb",
         "meta": {
           "versionId": "4",
           "lastUpdated": "2022-01-06T18:36:46.000+00:00",
@@ -1151,20 +1211,24 @@
         ],
         "reasonReference": [
           {
-            "reference": "Condition/claim-52cadc42",
+            "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
             "type": "Condition"
           }
         ]
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Procedure/7c91296f-9417-45c2-b209-33850d3c3ffb"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-81b6ac78",
+      "fullUrl": "Procedure/a6ee979a-1531-492d-b594-315f03bf0c55",
       "resource": {
         "resourceType": "Procedure",
-        "id": "claim-81b6ac78",
+        "id": "a6ee979a-1531-492d-b594-315f03bf0c55",
         "meta": {
           "versionId": "4",
           "lastUpdated": "2022-01-06T18:36:46.000+00:00",
@@ -1211,20 +1275,24 @@
         ],
         "reasonReference": [
           {
-            "reference": "Condition/claim-52cadc42",
+            "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
             "type": "Condition"
           }
         ]
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Procedure/a6ee979a-1531-492d-b594-315f03bf0c55"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-dcd50a48",
+      "fullUrl": "Procedure/d35f604e-1109-42e4-9d6f-81f9babec91b",
       "resource": {
         "resourceType": "Procedure",
-        "id": "claim-dcd50a48",
+        "id": "d35f604e-1109-42e4-9d6f-81f9babec91b",
         "meta": {
           "versionId": "4",
           "lastUpdated": "2022-01-06T18:36:47.000+00:00",
@@ -1271,20 +1339,24 @@
         ],
         "reasonReference": [
           {
-            "reference": "Condition/claim-52cadc42",
+            "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
             "type": "Condition"
           }
         ]
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Procedure/d35f604e-1109-42e4-9d6f-81f9babec91b"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-9acfed3b",
+      "fullUrl": "Procedure/09a9dcd9-1e9d-4501-bbb3-b9cd0e7882df",
       "resource": {
         "resourceType": "Procedure",
-        "id": "claim-9acfed3b",
+        "id": "09a9dcd9-1e9d-4501-bbb3-b9cd0e7882df",
         "meta": {
           "versionId": "4",
           "lastUpdated": "2022-01-06T18:37:28.000+00:00",
@@ -1331,20 +1403,24 @@
         ],
         "reasonReference": [
           {
-            "reference": "Condition/claim-52cadc42",
+            "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
             "type": "Condition"
           }
         ]
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Procedure/09a9dcd9-1e9d-4501-bbb3-b9cd0e7882df"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-0f2c37d1",
+      "fullUrl": "Procedure/81cffcda-3a34-4760-abf4-d5d6cb6030a7",
       "resource": {
         "resourceType": "Procedure",
-        "id": "claim-0f2c37d1",
+        "id": "81cffcda-3a34-4760-abf4-d5d6cb6030a7",
         "meta": {
           "versionId": "4",
           "lastUpdated": "2022-01-06T18:37:28.000+00:00",
@@ -1391,20 +1467,24 @@
         ],
         "reasonReference": [
           {
-            "reference": "Condition/claim-52cadc42",
+            "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
             "type": "Condition"
           }
         ]
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Procedure/81cffcda-3a34-4760-abf4-d5d6cb6030a7"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-ed483d11",
+      "fullUrl": "Procedure/ba870de3-1d40-42ae-a3b7-717e59c79871",
       "resource": {
         "resourceType": "Procedure",
-        "id": "claim-ed483d11",
+        "id": "ba870de3-1d40-42ae-a3b7-717e59c79871",
         "meta": {
           "versionId": "4",
           "lastUpdated": "2022-01-06T18:37:28.000+00:00",
@@ -1451,20 +1531,24 @@
         ],
         "reasonReference": [
           {
-            "reference": "Condition/claim-52cadc42",
+            "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
             "type": "Condition"
           }
         ]
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Procedure/ba870de3-1d40-42ae-a3b7-717e59c79871"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-9374adbd",
+      "fullUrl": "Procedure/205a7934-4a1d-4c96-bcf8edc0e-8b4f-420a-ae68-4956a4c86d61-0e0d8eb7e0b8",
       "resource": {
         "resourceType": "Procedure",
-        "id": "claim-9374adbd",
+        "id": "205a7934-4a1d-4c96-bcf8edc0e-8b4f-420a-ae68-4956a4c86d61-0e0d8eb7e0b8",
         "meta": {
           "versionId": "4",
           "lastUpdated": "2022-01-06T18:37:28.000+00:00",
@@ -1511,20 +1595,24 @@
         ],
         "reasonReference": [
           {
-            "reference": "Condition/claim-52cadc42",
+            "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
             "type": "Condition"
           }
         ]
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Procedure/205a7934-4a1d-4c96-bcf8edc0e-8b4f-420a-ae68-4956a4c86d61-0e0d8eb7e0b8"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-a725b307",
+      "fullUrl": "Procedure/77b76c7c-9d4d-468d-ab01-0cbcaa4ecd04",
       "resource": {
         "resourceType": "Procedure",
-        "id": "claim-a725b307",
+        "id": "77b76c7c-9d4d-468d-ab01-0cbcaa4ecd04",
         "meta": {
           "versionId": "4",
           "lastUpdated": "2022-01-06T18:37:28.000+00:00",
@@ -1571,17 +1659,21 @@
         ],
         "reasonReference": [
           {
-            "reference": "Condition/claim-52cadc42",
+            "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
             "type": "Condition"
           }
         ]
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Procedure/77b76c7c-9d4d-468d-ab01-0cbcaa4ecd04"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-59e90339",
+      "fullUrl": "Procedure/814d1cad-0c10-44b0-b660-e5dbd032db09",
       "resource": {
         "resourceType": "Procedure",
         "id": "claim-59e90339",
@@ -1631,20 +1723,24 @@
         ],
         "reasonReference": [
           {
-            "reference": "Condition/claim-52cadc42",
+            "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
             "type": "Condition"
           }
         ]
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Procedure/814d1cad-0c10-44b0-b660-e5dbd032db09"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-4565d08e",
+      "fullUrl": "Procedure/ea886a68-366c-431c-89b7-0e3f3b592a51",
       "resource": {
         "resourceType": "Procedure",
-        "id": "claim-4565d08e",
+        "id": "ea886a68-366c-431c-89b7-0e3f3b592a51",
         "meta": {
           "versionId": "4",
           "lastUpdated": "2022-01-06T18:37:29.000+00:00",
@@ -1691,20 +1787,24 @@
         ],
         "reasonReference": [
           {
-            "reference": "Condition/claim-52cadc42",
+            "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
             "type": "Condition"
           }
         ]
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Procedure/ea886a68-366c-431c-89b7-0e3f3b592a51"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-56ba375e",
+      "fullUrl": "Procedure/3097604e-a816-4d1b-8bc0-68e5fb11f6a7",
       "resource": {
         "resourceType": "Procedure",
-        "id": "claim-56ba375e",
+        "id": "3097604e-a816-4d1b-8bc0-68e5fb11f6a7",
         "meta": {
           "versionId": "4",
           "lastUpdated": "2022-01-06T18:37:29.000+00:00",
@@ -1751,20 +1851,24 @@
         ],
         "reasonReference": [
           {
-            "reference": "Condition/claim-52cadc42",
+            "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
             "type": "Condition"
           }
         ]
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Procedure/3097604e-a816-4d1b-8bc0-68e5fb11f6a7"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-79583fe4",
+      "fullUrl": "Procedure/032f653b-4e14-46d7-8bfa-9a42c1961846",
       "resource": {
         "resourceType": "Procedure",
-        "id": "claim-79583fe4",
+        "id": "032f653b-4e14-46d7-8bfa-9a42c1961846",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2022-01-06T18:49:57.000+00:00",
@@ -1796,37 +1900,41 @@
           "end": "2020-03-03"
         },
         "recorder": {
-          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
           "type": "Practitioner"
         },
         "asserter": {
-          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
           "type": "Practitioner"
         },
         "performer": [
           {
             "actor": {
-              "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+              "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
               "type": "Practitioner"
             }
           }
         ],
         "reasonReference": [
           {
-            "reference": "Condition/claim-52cadc42",
+            "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
             "type": "Condition"
           }
         ]
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Procedure/032f653b-4e14-46d7-8bfa-9a42c1961846"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Procedure/claim-f70ab607",
+      "fullUrl": "Procedure/1cee4a99-ef5d-406e-80de-3a9a1b47c445",
       "resource": {
         "resourceType": "Procedure",
-        "id": "claim-f70ab607",
+        "id": "1cee4a99-ef5d-406e-80de-3a9a1b47c445",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2022-01-06T18:49:59.000+00:00",
@@ -1858,37 +1966,41 @@
           "end": "2020-03-03"
         },
         "recorder": {
-          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
           "type": "Practitioner"
         },
         "asserter": {
-          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
           "type": "Practitioner"
         },
         "performer": [
           {
             "actor": {
-              "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+              "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
               "type": "Practitioner"
             }
           }
         ],
         "reasonReference": [
           {
-            "reference": "Condition/claim-52cadc42",
+            "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
             "type": "Condition"
           }
         ]
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Procedure/1cee4a99-ef5d-406e-80de-3a9a1b47c445"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-dd27652b",
+      "fullUrl": "Claim/1cee4a99-ef5d-406e-80de-3a9a1b47c445",
       "resource": {
         "resourceType": "Claim",
-        "id": "claim-dd27652b",
+        "id": "1cee4a99-ef5d-406e-80de-3a9a1b47c445",
         "meta": {
           "versionId": "5",
           "lastUpdated": "2022-04-07T21:32:32.000+00:00",
@@ -1920,7 +2032,7 @@
         },
         "created": "2020-03-10",
         "enterer": {
-          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
           "type": "Practitioner"
         },
         "insurer": {
@@ -1928,7 +2040,7 @@
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
           "type": "Practitioner"
         },
         "payee": {
@@ -1942,7 +2054,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+            "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
             "type": "Practitioner"
           }
         },
@@ -1950,7 +2062,7 @@
           {
             "sequence": 1,
             "diagnosisReference": {
-              "reference": "Condition/claim-52cadc42",
+              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
               "type": "Condition"
             },
             "onAdmission": {
@@ -2148,13 +2260,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Claim/1cee4a99-ef5d-406e-80de-3a9a1b47c445"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-f029ba5c",
+      "fullUrl": "Claim/3f8c585d-ddfa-4417-9cfe-480e7f2e0ef9",
       "resource": {
         "resourceType": "Claim",
-        "id": "claim-f029ba5c",
+        "id": "3f8c585d-ddfa-4417-9cfe-480e7f2e0ef9",
         "meta": {
           "versionId": "5",
           "lastUpdated": "2022-04-07T21:32:32.000+00:00",
@@ -2186,7 +2302,7 @@
         },
         "created": "2020-03-10",
         "enterer": {
-          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
           "type": "Practitioner"
         },
         "insurer": {
@@ -2194,7 +2310,7 @@
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
           "type": "Practitioner"
         },
         "payee": {
@@ -2208,7 +2324,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+            "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
             "type": "Practitioner"
           }
         },
@@ -2216,7 +2332,7 @@
           {
             "sequence": 1,
             "diagnosisReference": {
-              "reference": "Condition/claim-52cadc42",
+              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
               "type": "Condition"
             },
             "onAdmission": {
@@ -2414,13 +2530,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Claim/3f8c585d-ddfa-4417-9cfe-480e7f2e0ef9"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-5bf6f7d8",
+      "fullUrl": "Claim/d6120a1b-c32f-4c6d-ac7b-3ddeb2b65a51",
       "resource": {
         "resourceType": "Claim",
-        "id": "claim-5bf6f7d8",
+        "id": "d6120a1b-c32f-4c6d-ac7b-3ddeb2b65a51",
         "meta": {
           "versionId": "5",
           "lastUpdated": "2022-04-07T21:32:32.000+00:00",
@@ -2452,7 +2572,7 @@
         },
         "created": "2020-03-10",
         "enterer": {
-          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
           "type": "Practitioner"
         },
         "insurer": {
@@ -2460,7 +2580,7 @@
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
           "type": "Practitioner"
         },
         "payee": {
@@ -2474,7 +2594,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+            "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
             "type": "Practitioner"
           }
         },
@@ -2482,7 +2602,7 @@
           {
             "sequence": 1,
             "diagnosisReference": {
-              "reference": "Condition/claim-52cadc42",
+              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
               "type": "Condition"
             },
             "onAdmission": {
@@ -2680,13 +2800,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Claim/d6120a1b-c32f-4c6d-ac7b-3ddeb2b65a51"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-96dbab39",
+      "fullUrl": "Claim/4597818f-1550-433f-83be-d53977679aa2",
       "resource": {
         "resourceType": "Claim",
-        "id": "claim-96dbab39",
+        "id": "4597818f-1550-433f-83be-d53977679aa2",
         "meta": {
           "versionId": "5",
           "lastUpdated": "2022-04-07T21:32:32.000+00:00",
@@ -2718,7 +2842,7 @@
         },
         "created": "2020-03-10",
         "enterer": {
-          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
           "type": "Practitioner"
         },
         "insurer": {
@@ -2726,7 +2850,7 @@
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
           "type": "Practitioner"
         },
         "payee": {
@@ -2740,7 +2864,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+            "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
             "type": "Practitioner"
           }
         },
@@ -2748,7 +2872,7 @@
           {
             "sequence": 1,
             "diagnosisReference": {
-              "reference": "Condition/claim-52cadc42",
+              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
               "type": "Condition"
             },
             "onAdmission": {
@@ -2946,13 +3070,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Claim/4597818f-1550-433f-83be-d53977679aa2"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-dac4f593",
+      "fullUrl": "Claim/865713a8-0af2-4497-b832-209ffe87754e",
       "resource": {
         "resourceType": "Claim",
-        "id": "claim-dac4f593",
+        "id": "865713a8-0af2-4497-b832-209ffe87754e",
         "meta": {
           "versionId": "5",
           "lastUpdated": "2022-04-07T21:32:33.000+00:00",
@@ -2984,7 +3112,7 @@
         },
         "created": "2020-03-10",
         "enterer": {
-          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
           "type": "Practitioner"
         },
         "insurer": {
@@ -2992,7 +3120,7 @@
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
           "type": "Practitioner"
         },
         "payee": {
@@ -3006,7 +3134,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+            "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
             "type": "Practitioner"
           }
         },
@@ -3014,7 +3142,7 @@
           {
             "sequence": 1,
             "diagnosisReference": {
-              "reference": "Condition/claim-52cadc42",
+              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
               "type": "Condition"
             },
             "onAdmission": {
@@ -3212,13 +3340,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Claim/865713a8-0af2-4497-b832-209ffe87754e "
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-009b92b4",
+      "fullUrl": "Claim/c505eb9a-a5df-433f-a24c-c197c7c40d05",
       "resource": {
         "resourceType": "Claim",
-        "id": "claim-009b92b4",
+        "id": "c505eb9a-a5df-433f-a24c-c197c7c40d05",
         "meta": {
           "versionId": "3",
           "lastUpdated": "2022-02-22T18:15:50.000+00:00",
@@ -3278,7 +3410,7 @@
           {
             "sequence": 1,
             "diagnosisReference": {
-              "reference": "Condition/claim-52cadc42",
+              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
               "type": "Condition"
             },
             "onAdmission": {
@@ -3311,13 +3443,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Claim/c505eb9a-a5df-433f-a24c-c197c7c40d05"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-a479f532",
+      "fullUrl": "Claim/d4f1435f-c861-425e-8e5e-7d6bec641a90",
       "resource": {
         "resourceType": "Claim",
-        "id": "claim-a479f532",
+        "id": "d4f1435f-c861-425e-8e5e-7d6bec641a90",
         "meta": {
           "versionId": "3",
           "lastUpdated": "2022-02-22T18:15:50.000+00:00",
@@ -3377,7 +3513,7 @@
           {
             "sequence": 1,
             "diagnosisReference": {
-              "reference": "Condition/claim-52cadc42",
+              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
               "type": "Condition"
             },
             "onAdmission": {
@@ -3410,13 +3546,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Claim/c505eb9a-a5df-433f-a24c-c197c7c40d05"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-31d41fe3",
+      "fullUrl": "Claim/db2ad657-8a30-4e50-9727-87d8ec7d9a1d",
       "resource": {
         "resourceType": "Claim",
-        "id": "claim-31d41fe3",
+        "id": "db2ad657-8a30-4e50-9727-87d8ec7d9a1d",
         "meta": {
           "versionId": "3",
           "lastUpdated": "2022-02-22T18:15:51.000+00:00",
@@ -3476,7 +3616,7 @@
           {
             "sequence": 1,
             "diagnosisReference": {
-              "reference": "Condition/claim-52cadc42",
+              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
               "type": "Condition"
             },
             "onAdmission": {
@@ -3509,13 +3649,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Claim/db2ad657-8a30-4e50-9727-87d8ec7d9a1d"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-049b4d31",
+      "fullUrl": "Claim/f68e8381-bd21-41f0-895d-350f81b222c9",
       "resource": {
         "resourceType": "Claim",
-        "id": "claim-049b4d31",
+        "id": "f68e8381-bd21-41f0-895d-350f81b222c9",
         "meta": {
           "versionId": "3",
           "lastUpdated": "2022-02-22T18:15:51.000+00:00",
@@ -3575,7 +3719,7 @@
           {
             "sequence": 1,
             "diagnosisReference": {
-              "reference": "Condition/claim-52cadc42",
+              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
               "type": "Condition"
             },
             "onAdmission": {
@@ -3608,13 +3752,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Claim/f68e8381-bd21-41f0-895d-350f81b222c9"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-559003bb",
+      "fullUrl": "Claim/2398ee42-9e38-4260-9023-6987296367c5",
       "resource": {
         "resourceType": "Claim",
-        "id": "claim-559003bb",
+        "id": "2398ee42-9e38-4260-9023-6987296367c5 ",
         "meta": {
           "versionId": "3",
           "lastUpdated": "2022-02-22T18:15:51.000+00:00",
@@ -3674,7 +3822,7 @@
           {
             "sequence": 1,
             "diagnosisReference": {
-              "reference": "Condition/claim-52cadc42",
+              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
               "type": "Condition"
             },
             "onAdmission": {
@@ -3707,13 +3855,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Claim/2398ee42-9e38-4260-9023-6987296367c5"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-95176e6f",
+      "fullUrl": "Claim/b99432b2-aab3-45b5-bf32-94c95507d139",
       "resource": {
         "resourceType": "Claim",
-        "id": "claim-95176e6f",
+        "id": "b99432b2-aab3-45b5-bf32-94c95507d139",
         "meta": {
           "versionId": "3",
           "lastUpdated": "2022-02-22T18:15:52.000+00:00",
@@ -3773,7 +3925,7 @@
           {
             "sequence": 1,
             "diagnosisReference": {
-              "reference": "Condition/claim-52cadc42",
+              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
               "type": "Condition"
             },
             "onAdmission": {
@@ -3806,13 +3958,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Claim/b99432b2-aab3-45b5-bf32-94c95507d139"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-878351bb",
+      "fullUrl": "Claim/f87e3064-9b3b-466f-8192-40bc33945990",
       "resource": {
         "resourceType": "Claim",
-        "id": "claim-878351bb",
+        "id": "f87e3064-9b3b-466f-8192-40bc33945990",
         "meta": {
           "versionId": "3",
           "lastUpdated": "2022-02-22T18:16:31.000+00:00",
@@ -3872,7 +4028,7 @@
           {
             "sequence": 1,
             "diagnosisReference": {
-              "reference": "Condition/claim-52cadc42",
+              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
               "type": "Condition"
             },
             "onAdmission": {
@@ -3905,13 +4061,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Claim/f87e3064-9b3b-466f-8192-40bc33945990"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-f4d216fb",
+      "fullUrl": "Claim/e5d9de33-0f19-4919-abdd-5d37d8e4fe8d",
       "resource": {
         "resourceType": "Claim",
-        "id": "claim-f4d216fb",
+        "id": "e5d9de33-0f19-4919-abdd-5d37d8e4fe8d",
         "meta": {
           "versionId": "3",
           "lastUpdated": "2022-02-22T18:16:31.000+00:00",
@@ -3971,7 +4131,7 @@
           {
             "sequence": 1,
             "diagnosisReference": {
-              "reference": "Condition/claim-52cadc42",
+              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
               "type": "Condition"
             },
             "onAdmission": {
@@ -4004,13 +4164,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Claim/e5d9de33-0f19-4919-abdd-5d37d8e4fe8d"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-6105bcdc",
+      "fullUrl": "Claim/c568125f-9095-4887-9f99-a31a4e41fc9a",
       "resource": {
         "resourceType": "Claim",
-        "id": "claim-6105bcdc",
+        "id": "c568125f-9095-4887-9f99-a31a4e41fc9a",
         "meta": {
           "versionId": "3",
           "lastUpdated": "2022-02-22T18:16:31.000+00:00",
@@ -4070,7 +4234,7 @@
           {
             "sequence": 1,
             "diagnosisReference": {
-              "reference": "Condition/claim-52cadc42",
+              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
               "type": "Condition"
             },
             "onAdmission": {
@@ -4103,13 +4267,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Claim/c568125f-9095-4887-9f99-a31a4e41fc9a"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-198c6388",
+      "fullUrl": "Claim/bbfe1f49-ad5b-4b50-b9c0-9bf21a94031f",
       "resource": {
         "resourceType": "Claim",
-        "id": "claim-198c6388",
+        "id": "bbfe1f49-ad5b-4b50-b9c0-9bf21a94031f",
         "meta": {
           "versionId": "3",
           "lastUpdated": "2022-02-22T18:16:31.000+00:00",
@@ -4169,7 +4337,7 @@
           {
             "sequence": 1,
             "diagnosisReference": {
-              "reference": "Condition/claim-52cadc42",
+              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
               "type": "Condition"
             },
             "onAdmission": {
@@ -4202,13 +4370,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Claim/bbfe1f49-ad5b-4b50-b9c0-9bf21a94031f"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-dd21bf4b",
+      "fullUrl": "Claim/ac3c9308-8b72-48c5-b10e-365ff059033e",
       "resource": {
         "resourceType": "Claim",
-        "id": "claim-dd21bf4b",
+        "id": "ac3c9308-8b72-48c5-b10e-365ff059033e",
         "meta": {
           "versionId": "3",
           "lastUpdated": "2022-02-22T18:16:31.000+00:00",
@@ -4268,7 +4440,7 @@
           {
             "sequence": 1,
             "diagnosisReference": {
-              "reference": "Condition/claim-52cadc42",
+              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
               "type": "Condition"
             },
             "onAdmission": {
@@ -4301,13 +4473,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Claim/ac3c9308-8b72-48c5-b10e-365ff059033e"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-bc77c262",
+      "fullUrl": "Claim/fa09f4b6-2696-401b-8857-ef1f6309f463",
       "resource": {
         "resourceType": "Claim",
-        "id": "claim-bc77c262",
+        "id": "fa09f4b6-2696-401b-8857-ef1f6309f463",
         "meta": {
           "versionId": "3",
           "lastUpdated": "2022-02-22T18:16:31.000+00:00",
@@ -4367,7 +4543,7 @@
           {
             "sequence": 1,
             "diagnosisReference": {
-              "reference": "Condition/claim-52cadc42",
+              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
               "type": "Condition"
             },
             "onAdmission": {
@@ -4400,13 +4576,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Claim/fa09f4b6-2696-401b-8857-ef1f6309f463"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-66b6525b",
+      "fullUrl": "Claim/fa599250-7e78-4571-af78-afacbdc1ca77",
       "resource": {
         "resourceType": "Claim",
-        "id": "claim-66b6525b",
+        "id": "fa599250-7e78-4571-af78-afacbdc1ca77",
         "meta": {
           "versionId": "3",
           "lastUpdated": "2022-02-22T18:16:31.000+00:00",
@@ -4466,7 +4646,7 @@
           {
             "sequence": 1,
             "diagnosisReference": {
-              "reference": "Condition/claim-52cadc42",
+              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
               "type": "Condition"
             },
             "onAdmission": {
@@ -4499,13 +4679,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Claim/fa599250-7e78-4571-af78-afacbdc1ca77"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-f0d58db6",
+      "fullUrl": "Claim/61a9b9db-8507-43d5-b62f-0e351573ab02",
       "resource": {
         "resourceType": "Claim",
-        "id": "claim-f0d58db6",
+        "id": "61a9b9db-8507-43d5-b62f-0e351573ab02",
         "meta": {
           "versionId": "3",
           "lastUpdated": "2022-02-22T18:16:31.000+00:00",
@@ -4565,7 +4749,7 @@
           {
             "sequence": 1,
             "diagnosisReference": {
-              "reference": "Condition/claim-52cadc42",
+              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
               "type": "Condition"
             },
             "onAdmission": {
@@ -4598,13 +4782,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Claim/61a9b9db-8507-43d5-b62f-0e351573ab02"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-2d71acc4",
+      "fullUrl": "Claim/0592c1b9-cc56-487e-b17b-0f7ad9a1015e",
       "resource": {
         "resourceType": "Claim",
-        "id": "claim-2d71acc4",
+        "id": "0592c1b9-cc56-487e-b17b-0f7ad9a1015e",
         "meta": {
           "versionId": "3",
           "lastUpdated": "2022-02-22T18:16:31.000+00:00",
@@ -4664,7 +4852,7 @@
           {
             "sequence": 1,
             "diagnosisReference": {
-              "reference": "Condition/claim-52cadc42",
+              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
               "type": "Condition"
             },
             "onAdmission": {
@@ -4697,13 +4885,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Claim/0592c1b9-cc56-487e-b17b-0f7ad9a1015e"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-c742a83f",
+      "fullUrl": "Claim/170a071a-644f-4e23-b842-960dc7c9bd50",
       "resource": {
         "resourceType": "Claim",
-        "id": "claim-c742a83f",
+        "id": "170a071a-644f-4e23-b842-960dc7c9bd50",
         "meta": {
           "versionId": "3",
           "lastUpdated": "2022-02-22T18:16:32.000+00:00",
@@ -4763,7 +4955,7 @@
           {
             "sequence": 1,
             "diagnosisReference": {
-              "reference": "Condition/claim-52cadc42",
+              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
               "type": "Condition"
             },
             "onAdmission": {
@@ -4796,13 +4988,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Claim/170a071a-644f-4e23-b842-960dc7c9bd50"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-3330756b",
+      "fullUrl": "Claim/bd786b68-03c1-458e-9157-0c6ccfedbc2d",
       "resource": {
         "resourceType": "Claim",
-        "id": "claim-3330756b",
+        "id": "bd786b68-03c1-458e-9157-0c6ccfedbc2d",
         "meta": {
           "versionId": "3",
           "lastUpdated": "2022-02-22T18:16:32.000+00:00",
@@ -4862,7 +5058,7 @@
           {
             "sequence": 1,
             "diagnosisReference": {
-              "reference": "Condition/claim-52cadc42",
+              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
               "type": "Condition"
             },
             "onAdmission": {
@@ -4895,13 +5091,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Claim/bd786b68-03c1-458e-9157-0c6ccfedbc2d"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-9fa7d0cb",
+      "fullUrl": "Claim/8ce568b8-aadc-4ebe-9f55-2e2c9da29197",
       "resource": {
         "resourceType": "Claim",
-        "id": "claim-9fa7d0cb",
+        "id": "8ce568b8-aadc-4ebe-9f55-2e2c9da29197",
         "meta": {
           "versionId": "3",
           "lastUpdated": "2022-02-22T18:16:33.000+00:00",
@@ -4961,7 +5161,7 @@
           {
             "sequence": 1,
             "diagnosisReference": {
-              "reference": "Condition/claim-52cadc42",
+              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
               "type": "Condition"
             },
             "onAdmission": {
@@ -4994,13 +5194,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Claim/8ce568b8-aadc-4ebe-9f55-2e2c9da29197"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Claim/claim-284321b7",
+      "fullUrl": "Claim/f9e65006-197a-486c-adfa-bbbe368294c2",
       "resource": {
         "resourceType": "Claim",
-        "id": "claim-284321b7",
+        "id": "f9e65006-197a-486c-adfa-bbbe368294c2",
         "meta": {
           "versionId": "3",
           "lastUpdated": "2022-02-22T18:16:33.000+00:00",
@@ -5060,7 +5264,7 @@
           {
             "sequence": 1,
             "diagnosisReference": {
-              "reference": "Condition/claim-52cadc42",
+              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
               "type": "Condition"
             },
             "onAdmission": {
@@ -5093,13 +5297,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Claim/f9e65006-197a-486c-adfa-bbbe368294c2"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/ExplanationOfBenefit/claim-12185bf6",
+      "fullUrl": "ExplanationOfBenefit/4cf9dc47-5e71-47d0-b0ff-b283fe8dc47c",
       "resource": {
         "resourceType": "ExplanationOfBenefit",
-        "id": "claim-12185bf6",
+        "id": "4cf9dc47-5e71-47d0-b0ff-b283fe8dc47c",
         "meta": {
           "versionId": "4",
           "lastUpdated": "2022-04-07T21:47:14.000+00:00",
@@ -5131,7 +5339,7 @@
         },
         "created": "2020-03-03",
         "enterer": {
-          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
           "type": "Practitioner"
         },
         "insurer": {
@@ -5139,7 +5347,7 @@
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
           "type": "Practitioner"
         },
         "priority": {
@@ -5162,12 +5370,12 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+            "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
             "type": "Practitioner"
           }
         },
         "claim": {
-          "reference": "Claim/claim-dd27652b",
+          "reference": "Claim/1cee4a99-ef5d-406e-80de-3a9a1b47c445",
           "type": "Claim"
         },
         "claimResponse": {
@@ -5179,7 +5387,7 @@
           {
             "sequence": 1,
             "diagnosisReference": {
-              "reference": "Condition/claim-52cadc42",
+              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
               "type": "Condition"
             },
             "onAdmission": {
@@ -5198,7 +5406,7 @@
             "sequence": 1,
             "date": "2020-03-02",
             "procedureReference": {
-              "reference": "Procedure/claim-c21b87d3",
+              "reference": "Procedure/8b9a9a37-4d83-4400-b32f-48f681fc2f88",
               "type": "Procedure"
             }
           }
@@ -5401,13 +5609,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Claim/4cf9dc47-5e71-47d0-b0ff-b283fe8dc47c"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/ExplanationOfBenefit/claim-fa1bd3e1",
+      "fullUrl": "ExplanationOfBenefit/cd3be588-58eb-4152-9f3a-f91a2d10e247",
       "resource": {
         "resourceType": "ExplanationOfBenefit",
-        "id": "claim-fa1bd3e1",
+        "id": "cd3be588-58eb-4152-9f3a-f91a2d10e247",
         "meta": {
           "versionId": "3",
           "lastUpdated": "2022-02-22T20:53:55.000+00:00",
@@ -5475,7 +5687,7 @@
           }
         },
         "claim": {
-          "reference": "Claim/claim-dd27652b",
+          "reference": "Claim/1cee4a99-ef5d-406e-80de-3a9a1b47c445",
           "type": "Claim"
         },
         "claimResponse": {
@@ -5487,7 +5699,7 @@
           {
             "sequence": 1,
             "diagnosisReference": {
-              "reference": "Condition/claim-52cadc42",
+              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
               "type": "Condition"
             },
             "onAdmission": {
@@ -5503,7 +5715,7 @@
           {
             "sequence": 1,
             "procedureReference": {
-              "reference": "Procedure/claim-c21b87d3",
+              "reference": "Procedure/8b9a9a37-4d83-4400-b32f-48f681fc2f88",
               "type": "Procedure"
             }
           }
@@ -5544,13 +5756,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Claim/cd3be588-58eb-4152-9f3a-f91a2d10e247"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/4DD",
+      "fullUrl": "Observation/41ad774f-024f-4c16-b870-fb6702f389f9",
       "resource": {
         "resourceType": "Observation",
-        "id": "4DD",
+        "id": "41ad774f-024f-4c16-b870-fb6702f389f9",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-07-15T17:57:43.000+00:00",
@@ -5584,13 +5800,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/41ad774f-024f-4c16-b870-fb6702f389f9"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/8HH",
+      "fullUrl": "Observation/5f7ce707-9355-466a-846a-5613a3d22a89",
       "resource": {
         "resourceType": "Observation",
-        "id": "8HH",
+        "id": "5f7ce707-9355-466a-846a-5613a3d22a89",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-07-15T17:57:43.000+00:00",
@@ -5620,13 +5840,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/5f7ce707-9355-466a-846a-5613a3d22a89"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/5EE",
+      "fullUrl": "Observation/53ba89ca-25ea-4d25-aad7-532b3dc34a0f",
       "resource": {
         "resourceType": "Observation",
-        "id": "5EE",
+        "id": "53ba89ca-25ea-4d25-aad7-532b3dc34a0f",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-07-15T17:57:43.000+00:00",
@@ -5660,13 +5884,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/53ba89ca-25ea-4d25-aad7-532b3dc34a0f"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/9II",
+      "fullUrl": "Observation/303040a8-65d4-41d2-84c3-f72d467ecef3",
       "resource": {
         "resourceType": "Observation",
-        "id": "9II",
+        "id": "303040a8-65d4-41d2-84c3-f72d467ecef3",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-07-15T17:57:43.000+00:00",
@@ -5696,13 +5924,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/303040a8-65d4-41d2-84c3-f72d467ecef3"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/11KK",
+      "fullUrl": "Observation/033cccf8-643c-409e-89cb-346876d635bf",
       "resource": {
         "resourceType": "Observation",
-        "id": "11KK",
+        "id": "033cccf8-643c-409e-89cb-346876d635bf",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-07-15T17:57:43.000+00:00",
@@ -5736,13 +5968,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/033cccf8-643c-409e-89cb-346876d635bf"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/6FF",
+      "fullUrl": "Observation/dfb90ab8-4330-490a-b4d2-63b6127da0e6",
       "resource": {
         "resourceType": "Observation",
-        "id": "6FF",
+        "id": "dfb90ab8-4330-490a-b4d2-63b6127da0e6",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-07-15T17:57:43.000+00:00",
@@ -5776,13 +6012,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/dfb90ab8-4330-490a-b4d2-63b6127da0e6"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/10JJ",
+      "fullUrl": "Observation/2f68ae0a-519b-4f8e-9792-4aed2e22dc73",
       "resource": {
         "resourceType": "Observation",
-        "id": "10JJ",
+        "id": "2f68ae0a-519b-4f8e-9792-4aed2e22dc73",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-07-15T17:57:43.000+00:00",
@@ -5816,13 +6056,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/2f68ae0a-519b-4f8e-9792-4aed2e22dc73"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/7GG",
+      "fullUrl": "Observation/d4bc8c7f-7b9a-4f77-970d-592facce24ad",
       "resource": {
         "resourceType": "Observation",
-        "id": "7GG",
+        "id": "d4bc8c7f-7b9a-4f77-970d-592facce24ad",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-07-15T17:57:43.000+00:00",
@@ -5856,13 +6100,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/d4bc8c7f-7b9a-4f77-970d-592facce24ad"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/VS-PO-197323276",
+      "fullUrl": "Observation/f1bb00a3-cdfe-4d2f-9dbb-fd11896f7567",
       "resource": {
         "resourceType": "Observation",
-        "id": "VS-PO-197323276",
+        "id": "f1bb00a3-cdfe-4d2f-9dbb-fd11896f7567",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-07-15T17:57:43.000+00:00",
@@ -5938,13 +6186,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/f1bb00a3-cdfe-4d2f-9dbb-fd11896f7567"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/L-197323272",
+      "fullUrl": "Observation/11f659fd-0b0d-4d6f-a9e7-634226246ee4",
       "resource": {
         "resourceType": "Observation",
-        "id": "L-197323272",
+        "id": "11f659fd-0b0d-4d6f-a9e7-634226246ee4",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-07-15T17:57:43.000+00:00",
@@ -6001,13 +6253,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/11f659fd-0b0d-4d6f-a9e7-634226246ee4"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/2BB",
+      "fullUrl": "Observation/cf8edc0e-8b4f-420a-ae68-4956a4c86d61",
       "resource": {
         "resourceType": "Observation",
-        "id": "2BB",
+        "id": "cf8edc0e-8b4f-420a-ae68-4956a4c86d61",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-07-15T17:57:43.000+00:00",
@@ -6041,13 +6297,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/cf8edc0e-8b4f-420a-ae68-4956a4c86d61"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/3CC",
+      "fullUrl": "Observation/bfd7390b-c10f-4a3a-9595-5d150e5fe273",
       "resource": {
         "resourceType": "Observation",
-        "id": "3CC",
+        "id": "bfd7390b-c10f-4a3a-9595-5d150e5fe273",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-07-15T17:57:43.000+00:00",
@@ -6081,13 +6341,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/bfd7390b-c10f-4a3a-9595-5d150e5fe273"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/8Z",
+      "fullUrl": "Observation/d0181891-8d22-4b78-8b21-1839f15c66c4",
       "resource": {
         "resourceType": "Observation",
-        "id": "8Z",
+        "id": "d0181891-8d22-4b78-8b21-1839f15c66c4",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-07-15T17:57:43.000+00:00",
@@ -6121,13 +6385,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/d0181891-8d22-4b78-8b21-1839f15c66c4"
       }
     },
     {
-      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/VS-PO-197323275",
+      "fullUrl": "Observation/795e9a0b-37d2-4204-b12a-136f91e8d6e1",
       "resource": {
         "resourceType": "Observation",
-        "id": "VS-PO-197323275",
+        "id": "795e9a0b-37d2-4204-b12a-136f91e8d6e1",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2023-09-01T15:30:25.000Z"
@@ -6225,13 +6493,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/795e9a0b-37d2-4204-b12a-136f91e8d6e1"
       }
     },
     {
-      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/L-197323277",
+      "fullUrl": "Observation/b082b6f7-4f39-46fc-837d-f4495d9652e6",
       "resource": {
         "resourceType": "Observation",
-        "id": "L-197323277",
+        "id": "b082b6f7-4f39-46fc-837d-f4495d9652e6",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2023-09-01T15:30:25.000Z"
@@ -6342,13 +6614,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/b082b6f7-4f39-46fc-837d-f4495d9652e6"
       }
     },
     {
-      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/L-197323273",
+      "fullUrl": "Observation/15f0a0fe-a3d6-4e78-bc91-5b95ac6ddeac",
       "resource": {
         "resourceType": "Observation",
-        "id": "L-197323273",
+        "id": "15f0a0fe-a3d6-4e78-bc91-5b95ac6ddeac",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2023-09-01T15:23:01.000Z"
@@ -6444,13 +6720,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/15f0a0fe-a3d6-4e78-bc91-5b95ac6ddeac"
       }
     },
     {
-      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/L-197323271",
+      "fullUrl": "Observation/4dc91a6b-52d7-4cb2-9b2e-13c6b42fbf50",
       "resource": {
         "resourceType": "Observation",
-        "id": "L-197323271",
+        "id": "4dc91a6b-52d7-4cb2-9b2e-13c6b42fbf50 ",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2023-09-01T15:23:00.000Z"
@@ -6551,13 +6831,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/4dc91a6b-52d7-4cb2-9b2e-13c6b42fbf50"
       }
     },
     {
-      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/L-197323269",
+      "fullUrl": "Observation/8db63145-0bb8-4ce0-8f50-815f5708c41d",
       "resource": {
         "resourceType": "Observation",
-        "id": "L-197323269",
+        "id": "8db63145-0bb8-4ce0-8f50-815f5708c41d",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2023-09-01T15:22:59.000Z"
@@ -6653,13 +6937,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/8db63145-0bb8-4ce0-8f50-815f5708c41d"
       }
     },
     {
-      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/L-197323267",
+      "fullUrl": "Observation/3ca6505d-aa78-466d-ac22-8b51dbf39b52",
       "resource": {
         "resourceType": "Observation",
-        "id": "L-197323267",
+        "id": "3ca6505d-aa78-466d-ac22-8b51dbf39b52",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2023-09-01T15:22:58.000Z"
@@ -6760,13 +7048,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/3ca6505d-aa78-466d-ac22-8b51dbf39b52"
       }
     },
     {
-      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/L-197323265",
+      "fullUrl": "Observation/e4b68761-8119-4da7-83af-234b14cc6a38",
       "resource": {
         "resourceType": "Observation",
-        "id": "L-197323265",
+        "id": "e4b68761-8119-4da7-83af-234b14cc6a38",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2023-09-01T15:22:57.000Z"
@@ -6862,13 +7154,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/e4b68761-8119-4da7-83af-234b14cc6a38"
       }
     },
     {
-      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/L-197323263",
+      "fullUrl": "Observation/a7559521-a20a-430f-a408-d297b034d260",
       "resource": {
         "resourceType": "Observation",
-        "id": "L-197323263",
+        "id": "a7559521-a20a-430f-a408-d297b034d260",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2023-09-01T15:22:57.000Z"
@@ -6968,13 +7264,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/a7559521-a20a-430f-a408-d297b034d260"
       }
     },
     {
-      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/VS-197323261",
+      "fullUrl": "Observation/68a6f6ed-a939-4527-ad00-9349ac34b7fb",
       "resource": {
         "resourceType": "Observation",
-        "id": "VS-197323261",
+        "id": "68a6f6ed-a939-4527-ad00-9349ac34b7fb",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2023-09-01T15:22:57.000Z"
@@ -7132,13 +7432,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/68a6f6ed-a939-4527-ad00-9349ac34b7fb"
       }
     },
     {
-      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/VS-197323259",
+      "fullUrl": "Observation/9d780064-e46e-4f7c-a451-377986289fd6",
       "resource": {
         "resourceType": "Observation",
-        "id": "VS-197323259",
+        "id": "9d780064-e46e-4f7c-a451-377986289fd6",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2023-09-01T15:22:57.000Z"
@@ -7289,13 +7593,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/9d780064-e46e-4f7c-a451-377986289fd6"
       }
     },
     {
-      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/L-197323257",
+      "fullUrl": "Observation/714ee971-012a-47e3-8b7b-6d2854850b6d",
       "resource": {
         "resourceType": "Observation",
-        "id": "L-197323257",
+        "id": "714ee971-012a-47e3-8b7b-6d2854850b6d",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2023-09-01T15:18:19.000Z"
@@ -7377,10 +7685,14 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/714ee971-012a-47e3-8b7b-6d2854850b6d"
       }
     },
     {
-      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/L-197323255",
+      "fullUrl": "Observation/8c14a355-de23-46db-94cb-1982d99ec6bd",
       "resource": {
         "resourceType": "Observation",
         "id": "L-197323255",
@@ -7475,13 +7787,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/8c14a355-de23-46db-94cb-1982d99ec6bd"
       }
     },
     {
-      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/L-197323253",
+      "fullUrl": "Observation/59fa10c9-edf0-490a-80f8-8343aad74a81",
       "resource": {
         "resourceType": "Observation",
-        "id": "L-197323253",
+        "id": "59fa10c9-edf0-490a-80f8-8343aad74a81",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2023-09-01T15:18:19.000Z"
@@ -7573,13 +7889,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/59fa10c9-edf0-490a-80f8-8343aad74a81"
       }
     },
     {
-      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/L-197323251",
+      "fullUrl": "Observation/59fa10c9-edf0-490a-80f8-8343aad74a81",
       "resource": {
         "resourceType": "Observation",
-        "id": "L-197323251",
+        "id": "59fa10c9-edf0-490a-80f8-8343aad74a81",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2023-09-01T15:18:19.000Z"
@@ -7661,13 +7981,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/59fa10c9-edf0-490a-80f8-8343aad74a81"
       }
     },
     {
-      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/L-197323249",
+      "fullUrl": "Observation/4822a5ac-e11a-4d4d-a8db-7ef8a4757cb6",
       "resource": {
         "resourceType": "Observation",
-        "id": "L-197323249",
+        "id": "4822a5ac-e11a-4d4d-a8db-7ef8a4757cb6",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2023-09-01T15:18:19.000Z"
@@ -7759,13 +8083,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/4822a5ac-e11a-4d4d-a8db-7ef8a4757cb6"
       }
     },
     {
-      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/L-197323247",
+      "fullUrl": "Observation/68ca137b-dd27-4e0c-a289-c9d691383731",
       "resource": {
         "resourceType": "Observation",
-        "id": "L-197323247",
+        "id": "68ca137b-dd27-4e0c-a289-c9d691383731",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2023-09-01T15:18:19.000Z"
@@ -7887,13 +8215,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/68ca137b-dd27-4e0c-a289-c9d691383731"
       }
     },
     {
-      "fullUrl": "https://fhir-ehr.cerner.com/r4/e8a84236-c258-4952-98b7-a6ff8a9c587a/Observation/L-197323245",
+      "fullUrl": "Observation/ef2c6f0e-8e33-48b5-83b7-998859e41b8a",
       "resource": {
         "resourceType": "Observation",
-        "id": "L-197323245",
+        "id": "ef2c6f0e-8e33-48b5-83b7-998859e41b8a",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2023-09-01T15:18:19.000Z"
@@ -7985,13 +8317,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/ef2c6f0e-8e33-48b5-83b7-998859e41b8a"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Condition/104H",
+      "fullUrl": "Condition/a2313732-4abd-42cb-8bbf-dd777e5e3b20",
       "resource": {
         "resourceType": "Condition",
-        "id": "104H",
+        "id": "a2313732-4abd-42cb-8bbf-dd777e5e3b20",
         "meta": {
           "versionId": "2",
           "lastUpdated": "2024-07-15T17:57:43.000+00:00",
@@ -8060,13 +8396,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Condition/a2313732-4abd-42cb-8bbf-dd777e5e3b20"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Condition/105H",
+      "fullUrl": "Condition/3a02d8c2-be4a-4772-810a-ceb9dfd6f80a",
       "resource": {
         "resourceType": "Condition",
-        "id": "105H",
+        "id": "3a02d8c2-be4a-4772-810a-ceb9dfd6f80a",
         "meta": {
           "versionId": "2",
           "lastUpdated": "2024-07-15T17:57:43.000+00:00",
@@ -8135,13 +8475,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Condition/3a02d8c2-be4a-4772-810a-ceb9dfd6f80a"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/DiagnosticReport/108H",
+      "fullUrl": "DiagnosticReport/3a6390e2-7405-44bf-b968-16224c12cac0",
       "resource": {
         "resourceType": "DiagnosticReport",
-        "id": "108H",
+        "id": "3a6390e2-7405-44bf-b968-16224c12cac0",
         "meta": {
           "versionId": "3",
           "lastUpdated": "2024-07-15T17:57:43.000+00:00",
@@ -8189,26 +8533,30 @@
         "issued": "2023-12-15T14:09:35-05:00",
         "performer": [
           {
-            "reference": "Organization/103H",
+            "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
             "display": "Better Health Community Medical Center"
           }
         ],
         "result": [
           {
-            "reference": "Observation/109H",
+            "reference": "Observation/0a33326b-fbf2-4a59-a785-ad9ba5c40ce0",
             "display": "RPR Result"
           }
         ]
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "DiagnosticReport/3a6390e2-7405-44bf-b968-16224c12cac0"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/109H",
+      "fullUrl": "Observation/0a33326b-fbf2-4a59-a785-ad9ba5c40ce0",
       "resource": {
         "resourceType": "Observation",
-        "id": "109H",
+        "id": "0a33326b-fbf2-4a59-a785-ad9ba5c40ce0",
         "meta": {
           "versionId": "2",
           "lastUpdated": "2024-07-15T17:57:43.000+00:00",
@@ -8260,13 +8608,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/0a33326b-fbf2-4a59-a785-ad9ba5c40ce0"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/MedicationRequest/122M",
+      "fullUrl": "MedicationRequest/49725a38-06d2-4a40-9e67-f9845dd544ab",
       "resource": {
         "resourceType": "MedicationRequest",
-        "id": "122M",
+        "id": "49725a38-06d2-4a40-9e67-f9845dd544ab",
         "meta": {
           "versionId": "2",
           "lastUpdated": "2024-07-15T17:57:43.000+00:00",
@@ -8306,7 +8658,7 @@
         },
         "authoredOn": "2023-12-15T15:24:55-05:00",
         "requester": {
-          "reference": "Practitioner/102H",
+          "reference": "Practitioner/297f1408-0613-42e3-b526-2e113a5584ea ",
           "display": "Susan Miller MD"
         },
         "dosageInstruction": [
@@ -8317,13 +8669,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "MedicationRequest/49725a38-06d2-4a40-9e67-f9845dd544ab"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/MedicationAdministration/123M",
+      "fullUrl": "MedicationAdministration/8093a4d2-754f-41d8-8ea3-fb1d43d64eb9",
       "resource": {
         "resourceType": "MedicationAdministration",
-        "id": "123M",
+        "id": "8093a4d2-754f-41d8-8ea3-fb1d43d64eb9",
         "meta": {
           "versionId": "2",
           "lastUpdated": "2024-07-15T17:57:43.000+00:00",
@@ -8363,7 +8719,7 @@
         "performer": [
           {
             "actor": {
-              "reference": "Practitioner/102H",
+              "reference": "Practitioner/297f1408-0613-42e3-b526-2e113a5584ea ",
               "display": "Susan Miller MD"
             }
           }
@@ -8393,13 +8749,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "MedicationAdministration/8093a4d2-754f-41d8-8ea3-fb1d43d64eb9"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Encounter/106H",
+      "fullUrl": "Encounter/87a18604-f377-4c2c-9f64-12134f1dd56e",
       "resource": {
         "resourceType": "Encounter",
-        "id": "106H",
+        "id": "87a18604-f377-4c2c-9f64-12134f1dd56e",
         "meta": {
           "versionId": "2",
           "lastUpdated": "2024-07-15T17:57:43.000+00:00",
@@ -8432,7 +8792,7 @@
         "participant": [
           {
             "individual": {
-              "reference": "Practitioner/102H",
+              "reference": "Practitioner/297f1408-0613-42e3-b526-2e113a5584ea ",
               "display": "Susan Miller MD"
             }
           }
@@ -8443,24 +8803,28 @@
         },
         "reasonReference": [
           {
-            "reference": "Condition/105H",
+            "reference": "Condition/a2313732-4abd-42cb-8bbf-dd777e5e3b20",
             "display": "Suspected Syphilis"
           }
         ],
         "serviceProvider": {
-          "reference": "Organization/103H",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "display": "Better Health Community Medical Center"
         }
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Encounter/87a18604-f377-4c2c-9f64-12134f1dd56e"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/115H",
+      "fullUrl": "Observation/212723e5-1ce0-400a-bb14-caacd3e36bbc",
       "resource": {
         "resourceType": "Observation",
-        "id": "115H",
+        "id": "212723e5-1ce0-400a-bb14-caacd3e36bbc",
         "meta": {
           "versionId": "2",
           "lastUpdated": "2024-07-15T17:57:43.000+00:00",
@@ -8503,13 +8867,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/212723e5-1ce0-400a-bb14-caacd3e36bbc"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/QuestionnaireResponse/112H",
+      "fullUrl": "QuestionnaireResponse/b9715ab2-2a6c-4b8a-8c13-b19b3da5cd6e",
       "resource": {
         "resourceType": "QuestionnaireResponse",
-        "id": "112H",
+        "id": "b9715ab2-2a6c-4b8a-8c13-b19b3da5cd6e",
         "meta": {
           "versionId": "2",
           "lastUpdated": "2024-07-15T17:57:43.000+00:00",
@@ -8646,7 +9014,7 @@
                         "id": "SDOHCC-QuestionnaireResponseHungerVitalSignExample"
                       },
                       {
-                        "id": "112H",
+                        "id": "b9715ab2-2a6c-4b8a-8c13-b19b3da5cd6e",
                         "item": [
                           {
                             "linkId": "/93042-0",
@@ -8812,10 +9180,14 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "QuestionnaireResponse/b9715ab2-2a6c-4b8a-8c13-b19b3da5cd6e"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/ServiceRequest/107H",
+      "fullUrl": "ServiceRequest/6af1f84c-9592-4f82-bec8-963ab55f5e89",
       "resource": {
         "resourceType": "ServiceRequest",
         "id": "107H",
@@ -8866,30 +9238,34 @@
           "display": "Hyper A Unlucky"
         },
         "encounter": {
-          "reference": "Encounter/106H",
+          "reference": "Encounter/87a18604-f377-4c2c-9f64-12134f1dd56e",
           "display": "Encounter for symptoms of syphilis"
         },
         "authoredOn": "2023-12-15T11:56:15-05:00",
         "requester": {
-          "reference": "Practitioner/102H",
+          "reference": "Practitioner/297f1408-0613-42e3-b526-2e113a5584ea",
           "display": "Susan Miller MD"
         },
         "reasonReference": [
           {
-            "reference": "Condition/105H",
+            "reference": "Condition/a2313732-4abd-42cb-8bbf-dd777e5e3b20",
             "display": "Suspected Syphilis"
           }
         ]
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "ServiceRequest/6af1f84c-9592-4f82-bec8-963ab55f5e89"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/113H",
+      "fullUrl": "Observation/bb44b956-bfa3-40a1-8898-7c8757b42c5f",
       "resource": {
         "resourceType": "Observation",
-        "id": "113H",
+        "id": "bb44b956-bfa3-40a1-8898-7c8757b42c5f",
         "meta": {
           "versionId": "2",
           "lastUpdated": "2024-07-15T17:57:43.000+00:00",
@@ -8962,20 +9338,24 @@
         },
         "derivedFrom": [
           {
-            "reference": "QuestionnaireResponse/112H",
+            "reference": "QuestionnaireResponse/b9715ab2-2a6c-4b8a-8c13-b19b3da5cd6e",
             "display": "SDOH Questionnaire"
           }
         ]
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/bb44b956-bfa3-40a1-8898-7c8757b42c5f"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Condition/114H",
+      "fullUrl": "Condition/d0756371-c7bf-4cb7-8c57-19c94bba4ebd",
       "resource": {
         "resourceType": "Condition",
-        "id": "114H",
+        "id": "d0756371-c7bf-4cb7-8c57-19c94bba4ebd",
         "meta": {
           "versionId": "2",
           "lastUpdated": "2024-07-15T17:57:43.000+00:00",
@@ -9063,10 +9443,14 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Condition/d0756371-c7bf-4cb7-8c57-19c94bba4ebd"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Observation/3bc88f73-c57e-4c0f-b02b-89a46f5b6759",
+      "fullUrl": "Observation/3bc88f73-c57e-4c0f-b02b-89a46f5b6759",
       "resource": {
         "resourceType": "Observation",
         "id": "3bc88f73-c57e-4c0f-b02b-89a46f5b6759",
@@ -9127,10 +9511,14 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/3bc88f73-c57e-4c0f-b02b-89a46f5b6759"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/MedicationRequest/3bc88f73-c57e-4c0f-b02b-89a46f5b6739",
+      "fullUrl": "MedicationRequest/3bc88f73-c57e-4c0f-b02b-89a46f5b6739",
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "3bc88f73-c57e-4c0f-b02b-89a46f5b6739",
@@ -9168,7 +9556,7 @@
         ],
         "reasonReference": [
           {
-            "reference": "Condition/claim-52cadc42"
+            "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5"
           }
         ],
         "dosageInstruction": [
@@ -9179,10 +9567,14 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "MedicationRequest/3bc88f73-c57e-4c0f-b02b-89a46f5b6739"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Condition/3bc88fa3-c57e-4c0f-b02b-89a46f5b6739",
+      "fullUrl": "Condition/3bc88fa3-c57e-4c0f-b02b-89a46f5b6739",
       "resource": {
         "resourceType": "Condition",
         "id": "3bc88fa3-c57e-4c0f-b02b-89a46f5b6739",
@@ -9221,13 +9613,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Condition/3bc88fa3-c57e-4c0f-b02b-89a46f5b6739"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Practitioner/102H",
+      "fullUrl": "Practitioner/297f1408-0613-42e3-b526-2e113a5584ea",
       "resource": {
         "resourceType": "Practitioner",
-        "id": "102H",
+        "id": "297f1408-0613-42e3-b526-2e113a5584ea ",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-01-16T15:10:21.000+00:00",
@@ -9287,13 +9683,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Practitioner/297f1408-0613-42e3-b526-2e113a5584ea"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/HeliosConnectathonSa/open/Organization/103H",
+      "fullUrl": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
       "resource": {
         "resourceType": "Organization",
-        "id": "103H",
+        "id": "cc8a572b-0ae5-4497-97cf-bab563cbb131",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-01-16T15:10:33.000+00:00",
@@ -9357,14 +9757,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131"
       }
     },
-
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Observation/130980",
+      "fullUrl": "Observation/6d22c4f2-1e19-42c7-8618-ed0f6b8e4f7b",
       "resource": {
         "resourceType": "Observation",
-        "id": "130980",
+        "id": "6d22c4f2-1e19-42c7-8618-ed0f6b8e4f7b",
         "meta": {
           "versionId": "2",
           "lastUpdated": "2024-05-16T13:08:45.000+00:00",
@@ -9422,13 +9825,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/6d22c4f2-1e19-42c7-8618-ed0f6b8e4f7b"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Observation/130981",
+      "fullUrl": "Observation/fc75173f-d59c-4cbf-af0e-39447630843e",
       "resource": {
         "resourceType": "Observation",
-        "id": "130981",
+        "id": "fc75173f-d59c-4cbf-af0e-39447630843e",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-04-22T22:53:54.000+00:00",
@@ -9486,13 +9893,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/fc75173f-d59c-4cbf-af0e-39447630843e"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Observation/130982",
+      "fullUrl": "Observation/673e0eb2-56bc-44c4-8f60-14b2b9ba0a88",
       "resource": {
         "resourceType": "Observation",
-        "id": "130982",
+        "id": "673e0eb2-56bc-44c4-8f60-14b2b9ba0a88",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-04-22T22:53:54.000+00:00",
@@ -9529,10 +9940,14 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/673e0eb2-56bc-44c4-8f60-14b2b9ba0a88"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Condition/130983",
+      "fullUrl": "Condition/804a1d9d-bef0-469a-af40-a0145503c3aa",
       "resource": {
         "resourceType": "Condition",
         "id": "130983",
@@ -9575,13 +9990,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Condition/804a1d9d-bef0-469a-af40-a0145503c3aa"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Encounter/130984",
+      "fullUrl": "Encounter/c84e5053-2231-4bd1-ad3a-6062a0684bc4",
       "resource": {
         "resourceType": "Encounter",
-        "id": "130984",
+        "id": "c84e5053-2231-4bd1-ad3a-6062a0684bc4",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-04-22T22:53:54.000+00:00",
@@ -9604,7 +10023,7 @@
               "end": "2024-03-03"
             },
             "individual": {
-              "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+              "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
               "type": "Practitioner"
             }
           }
@@ -9628,13 +10047,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Encounter/c84e5053-2231-4bd1-ad3a-6062a0684bc4"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/MedicationRequest/130985",
+      "fullUrl": "MedicationRequest/546a8b86-6901-4ade-ace4-816566a1e620",
       "resource": {
         "resourceType": "MedicationRequest",
-        "id": "130985",
+        "id": "546a8b86-6901-4ade-ace4-816566a1e620",
         "meta": {
           "versionId": "2",
           "lastUpdated": "2024-04-23T11:06:48.000+00:00",
@@ -9685,13 +10108,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "QuestionnaireResponse/546a8b86-6901-4ade-ace4-816566a1e620"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/DiagnosticReport/130986",
+      "fullUrl": "DiagnosticReport/8dd016a4-5189-44b4-bdb5-786eadb9851a",
       "resource": {
         "resourceType": "DiagnosticReport",
-        "id": "130986",
+        "id": "8dd016a4-5189-44b4-bdb5-786eadb9851a",
         "meta": {
           "versionId": "3",
           "lastUpdated": "2024-04-23T11:04:37.000+00:00",
@@ -9731,7 +10158,7 @@
         "issued": "2000-04-04",
         "result": [
           {
-            "reference": "Observation/130980"
+            "reference": "Observation/6d22c4f2-1e19-42c7-8618-ed0f6b8e4f7b"
           },
           {
             "reference": "Observation/130981"
@@ -9740,10 +10167,14 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "DiagnosticReport/8dd016a4-5189-44b4-bdb5-786eadb9851a"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Observation/131106",
+      "fullUrl": "Observation/606c78ab-b778-4ad2-8db2-b2e205f15c41",
       "resource": {
         "resourceType": "Observation",
         "id": "131106",
@@ -9804,10 +10235,14 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/606c78ab-b778-4ad2-8db2-b2e205f15c41"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Observation/131107",
+      "fullUrl": "Observation/c43d2272-bb9a-4d61-8908-f000b77783de",
       "resource": {
         "resourceType": "Observation",
         "id": "131107",
@@ -9868,13 +10303,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/c43d2272-bb9a-4d61-8908-f000b77783de"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Observation/131108",
+      "fullUrl": "Observation/622b609a-bbae-4191-b9c2-2bae98902c73",
       "resource": {
         "resourceType": "Observation",
-        "id": "131108",
+        "id": "622b609a-bbae-4191-b9c2-2bae98902c73",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-05-15T14:43:44.000+00:00",
@@ -9911,10 +10350,14 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/622b609a-bbae-4191-b9c2-2bae98902c73"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Condition/131109",
+      "fullUrl": "Condition/547054c8-cbf0-4110-916b-6ccfd1345ff0",
       "resource": {
         "resourceType": "Condition",
         "id": "131109",
@@ -9957,10 +10400,14 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Condition/547054c8-cbf0-4110-916b-6ccfd1345ff0"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Condition/131110",
+      "fullUrl": "Condition/6bbcfd78-deb7-4715-9dfc-68e1f0918ad2",
       "resource": {
         "resourceType": "Condition",
         "id": "131110",
@@ -10003,10 +10450,14 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Condition/6bbcfd78-deb7-4715-9dfc-68e1f0918ad2"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Encounter/131111",
+      "fullUrl": "Encounter/22b3486d-269e-43b0-bfa9-2aaac9d92050",
       "resource": {
         "resourceType": "Encounter",
         "id": "131111",
@@ -10032,7 +10483,7 @@
               "end": "2024-05-03"
             },
             "individual": {
-              "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+              "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
               "type": "Practitioner"
             }
           }
@@ -10056,10 +10507,14 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Encounter/22b3486d-269e-43b0-bfa9-2aaac9d92050"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/MedicationRequest/131112",
+      "fullUrl": "MedicationRequest/41e37368-1036-4abb-adf7-f7157cfa5a0f",
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "131112",
@@ -10108,10 +10563,14 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "MedicationRequest/41e37368-1036-4abb-adf7-f7157cfa5a0f"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/MedicationRequest/131113",
+      "fullUrl": "MedicationRequest/d2d609fe-aef2-403d-9614-a6d2bc823a03",
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "131113",
@@ -10160,10 +10619,14 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "MedicationRequest/d2d609fe-aef2-403d-9614-a6d2bc823a03"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/DiagnosticReport/131114",
+      "fullUrl": "DiagnosticReport/55066176-b4a0-485c-b68e-b31f3e28a442",
       "resource": {
         "resourceType": "DiagnosticReport",
         "id": "131114",
@@ -10207,13 +10670,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "DiagnosticReport/55066176-b4a0-485c-b68e-b31f3e28a442"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Practitioner/1760480503d96030446269cb1e0a862d",
+      "fullUrl": "Practitioner/9806f83f-41c4-48b2-a23f-ffeb328f8348",
       "resource": {
         "resourceType": "Practitioner",
-        "id": "1760480503d96030446269cb1e0a862d",
+        "id": "5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2022-01-06T03:09:18.000+00:00",
@@ -10250,11 +10717,14 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Practitioner/9806f83f-41c4-48b2-a23f-ffeb328f8348"
       }
     },
-
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Observation/131043",
+      "fullUrl": "Observation/16cd022c-ce74-47dc-96a5-62afeb62a238",
       "resource": {
         "resourceType": "Observation",
         "id": "131043",
@@ -10315,13 +10785,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/16cd022c-ce74-47dc-96a5-62afeb62a238"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Observation/131044",
+      "fullUrl": "Observation/317a32d1-16ef-479d-8ba5-eec53da3b549",
       "resource": {
         "resourceType": "Observation",
-        "id": "131044",
+        "id": "317a32d1-16ef-479d-8ba5-eec53da3b549",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-04-23T11:56:10.000+00:00",
@@ -10379,13 +10853,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/317a32d1-16ef-479d-8ba5-eec53da3b549"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Observation/131045",
+      "fullUrl": "Observation/c1d41419-8d6b-4041-8ff9-d65bb08c270f",
       "resource": {
         "resourceType": "Observation",
-        "id": "131045",
+        "id": "c1d41419-8d6b-4041-8ff9-d65bb08c270f",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-04-23T11:56:10.000+00:00",
@@ -10431,13 +10909,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/c1d41419-8d6b-4041-8ff9-d65bb08c270f"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Observation/131046",
+      "fullUrl": "Observation/baf8e26b-5d3b-478d-b72b-ed3d54cdfc69",
       "resource": {
         "resourceType": "Observation",
-        "id": "131046",
+        "id": "baf8e26b-5d3b-478d-b72b-ed3d54cdfc69",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-04-23T11:56:10.000+00:00",
@@ -10483,13 +10965,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/baf8e26b-5d3b-478d-b72b-ed3d54cdfc69"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Condition/131047",
+      "fullUrl": "Condition/5c52f9aa-82e9-4f13-be73-ee4c9539f785",
       "resource": {
         "resourceType": "Condition",
-        "id": "131047",
+        "id": "5c52f9aa-82e9-4f13-be73-ee4c9539f785",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-04-23T11:56:10.000+00:00",
@@ -10529,13 +11015,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Condition/5c52f9aa-82e9-4f13-be73-ee4c9539f785"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Condition/131048",
+      "fullUrl": "Condition/6e4f3cd1-099d-4684-903e-70bf4bcaa4a1",
       "resource": {
         "resourceType": "Condition",
-        "id": "131048",
+        "id": "6e4f3cd1-099d-4684-903e-70bf4bcaa4a1",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-04-23T11:56:10.000+00:00",
@@ -10575,13 +11065,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Condition/6e4f3cd1-099d-4684-903e-70bf4bcaa4a1"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Encounter/131049",
+      "fullUrl": "Encounter/7f613cae-d0e6-4e06-9026-4b4fef8273b6",
       "resource": {
         "resourceType": "Encounter",
-        "id": "131049",
+        "id": "7f613cae-d0e6-4e06-9026-4b4fef8273b6",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-04-23T11:56:10.000+00:00",
@@ -10604,7 +11098,7 @@
               "end": "2022-12-15"
             },
             "individual": {
-              "reference": "Practitioner/1760480503d96030446269cb1e0a862d",
+              "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
               "type": "Practitioner"
             }
           }
@@ -10628,13 +11122,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Encounter/7f613cae-d0e6-4e06-9026-4b4fef8273b6"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/MedicationRequest/131050",
+      "fullUrl": "MedicationRequest/c911589d-683f-49a8-97d3-f231033a97df",
       "resource": {
         "resourceType": "MedicationRequest",
-        "id": "131050",
+        "id": "c911589d-683f-49a8-97d3-f231033a97df",
         "meta": {
           "versionId": "4",
           "lastUpdated": "2024-04-23T12:08:27.000+00:00",
@@ -10674,7 +11172,7 @@
         ],
         "reasonReference": [
           {
-            "reference": "Condition/131047"
+            "reference": "Condition/5c52f9aa-82e9-4f13-be73-ee4c9539f785"
           }
         ],
         "dosageInstruction": [
@@ -10685,10 +11183,14 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "MedicationRequest/c911589d-683f-49a8-97d3-f231033a97df"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/MedicationRequest/131051",
+      "fullUrl": "MedicationRequest/43f7e264-161a-4e8a-9cef-aea6d6f7bfb7",
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "131051",
@@ -10731,7 +11233,7 @@
         ],
         "reasonReference": [
           {
-            "reference": "Condition/131048"
+            "reference": "Condition/6e4f3cd1-099d-4684-903e-70bf4bcaa4a1"
           }
         ],
         "dosageInstruction": [
@@ -10742,10 +11244,14 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "MedicationRequest/43f7e264-161a-4e8a-9cef-aea6d6f7bfb7"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/DiagnosticReport/131052",
+      "fullUrl": "DiagnosticReport/7ea6d8c0-b493-4208-8e07-30432aa34ee3",
       "resource": {
         "resourceType": "DiagnosticReport",
         "id": "131052",
@@ -10791,16 +11297,20 @@
             "reference": "Observation/131043"
           },
           {
-            "reference": "Observation/131044"
+            "reference": "Observation/317a32d1-16ef-479d-8ba5-eec53da3b549"
           }
         ]
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "DiagnosticReport/7ea6d8c0-b493-4208-8e07-30432aa34ee3"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/MedicationRequest/131115",
+      "fullUrl": "MedicationRequest/d3c8fbcd-8212-437e-bafd-7cb946770c3f",
       "resource": {
         "resourceType": "MedicationRequest",
         "id": "131115",
@@ -10844,13 +11354,17 @@
       },
       "search": {
         "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "MedicationRequest/d3c8fbcd-8212-437e-bafd-7cb946770c3f"
       }
     },
     {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Practitioner/1760480503d96030446269cb1e0a862d",
+      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
       "resource": {
         "resourceType": "Practitioner",
-        "id": "1760480503d96030446269cb1e0a862d",
+        "id": "5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2022-01-06T03:09:18.000+00:00",
@@ -10859,7 +11373,7 @@
         "identifier": [
           {
             "system": "http://hl7.org/fhir/sid/us-npi",
-            "value": "1760480503d96030446269cb1e0a862d"
+            "value": "5122d9eb-e0c8-4fd4-a734-3d7909d2f811"
           }
         ],
         "active": true,

--- a/containers/tefca-viewer/src/app/tests/assets/GoldenSickPatient.json
+++ b/containers/tefca-viewer/src/app/tests/assets/GoldenSickPatient.json
@@ -143,6 +143,353 @@
       }
     },
     {
+      "fullUrl": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "8085737b-28ec-4b23-8604-83fd20076933",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-01-16T15:08:36.000+00:00",
+          "source": "#zOdodLUnhoAvr3zS",
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><p><b>id</b>: practitioner-1</p><p><b>meta</b>: </p><p><b>identifier</b>: id: 9941339108, id: 25456</p><p><b>name</b>: Ronald Bone </p><p><b>address</b>: 1003 Healthcare Drive Amherst MA 01002 (HOME)</p></div>"
+        },
+        "identifier": [
+          {
+            "system": "http://hl7.org.fhir/sid/us-npi",
+            "value": "1948792758"
+          },
+          {
+            "system": "http://www.acme.org/practitioners",
+            "value": "25647"
+          }
+        ],
+        "name": [
+          {
+            "family": "Pocondriac",
+            "given": ["Hai"],
+            "prefix": ["Dr"]
+          }
+        ],
+        "address": [
+          {
+            "use": "home",
+            "line": ["4531 Marketplace Drive"],
+            "city": "Lansing",
+            "state": "MI",
+            "postalCode": "48893"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933"
+      }
+    },
+    {
+      "fullUrl": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "cc8a572b-0ae5-4497-97cf-bab563cbb131",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-01-16T15:10:33.000+00:00",
+          "source": "#bwuzbwMbMAdhDTk3",
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">This is a simple narrative with only plain text</div>"
+        },
+        "extension": [
+          {
+            "url": "http://mihin.org/extension/copyright",
+            "valueString": "Copyright 2014-2023 Michigan Health Information Network Shared Services. Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0.  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
+          }
+        ],
+        "identifier": [
+          {
+            "system": "http://hl7.org.fhir/sid/us-npi",
+            "value": "6497258403"
+          },
+          {
+            "system": "http://www.acme.org/organization",
+            "value": "3497521864"
+          }
+        ],
+        "active": true,
+        "type": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/organization-type",
+                "code": "prov",
+                "display": "Healthcare Provider"
+              }
+            ]
+          }
+        ],
+        "name": "Better Health Community Medical Center",
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "(+1) 734-677-7777"
+          },
+          {
+            "system": "email",
+            "value": "betterhealthcommunitymedicalcenter@acme.org"
+          }
+        ],
+        "address": [
+          {
+            "line": ["2034 West Main St"],
+            "city": "Hamersville",
+            "state": "OH",
+            "postalCode": "45130",
+            "country": "USA"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131"
+      }
+    },
+    {
+      "fullUrl": "Account/6443687a-442e-4737-a247-c08c7bb3179c",
+      "resource": {
+        "resourceType": "Account",
+        "id": "6443687a-442e-4737-a247-c08c7bb3179c",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2022-01-06T13:57:52.000+00:00",
+          "source": "#84caf125c9ce2e7d"
+        },
+        "identifier": [
+          {
+            "system": "http://iol.health.com/Account",
+            "value": "d96030446269cb1e0a862d"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+              "code": "PBILLACCT",
+              "display": "Patient Billing Acount"
+            }
+          ]
+        },
+        "subject": [
+          {
+            "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+            "type": "Patient"
+          }
+        ],
+        "servicePeriod": {
+          "start": "2020-03-04",
+          "end": "2020-03-04"
+        },
+        "coverage": [
+          {
+            "priority": 6
+          }
+        ],
+        "owner": {
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
+          "type": "Organization"
+        },
+        "guarantor": [
+          {
+            "party": {
+              "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+              "type": "Patient"
+            },
+            "period": {
+              "start": "2020-03-04",
+              "end": "2020-03-08"
+            }
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Account/6443687a-442e-4737-a247-c08c7bb3179c"
+      }
+    },
+    {
+      "fullUrl": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464",
+      "resource": {
+        "resourceType": "Encounter",
+        "id": "42eede74-6328-44e4-8dcf-fd9f4057b464",
+        "meta": {
+          "versionId": "14",
+          "lastUpdated": "2024-04-11T22:06:33.000+00:00",
+          "source": "#tiG9A1ye7499UPBA"
+        },
+        "identifier": [
+          {
+            "system": "http://better.health.insurance.com/Encounter",
+            "value": "42eede74-6328-44e4-8dcf-fd9f4057b464"
+          }
+        ],
+        "status": "in-progress",
+        "class": {
+          "system": "https://hl7.org/fhir/R4/codesystem-service-type.html",
+          "code": "441",
+          "display": "Sexually Transmitted"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "participant": [
+          {
+            "period": {
+              "start": "2020-03-02",
+              "end": "2020-03-03"
+            },
+            "individual": {
+              "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
+              "type": "Practitioner"
+            }
+          }
+        ],
+        "period": {
+          "start": "2024-03-11",
+          "end": "2024-04-11"
+        },
+        "reasonCode": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "2339001",
+                "display": "Sexual overexposure"
+              }
+            ],
+            "text": "Sexual overexposure"
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
+            "type": "Condition"
+          }
+        ],
+        "diagnosis": [
+          {
+            "condition": {
+              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
+              "type": "Condition"
+            }
+          }
+        ],
+        "account": [
+          {
+            "reference": "Account/6443687a-442e-4737-a247-c08c7bb3179c",
+            "type": "Account"
+          },
+          {
+            "reference": "Account/147bd32e-d3ee-45eb-8301-905b6f14b027",
+            "type": "Account"
+          }
+        ],
+        "partOf": {
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464"
+        }
+      },
+      "search": {
+        "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464"
+      }
+    },
+    {
+      "fullUrl": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
+      "resource": {
+        "resourceType": "Coverage",
+        "id": "d91140ee-684a-487e-894f-2791f82e1888",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2022-01-06T03:11:43.000+00:00",
+          "source": "#c64259dfad10ca17"
+        },
+        "identifier": [
+          {
+            "system": "http://better.health.insurance.com/plan",
+            "value": "d96030446269cb1e0a862d36237"
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/v3/ActCode",
+              "code": "PPO",
+              "display": "preferred provider organization policy"
+            }
+          ]
+        },
+        "policyHolder": {
+          "display": "Cayden Abbott"
+        },
+        "subscriber": {
+          "display": "Cayden Abbott"
+        },
+        "beneficiary": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "relationship": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/policyholder-relationship",
+              "code": "self",
+              "display": "Self"
+            }
+          ]
+        },
+        "period": {
+          "start": "2018-11-04",
+          "end": "2019-11-04"
+        },
+        "payor": [
+          {
+            "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
+            "type": "Organization"
+          }
+        ],
+        "order": 1
+      },
+      "search": {
+        "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Coverage/d91140ee-684a-487e-894f-2791f82e1888"
+      }
+    },
+    {
       "fullUrl": "Condition/c989f4f5-8416-48ae-b8ba-e0505656b453",
       "resource": {
         "resourceType": "Condition",
@@ -301,7 +648,7 @@
       },
       "request": {
         "method": "PUT",
-        "url": "Condition/aedbbe7e-3496-4366-883e-34aab9841fa3"
+        "url": "MedicationRequest/aedbbe7e-3496-4366-883e-34aab9841fa3"
       }
     },
     {
@@ -413,7 +760,7 @@
           }
         ],
         "request": {
-          "reference": "MedicationRequest/5C"
+          "reference": "MedicationRequest/aedbbe7e-3496-4366-883e-34aab9841fa3"
         },
         "dosage": {
           "text": "Rapid daily-dose escalation, until tolerated, from 3 mg/d, and then 10 mg/d, to the recommended maintenance dose of 30 mg IV over 120 min, 3 times per wk on alternate days for up to 12 wk",
@@ -451,123 +798,7 @@
         "url": "MedicationAdministration/dfa9a326-b056-4ec1-89bf-2a04a36af86b"
       }
     },
-    {
-      "fullUrl": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
-      "resource": {
-        "resourceType": "Practitioner",
-        "id": "8085737b-28ec-4b23-8604-83fd20076933",
-        "meta": {
-          "versionId": "1",
-          "lastUpdated": "2024-01-16T15:08:36.000+00:00",
-          "source": "#zOdodLUnhoAvr3zS",
-          "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
-          ]
-        },
-        "text": {
-          "status": "generated",
-          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><p><b>id</b>: practitioner-1</p><p><b>meta</b>: </p><p><b>identifier</b>: id: 9941339108, id: 25456</p><p><b>name</b>: Ronald Bone </p><p><b>address</b>: 1003 Healthcare Drive Amherst MA 01002 (HOME)</p></div>"
-        },
-        "identifier": [
-          {
-            "system": "http://hl7.org.fhir/sid/us-npi",
-            "value": "1948792758"
-          },
-          {
-            "system": "http://www.acme.org/practitioners",
-            "value": "25647"
-          }
-        ],
-        "name": [
-          {
-            "family": "Pocondriac",
-            "given": ["Hai"],
-            "prefix": ["Dr"]
-          }
-        ],
-        "address": [
-          {
-            "use": "home",
-            "line": ["4531 Marketplace Drive"],
-            "city": "Lansing",
-            "state": "MI",
-            "postalCode": "48893"
-          }
-        ]
-      },
-      "search": {
-        "mode": "match"
-      },
-      "request": {
-        "method": "PUT",
-        "url": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933"
-      }
-    },
-    {
-      "fullUrl": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
-      "resource": {
-        "resourceType": "Coverage",
-        "id": "d91140ee-684a-487e-894f-2791f82e1888",
-        "meta": {
-          "versionId": "1",
-          "lastUpdated": "2022-01-06T03:11:43.000+00:00",
-          "source": "#c64259dfad10ca17"
-        },
-        "identifier": [
-          {
-            "system": "http://better.health.insurance.com/plan",
-            "value": "d96030446269cb1e0a862d36237"
-          }
-        ],
-        "status": "active",
-        "type": {
-          "coding": [
-            {
-              "system": "http://hl7.org/fhir/v3/ActCode",
-              "code": "PPO",
-              "display": "preferred provider organization policy"
-            }
-          ]
-        },
-        "policyHolder": {
-          "display": "Cayden Abbott"
-        },
-        "subscriber": {
-          "display": "Cayden Abbott"
-        },
-        "beneficiary": {
-          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
-          "type": "Patient"
-        },
-        "relationship": {
-          "coding": [
-            {
-              "system": "http://hl7.org/fhir/policyholder-relationship",
-              "code": "self",
-              "display": "Self"
-            }
-          ]
-        },
-        "period": {
-          "start": "2018-11-04",
-          "end": "2019-11-04"
-        },
-        "payor": [
-          {
-            "reference": "Organization/claim-8c651f04",
-            "type": "Organization"
-          }
-        ],
-        "order": 1
-      },
-      "search": {
-        "mode": "match"
-      },
-      "request": {
-        "method": "PUT",
-        "url": "Coverage/d91140ee-684a-487e-894f-2791f82e1888"
-      }
-    },
+
     {
       "fullUrl": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
       "resource": {
@@ -613,72 +844,7 @@
         "url": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5"
       }
     },
-    {
-      "fullUrl": "Account/6443687a-442e-4737-a247-c08c7bb3179c",
-      "resource": {
-        "resourceType": "Account",
-        "id": "6443687a-442e-4737-a247-c08c7bb3179c",
-        "meta": {
-          "versionId": "1",
-          "lastUpdated": "2022-01-06T13:57:52.000+00:00",
-          "source": "#84caf125c9ce2e7d"
-        },
-        "identifier": [
-          {
-            "system": "http://iol.health.com/Account",
-            "value": "d96030446269cb1e0a862d"
-          }
-        ],
-        "status": "active",
-        "type": {
-          "coding": [
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-              "code": "PBILLACCT",
-              "display": "Patient Billing Acount"
-            }
-          ]
-        },
-        "subject": [
-          {
-            "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
-            "type": "Patient"
-          }
-        ],
-        "servicePeriod": {
-          "start": "2020-03-04",
-          "end": "2020-03-04"
-        },
-        "coverage": [
-          {
-            "priority": 6
-          }
-        ],
-        "owner": {
-          "reference": "Organization/claim-8c651f04",
-          "type": "Organization"
-        },
-        "guarantor": [
-          {
-            "party": {
-              "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
-              "type": "Patient"
-            },
-            "period": {
-              "start": "2020-03-04",
-              "end": "2020-03-08"
-            }
-          }
-        ]
-      },
-      "search": {
-        "mode": "match"
-      },
-      "request": {
-        "method": "PUT",
-        "url": "Account/6443687a-442e-4737-a247-c08c7bb3179c"
-      }
-    },
+
     {
       "fullUrl": "Account/54375c99-189d-4e4d-90c5-36cc4278a36c",
       "resource": {
@@ -721,7 +887,7 @@
           }
         ],
         "owner": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "guarantor": [
@@ -787,7 +953,7 @@
           }
         ],
         "owner": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "guarantor": [
@@ -853,7 +1019,7 @@
           }
         ],
         "owner": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "guarantor": [
@@ -877,162 +1043,6 @@
       }
     },
     {
-      "fullUrl": "Account/c147bd32e-d3ee-45eb-8301-905b6f14b027",
-      "resource": {
-        "resourceType": "Account",
-        "id": "c147bd32e-d3ee-45eb-8301-905b6f14b027 ",
-        "meta": {
-          "versionId": "1",
-          "lastUpdated": "2022-01-06T14:04:53.000+00:00",
-          "source": "#124943d0c5608988"
-        },
-        "identifier": [
-          {
-            "system": "http://iol.health.com/Account",
-            "value": "d96030446269cb1e0a862d"
-          }
-        ],
-        "status": "active",
-        "type": {
-          "coding": [
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-              "code": "PBILLACCT",
-              "display": "Patient Billing Acount"
-            }
-          ]
-        },
-        "subject": [
-          {
-            "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
-            "type": "Patient"
-          }
-        ],
-        "coverage": [
-          {
-            "priority": 2
-          }
-        ],
-        "owner": {
-          "reference": "Organization/claim-8c651f04",
-          "type": "Organization"
-        },
-        "guarantor": [
-          {
-            "party": {
-              "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
-              "type": "Patient"
-            }
-          }
-        ]
-      },
-      "search": {
-        "mode": "match"
-      },
-      "request": {
-        "method": "PUT",
-        "url": "Account/c147bd32e-d3ee-45eb-8301-905b6f14b027"
-      }
-    },
-    {
-      "fullUrl": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464",
-      "resource": {
-        "resourceType": "Encounter",
-        "id": "42eede74-6328-44e4-8dcf-fd9f4057b464",
-        "meta": {
-          "versionId": "14",
-          "lastUpdated": "2024-04-11T22:06:33.000+00:00",
-          "source": "#tiG9A1ye7499UPBA"
-        },
-        "identifier": [
-          {
-            "system": "http://better.health.insurance.com/Encounter",
-            "value": "d96030446269cb1e0a862d"
-          }
-        ],
-        "status": "in-progress",
-        "class": {
-          "system": "https://hl7.org/fhir/R4/codesystem-service-type.html",
-          "code": "441",
-          "display": "Sexually Transmitted"
-        },
-        "subject": {
-          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
-          "type": "Patient"
-        },
-        "participant": [
-          {
-            "period": {
-              "start": "2020-03-02",
-              "end": "2020-03-03"
-            },
-            "individual": {
-              "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
-              "type": "Practitioner"
-            }
-          }
-        ],
-        "period": {
-          "start": "2024-03-11",
-          "end": "2024-04-11"
-        },
-        "reasonCode": [
-          {
-            "coding": [
-              {
-                "system": "http://snomed.info/sct",
-                "code": "2339001",
-                "display": "Sexual overexposure"
-              }
-            ],
-            "text": "Sexual overexposure"
-          }
-        ],
-        "reasonReference": [
-          {
-            "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
-            "type": "Condition"
-          }
-        ],
-        "diagnosis": [
-          {
-            "condition": {
-              "reference": "Condition/c7ae0606-d0df-4ffd-a535-91697eabf9d5",
-              "type": "Condition"
-            }
-          }
-        ],
-        "account": [
-          {
-            "reference": "Account/claim-169db2e3",
-            "type": "Account"
-          },
-          {
-            "reference": "Account/claim-46eced41",
-            "type": "Account"
-          },
-          {
-            "reference": "Account/147bd32e-d3ee-45eb-8301-905b6f14b027 ",
-            "type": "Account"
-          },
-          {
-            "reference": "Account/c147bd32e-d3ee-45eb-8301-905b6f14b027 ",
-            "type": "Account"
-          }
-        ],
-        "partOf": {
-          "reference": "Encounter/d96030446269cb1e0a862d"
-        }
-      },
-      "search": {
-        "mode": "match"
-      },
-      "request": {
-        "method": "PUT",
-        "url": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464"
-      }
-    },
-    {
       "fullUrl": "Procedure/8b9a9a37-4d83-4400-b32f-48f681fc2f88",
       "resource": {
         "resourceType": "Procedure",
@@ -1044,7 +1054,7 @@
         },
         "identifier": [
           {
-            "value": "d96030446269cb1e0a862d"
+            "value": "42eede74-6328-44e4-8dcf-fd9f4057b464"
           }
         ],
         "status": "completed",
@@ -1062,21 +1072,21 @@
           "type": "Patient"
         },
         "encounter": {
-          "reference": "Encounter/d96030446269cb1e0a862d",
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464",
           "type": "Encounter"
         },
         "recorder": {
-          "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "asserter": {
-          "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "performer": [
           {
             "actor": {
-              "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+              "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
               "type": "Practitioner"
             }
           }
@@ -1126,21 +1136,21 @@
           "type": "Patient"
         },
         "encounter": {
-          "reference": "Encounter/d96030446269cb1e0a862d",
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464",
           "type": "Encounter"
         },
         "recorder": {
-          "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "asserter": {
-          "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "performer": [
           {
             "actor": {
-              "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+              "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
               "type": "Practitioner"
             }
           }
@@ -1190,21 +1200,21 @@
           "type": "Patient"
         },
         "encounter": {
-          "reference": "Encounter/d96030446269cb1e0a862d",
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464",
           "type": "Encounter"
         },
         "recorder": {
-          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "asserter": {
-          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "performer": [
           {
             "actor": {
-              "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+              "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
               "type": "Practitioner"
             }
           }
@@ -1254,21 +1264,21 @@
           "type": "Patient"
         },
         "encounter": {
-          "reference": "Encounter/d96030446269cb1e0a862d",
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464",
           "type": "Encounter"
         },
         "recorder": {
-          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "asserter": {
-          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "performer": [
           {
             "actor": {
-              "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+              "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
               "type": "Practitioner"
             }
           }
@@ -1318,21 +1328,21 @@
           "type": "Patient"
         },
         "encounter": {
-          "reference": "Encounter/d96030446269cb1e0a862d",
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464",
           "type": "Encounter"
         },
         "recorder": {
-          "reference": "Practitioner/1346205721d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "asserter": {
-          "reference": "Practitioner/1346205721d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "performer": [
           {
             "actor": {
-              "reference": "Practitioner/1346205721d96030446269cb1e0a862d",
+              "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
               "type": "Practitioner"
             }
           }
@@ -1382,21 +1392,21 @@
           "type": "Patient"
         },
         "encounter": {
-          "reference": "Encounter/d96030446269cb1e0a862d",
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464",
           "type": "Encounter"
         },
         "recorder": {
-          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "asserter": {
-          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "performer": [
           {
             "actor": {
-              "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+              "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
               "type": "Practitioner"
             }
           }
@@ -1446,21 +1456,21 @@
           "type": "Patient"
         },
         "encounter": {
-          "reference": "Encounter/d96030446269cb1e0a862d",
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464",
           "type": "Encounter"
         },
         "recorder": {
-          "reference": "Practitioner/1447213657d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "asserter": {
-          "reference": "Practitioner/1447213657d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "performer": [
           {
             "actor": {
-              "reference": "Practitioner/1447213657d96030446269cb1e0a862d",
+              "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
               "type": "Practitioner"
             }
           }
@@ -1510,21 +1520,21 @@
           "type": "Patient"
         },
         "encounter": {
-          "reference": "Encounter/d96030446269cb1e0a862d",
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464",
           "type": "Encounter"
         },
         "recorder": {
-          "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "asserter": {
-          "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "performer": [
           {
             "actor": {
-              "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+              "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
               "type": "Practitioner"
             }
           }
@@ -1545,10 +1555,10 @@
       }
     },
     {
-      "fullUrl": "Procedure/205a7934-4a1d-4c96-bcf8edc0e-8b4f-420a-ae68-4956a4c86d61-0e0d8eb7e0b8",
+      "fullUrl": "Procedure/9b7d7bc9-986a-42e5-a0ef-287a7c31d9ff",
       "resource": {
         "resourceType": "Procedure",
-        "id": "205a7934-4a1d-4c96-bcf8edc0e-8b4f-420a-ae68-4956a4c86d61-0e0d8eb7e0b8",
+        "id": "9b7d7bc9-986a-42e5-a0ef-287a7c31d9ff",
         "meta": {
           "versionId": "4",
           "lastUpdated": "2022-01-06T18:37:28.000+00:00",
@@ -1574,21 +1584,21 @@
           "type": "Patient"
         },
         "encounter": {
-          "reference": "Encounter/d96030446269cb1e0a862d",
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464",
           "type": "Encounter"
         },
         "recorder": {
-          "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "asserter": {
-          "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "performer": [
           {
             "actor": {
-              "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+              "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
               "type": "Practitioner"
             }
           }
@@ -1605,7 +1615,7 @@
       },
       "request": {
         "method": "PUT",
-        "url": "Procedure/205a7934-4a1d-4c96-bcf8edc0e-8b4f-420a-ae68-4956a4c86d61-0e0d8eb7e0b8"
+        "url": "Procedure/9b7d7bc9-986a-42e5-a0ef-287a7c31d9ff"
       }
     },
     {
@@ -1638,21 +1648,21 @@
           "type": "Patient"
         },
         "encounter": {
-          "reference": "Encounter/d96030446269cb1e0a862d",
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464",
           "type": "Encounter"
         },
         "recorder": {
-          "reference": "Practitioner/1629377890d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "asserter": {
-          "reference": "Practitioner/1629377890d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "performer": [
           {
             "actor": {
-              "reference": "Practitioner/1629377890d96030446269cb1e0a862d",
+              "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
               "type": "Practitioner"
             }
           }
@@ -1676,7 +1686,7 @@
       "fullUrl": "Procedure/814d1cad-0c10-44b0-b660-e5dbd032db09",
       "resource": {
         "resourceType": "Procedure",
-        "id": "claim-59e90339",
+        "id": "814d1cad-0c10-44b0-b660-e5dbd032db09",
         "meta": {
           "versionId": "4",
           "lastUpdated": "2022-01-06T18:37:29.000+00:00",
@@ -1702,21 +1712,21 @@
           "type": "Patient"
         },
         "encounter": {
-          "reference": "Encounter/d96030446269cb1e0a862d",
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464",
           "type": "Encounter"
         },
         "recorder": {
-          "reference": "Practitioner/1326321084d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "asserter": {
-          "reference": "Practitioner/1326321084d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "performer": [
           {
             "actor": {
-              "reference": "Practitioner/1326321084d96030446269cb1e0a862d",
+              "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
               "type": "Practitioner"
             }
           }
@@ -1766,21 +1776,21 @@
           "type": "Patient"
         },
         "encounter": {
-          "reference": "Encounter/d96030446269cb1e0a862d",
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464",
           "type": "Encounter"
         },
         "recorder": {
-          "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "asserter": {
-          "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "performer": [
           {
             "actor": {
-              "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+              "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
               "type": "Practitioner"
             }
           }
@@ -1830,21 +1840,21 @@
           "type": "Patient"
         },
         "encounter": {
-          "reference": "Encounter/d96030446269cb1e0a862d",
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464",
           "type": "Encounter"
         },
         "recorder": {
-          "reference": "Practitioner/1275598047d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "asserter": {
-          "reference": "Practitioner/1275598047d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "performer": [
           {
             "actor": {
-              "reference": "Practitioner/1275598047d96030446269cb1e0a862d",
+              "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
               "type": "Practitioner"
             }
           }
@@ -1892,7 +1902,7 @@
           "type": "Patient"
         },
         "encounter": {
-          "reference": "Encounter/d96030446269cb1e0a862d",
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464",
           "type": "Encounter"
         },
         "performedPeriod": {
@@ -1900,17 +1910,17 @@
           "end": "2020-03-03"
         },
         "recorder": {
-          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "asserter": {
-          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "performer": [
           {
             "actor": {
-              "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
+              "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
               "type": "Practitioner"
             }
           }
@@ -1958,7 +1968,7 @@
           "type": "Patient"
         },
         "encounter": {
-          "reference": "Encounter/d96030446269cb1e0a862d",
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464",
           "type": "Encounter"
         },
         "performedPeriod": {
@@ -1966,17 +1976,17 @@
           "end": "2020-03-03"
         },
         "recorder": {
-          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "asserter": {
-          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "performer": [
           {
             "actor": {
-              "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
+              "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
               "type": "Practitioner"
             }
           }
@@ -2032,15 +2042,15 @@
         },
         "created": "2020-03-10",
         "enterer": {
-          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "insurer": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "payee": {
@@ -2054,7 +2064,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
+            "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
             "type": "Practitioner"
           }
         },
@@ -2086,7 +2096,7 @@
           {
             "sequence": 1,
             "coverage": {
-              "reference": "Coverage/claim-1788c921",
+              "reference": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
               "type": "Coverage"
             }
           }
@@ -2302,15 +2312,15 @@
         },
         "created": "2020-03-10",
         "enterer": {
-          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "insurer": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "payee": {
@@ -2324,7 +2334,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
+            "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
             "type": "Practitioner"
           }
         },
@@ -2356,7 +2366,7 @@
           {
             "sequence": 1,
             "coverage": {
-              "reference": "Coverage/claim-1788c921",
+              "reference": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
               "type": "Coverage"
             }
           }
@@ -2572,15 +2582,15 @@
         },
         "created": "2020-03-10",
         "enterer": {
-          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "insurer": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "payee": {
@@ -2594,7 +2604,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
+            "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
             "type": "Practitioner"
           }
         },
@@ -2626,7 +2636,7 @@
           {
             "sequence": 1,
             "coverage": {
-              "reference": "Coverage/claim-1788c921",
+              "reference": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
               "type": "Coverage"
             }
           }
@@ -2842,15 +2852,15 @@
         },
         "created": "2020-03-10",
         "enterer": {
-          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "insurer": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "payee": {
@@ -2864,7 +2874,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
+            "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
             "type": "Practitioner"
           }
         },
@@ -2896,7 +2906,7 @@
           {
             "sequence": 1,
             "coverage": {
-              "reference": "Coverage/claim-1788c921",
+              "reference": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
               "type": "Coverage"
             }
           }
@@ -3112,15 +3122,15 @@
         },
         "created": "2020-03-10",
         "enterer": {
-          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "insurer": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "payee": {
@@ -3134,7 +3144,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
+            "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
             "type": "Practitioner"
           }
         },
@@ -3166,7 +3176,7 @@
           {
             "sequence": 1,
             "coverage": {
-              "reference": "Coverage/claim-1788c921",
+              "reference": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
               "type": "Coverage"
             }
           }
@@ -3343,7 +3353,7 @@
       },
       "request": {
         "method": "PUT",
-        "url": "Claim/865713a8-0af2-4497-b832-209ffe87754e "
+        "url": "Claim/865713a8-0af2-4497-b832-209ffe87754e"
       }
     },
     {
@@ -3380,15 +3390,15 @@
           "end": "2019-05-07"
         },
         "enterer": {
-          "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "insurer": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "payee": {
@@ -3402,7 +3412,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+            "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
             "type": "Practitioner"
           }
         },
@@ -3431,7 +3441,7 @@
           {
             "sequence": 1,
             "coverage": {
-              "reference": "Coverage/claim-1788c921",
+              "reference": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
               "type": "Coverage"
             }
           }
@@ -3483,15 +3493,15 @@
           "end": "2019-05-07"
         },
         "enterer": {
-          "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "insurer": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "payee": {
@@ -3505,7 +3515,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+            "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
             "type": "Practitioner"
           }
         },
@@ -3534,7 +3544,7 @@
           {
             "sequence": 1,
             "coverage": {
-              "reference": "Coverage/claim-1788c921",
+              "reference": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
               "type": "Coverage"
             }
           }
@@ -3586,15 +3596,15 @@
           "end": "2019-08-20"
         },
         "enterer": {
-          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "insurer": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "payee": {
@@ -3608,7 +3618,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+            "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
             "type": "Practitioner"
           }
         },
@@ -3637,7 +3647,7 @@
           {
             "sequence": 1,
             "coverage": {
-              "reference": "Coverage/claim-1788c921",
+              "reference": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
               "type": "Coverage"
             }
           }
@@ -3689,15 +3699,15 @@
           "end": "2019-08-20"
         },
         "enterer": {
-          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "insurer": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "payee": {
@@ -3711,7 +3721,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+            "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
             "type": "Practitioner"
           }
         },
@@ -3740,7 +3750,7 @@
           {
             "sequence": 1,
             "coverage": {
-              "reference": "Coverage/claim-1788c921",
+              "reference": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
               "type": "Coverage"
             }
           }
@@ -3792,15 +3802,15 @@
           "end": "2019-08-20"
         },
         "enterer": {
-          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "insurer": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "payee": {
@@ -3814,7 +3824,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+            "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
             "type": "Practitioner"
           }
         },
@@ -3843,7 +3853,7 @@
           {
             "sequence": 1,
             "coverage": {
-              "reference": "Coverage/claim-1788c921",
+              "reference": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
               "type": "Coverage"
             }
           }
@@ -3895,15 +3905,15 @@
           "end": "2019-09-24"
         },
         "enterer": {
-          "reference": "Practitioner/1346205721d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "insurer": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/1346205721d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "payee": {
@@ -3917,7 +3927,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/1346205721d96030446269cb1e0a862d",
+            "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
             "type": "Practitioner"
           }
         },
@@ -3946,7 +3956,7 @@
           {
             "sequence": 1,
             "coverage": {
-              "reference": "Coverage/claim-1788c921",
+              "reference": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
               "type": "Coverage"
             }
           }
@@ -3998,15 +4008,15 @@
           "end": "2019-02-26"
         },
         "enterer": {
-          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "insurer": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "payee": {
@@ -4020,7 +4030,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+            "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
             "type": "Practitioner"
           }
         },
@@ -4049,7 +4059,7 @@
           {
             "sequence": 1,
             "coverage": {
-              "reference": "Coverage/claim-1788c921",
+              "reference": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
               "type": "Coverage"
             }
           }
@@ -4101,15 +4111,15 @@
           "end": "2019-02-26"
         },
         "enterer": {
-          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "insurer": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "payee": {
@@ -4123,7 +4133,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+            "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
             "type": "Practitioner"
           }
         },
@@ -4152,7 +4162,7 @@
           {
             "sequence": 1,
             "coverage": {
-              "reference": "Coverage/claim-1788c921",
+              "reference": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
               "type": "Coverage"
             }
           }
@@ -4204,15 +4214,15 @@
           "end": "2019-02-26"
         },
         "enterer": {
-          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "insurer": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "payee": {
@@ -4226,7 +4236,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+            "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
             "type": "Practitioner"
           }
         },
@@ -4255,7 +4265,7 @@
           {
             "sequence": 1,
             "coverage": {
-              "reference": "Coverage/claim-1788c921",
+              "reference": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
               "type": "Coverage"
             }
           }
@@ -4307,15 +4317,15 @@
           "end": "2020-03-14"
         },
         "enterer": {
-          "reference": "Practitioner/1447213657d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "insurer": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/1447213657d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "payee": {
@@ -4329,7 +4339,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/1447213657d96030446269cb1e0a862d",
+            "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
             "type": "Practitioner"
           }
         },
@@ -4358,7 +4368,7 @@
           {
             "sequence": 1,
             "coverage": {
-              "reference": "Coverage/claim-1788c921",
+              "reference": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
               "type": "Coverage"
             }
           }
@@ -4410,15 +4420,15 @@
           "end": "2020-03-11"
         },
         "enterer": {
-          "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "insurer": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "payee": {
@@ -4432,7 +4442,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+            "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
             "type": "Practitioner"
           }
         },
@@ -4461,7 +4471,7 @@
           {
             "sequence": 1,
             "coverage": {
-              "reference": "Coverage/claim-1788c921",
+              "reference": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
               "type": "Coverage"
             }
           }
@@ -4513,15 +4523,15 @@
           "end": "2020-03-11"
         },
         "enterer": {
-          "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "insurer": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "payee": {
@@ -4535,7 +4545,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+            "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
             "type": "Practitioner"
           }
         },
@@ -4564,7 +4574,7 @@
           {
             "sequence": 1,
             "coverage": {
-              "reference": "Coverage/claim-1788c921",
+              "reference": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
               "type": "Coverage"
             }
           }
@@ -4616,15 +4626,15 @@
           "end": "2020-03-11"
         },
         "enterer": {
-          "reference": "Practitioner/1629377890d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "insurer": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/1629377890d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "payee": {
@@ -4638,7 +4648,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/1629377890d96030446269cb1e0a862d",
+            "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
             "type": "Practitioner"
           }
         },
@@ -4667,7 +4677,7 @@
           {
             "sequence": 1,
             "coverage": {
-              "reference": "Coverage/claim-1788c921",
+              "reference": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
               "type": "Coverage"
             }
           }
@@ -4719,15 +4729,15 @@
           "end": "2020-03-11"
         },
         "enterer": {
-          "reference": "Practitioner/1326321084d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "insurer": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/1326321084d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "payee": {
@@ -4741,7 +4751,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/1326321084d96030446269cb1e0a862d",
+            "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
             "type": "Practitioner"
           }
         },
@@ -4770,7 +4780,7 @@
           {
             "sequence": 1,
             "coverage": {
-              "reference": "Coverage/claim-1788c921",
+              "reference": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
               "type": "Coverage"
             }
           }
@@ -4822,15 +4832,15 @@
           "end": "2020-03-11"
         },
         "enterer": {
-          "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "insurer": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "payee": {
@@ -4844,7 +4854,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/1053655746d96030446269cb1e0a862d",
+            "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
             "type": "Practitioner"
           }
         },
@@ -4873,7 +4883,7 @@
           {
             "sequence": 1,
             "coverage": {
-              "reference": "Coverage/claim-1788c921",
+              "reference": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
               "type": "Coverage"
             }
           }
@@ -4925,15 +4935,15 @@
           "end": "2020-03-13"
         },
         "enterer": {
-          "reference": "Practitioner/1801037239d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "insurer": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/1801037239d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "payee": {
@@ -4947,7 +4957,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/1801037239d96030446269cb1e0a862d",
+            "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
             "type": "Practitioner"
           }
         },
@@ -4976,7 +4986,7 @@
           {
             "sequence": 1,
             "coverage": {
-              "reference": "Coverage/claim-1788c921",
+              "reference": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
               "type": "Coverage"
             }
           }
@@ -5028,15 +5038,15 @@
           "end": "2020-03-06"
         },
         "enterer": {
-          "reference": "Practitioner/1275598047d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "insurer": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/1275598047d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "payee": {
@@ -5050,7 +5060,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/1275598047d96030446269cb1e0a862d",
+            "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
             "type": "Practitioner"
           }
         },
@@ -5079,7 +5089,7 @@
           {
             "sequence": 1,
             "coverage": {
-              "reference": "Coverage/claim-1788c921",
+              "reference": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
               "type": "Coverage"
             }
           }
@@ -5131,15 +5141,15 @@
           "end": "2020-07-18"
         },
         "enterer": {
-          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "insurer": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "payee": {
@@ -5153,7 +5163,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+            "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
             "type": "Practitioner"
           }
         },
@@ -5182,7 +5192,7 @@
           {
             "sequence": 1,
             "coverage": {
-              "reference": "Coverage/claim-1788c921",
+              "reference": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
               "type": "Coverage"
             }
           }
@@ -5234,15 +5244,15 @@
           "end": "2020-07-18"
         },
         "enterer": {
-          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "insurer": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "payee": {
@@ -5256,7 +5266,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/1528023850d96030446269cb1e0a862d",
+            "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
             "type": "Practitioner"
           }
         },
@@ -5285,7 +5295,7 @@
           {
             "sequence": 1,
             "coverage": {
-              "reference": "Coverage/claim-1788c921",
+              "reference": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
               "type": "Coverage"
             }
           }
@@ -5339,15 +5349,15 @@
         },
         "created": "2020-03-03",
         "enterer": {
-          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "insurer": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "priority": {
@@ -5370,7 +5380,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
+            "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
             "type": "Practitioner"
           }
         },
@@ -5415,7 +5425,7 @@
           {
             "focal": true,
             "coverage": {
-              "reference": "Coverage/claim-1788c921",
+              "reference": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
               "type": "Coverage"
             }
           }
@@ -5612,7 +5622,7 @@
       },
       "request": {
         "method": "PUT",
-        "url": "Claim/4cf9dc47-5e71-47d0-b0ff-b283fe8dc47c"
+        "url": "ExplanationOfBenefit/4cf9dc47-5e71-47d0-b0ff-b283fe8dc47c"
       }
     },
     {
@@ -5651,15 +5661,15 @@
         },
         "created": "2019-05-02",
         "enterer": {
-          "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "insurer": {
-          "reference": "Organization/claim-8c651f04",
+          "reference": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
           "type": "Organization"
         },
         "provider": {
-          "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
           "type": "Practitioner"
         },
         "priority": {
@@ -5682,7 +5692,7 @@
             ]
           },
           "party": {
-            "reference": "Practitioner/1225092273d96030446269cb1e0a862d",
+            "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
             "type": "Practitioner"
           }
         },
@@ -5724,7 +5734,7 @@
           {
             "focal": true,
             "coverage": {
-              "reference": "Coverage/claim-1788c921",
+              "reference": "Coverage/d91140ee-684a-487e-894f-2791f82e1888",
               "type": "Coverage"
             }
           }
@@ -5759,7 +5769,7 @@
       },
       "request": {
         "method": "PUT",
-        "url": "Claim/cd3be588-58eb-4152-9f3a-f91a2d10e247"
+        "url": "ExplanationOfBenefit/cd3be588-58eb-4152-9f3a-f91a2d10e247"
       }
     },
     {
@@ -6460,7 +6470,7 @@
           "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
         },
         "encounter": {
-          "reference": "Encounter/97991794"
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464"
         },
         "effectiveDateTime": "2023-09-01T15:21:00.000Z",
         "issued": "2023-09-01T15:30:25.000Z",
@@ -6481,7 +6491,7 @@
                 "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
               }
             ],
-            "reference": "Practitioner/683925"
+            "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933"
           }
         ],
         "valueQuantity": {
@@ -6563,7 +6573,7 @@
           "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
         },
         "encounter": {
-          "reference": "Encounter/97991794"
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464"
         },
         "effectiveDateTime": "2023-09-01T15:21:00.000Z",
         "issued": "2023-09-01T15:30:25.000Z",
@@ -6597,7 +6607,7 @@
                 "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
               }
             ],
-            "reference": "Practitioner/683925"
+            "reference": "Practioner/8085737b-28ec-4b23-8604-83fd20076933"
           }
         ],
         "valueCodeableConcept": {
@@ -6668,7 +6678,7 @@
           "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
         },
         "encounter": {
-          "reference": "Encounter/97991794"
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464"
         },
         "effectiveDateTime": "2023-09-01T15:21:00.000Z",
         "issued": "2023-09-01T15:22:59.000Z",
@@ -6779,7 +6789,7 @@
           "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
         },
         "encounter": {
-          "reference": "Encounter/97991794"
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464"
         },
         "effectiveDateTime": "2023-09-01T15:21:00.000Z",
         "issued": "2023-09-01T15:22:59.000Z",
@@ -6885,7 +6895,7 @@
           "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
         },
         "encounter": {
-          "reference": "Encounter/97991794"
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464"
         },
         "effectiveDateTime": "2023-09-01T15:21:00.000Z",
         "issued": "2023-09-01T15:22:58.000Z",
@@ -6996,7 +7006,7 @@
           "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
         },
         "encounter": {
-          "reference": "Encounter/97991794"
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464"
         },
         "effectiveDateTime": "2023-09-01T15:21:00.000Z",
         "issued": "2023-09-01T15:22:58.000Z",
@@ -7108,7 +7118,7 @@
           "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
         },
         "encounter": {
-          "reference": "Encounter/97991794"
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464"
         },
         "effectiveDateTime": "2023-09-01T15:21:00.000Z",
         "issued": "2023-09-01T15:22:57.000Z",
@@ -7142,7 +7152,7 @@
                 "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
               }
             ],
-            "reference": "Practitioner/683925"
+            "reference": "Practioner/8085737b-28ec-4b23-8604-83fd20076933"
           }
         ],
         "valueQuantity": {
@@ -7218,7 +7228,7 @@
           "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
         },
         "encounter": {
-          "reference": "Encounter/97991794"
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464"
         },
         "effectiveDateTime": "2023-09-01T15:21:00.000Z",
         "issued": "2023-09-01T15:22:57.000Z",
@@ -7252,7 +7262,7 @@
                 "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
               }
             ],
-            "reference": "Practitioner/683925"
+            "reference": "Practioner/8085737b-28ec-4b23-8604-83fd20076933"
           }
         ],
         "valueQuantity": {
@@ -7325,7 +7335,7 @@
           "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
         },
         "encounter": {
-          "reference": "Encounter/97991794"
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464"
         },
         "effectiveDateTime": "2023-09-01T15:21:00.000Z",
         "issued": "2023-09-01T15:22:57.000Z",
@@ -7346,7 +7356,7 @@
                 "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
               }
             ],
-            "reference": "Practitioner/683925"
+            "reference": "Practioner/8085737b-28ec-4b23-8604-83fd20076933"
           }
         ],
         "valueQuantity": {
@@ -7513,7 +7523,7 @@
           "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
         },
         "encounter": {
-          "reference": "Encounter/97991794"
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464"
         },
         "effectiveDateTime": "2023-09-01T15:21:00.000Z",
         "issued": "2023-09-01T15:22:57.000Z",
@@ -7534,7 +7544,7 @@
                 "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
               }
             ],
-            "reference": "Practitioner/683925"
+            "reference": "Practioner/8085737b-28ec-4b23-8604-83fd20076933"
           }
         ],
         "valueQuantity": {
@@ -7644,7 +7654,7 @@
           "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
         },
         "encounter": {
-          "reference": "Encounter/97991794"
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464"
         },
         "effectiveDateTime": "2023-09-01T15:17:00.000Z",
         "issued": "2023-09-01T15:18:19.000Z",
@@ -7678,7 +7688,7 @@
                 "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
               }
             ],
-            "reference": "Practitioner/683925"
+            "reference": "Practioner/8085737b-28ec-4b23-8604-83fd20076933"
           }
         ],
         "valueDateTime": "2023-09-23"
@@ -7695,7 +7705,7 @@
       "fullUrl": "Observation/8c14a355-de23-46db-94cb-1982d99ec6bd",
       "resource": {
         "resourceType": "Observation",
-        "id": "L-197323255",
+        "id": "8c14a355-de23-46db-94cb-1982d99ec6bd",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2023-09-01T15:18:19.000Z"
@@ -7736,7 +7746,7 @@
           "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
         },
         "encounter": {
-          "reference": "Encounter/97991794"
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464"
         },
         "effectiveDateTime": "2023-09-01T15:17:00.000Z",
         "issued": "2023-09-01T15:18:19.000Z",
@@ -7770,7 +7780,7 @@
                 "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
               }
             ],
-            "reference": "Practitioner/683925"
+            "reference": "Practioner/8085737b-28ec-4b23-8604-83fd20076933"
           }
         ],
         "valueCodeableConcept": {
@@ -7838,7 +7848,7 @@
           "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
         },
         "encounter": {
-          "reference": "Encounter/97991794"
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464"
         },
         "effectiveDateTime": "2023-09-01T15:17:00.000Z",
         "issued": "2023-09-01T15:18:19.000Z",
@@ -7872,7 +7882,7 @@
                 "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
               }
             ],
-            "reference": "Practitioner/683925"
+            "reference": "Practioner/8085737b-28ec-4b23-8604-83fd20076933"
           }
         ],
         "valueCodeableConcept": {
@@ -7940,7 +7950,7 @@
           "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
         },
         "encounter": {
-          "reference": "Encounter/97991794"
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464"
         },
         "effectiveDateTime": "2023-09-01T15:17:00.000Z",
         "issued": "2023-09-01T15:18:19.000Z",
@@ -7974,7 +7984,7 @@
                 "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
               }
             ],
-            "reference": "Practitioner/683925"
+            "reference": "Practioner/8085737b-28ec-4b23-8604-83fd20076933"
           }
         ],
         "valueDateTime": "2023-09-01T10:18:00-05:00"
@@ -8032,7 +8042,7 @@
           "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
         },
         "encounter": {
-          "reference": "Encounter/97991794"
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464"
         },
         "effectiveDateTime": "2023-09-01T15:17:00.000Z",
         "issued": "2023-09-01T15:18:19.000Z",
@@ -8066,7 +8076,7 @@
                 "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
               }
             ],
-            "reference": "Practitioner/683925"
+            "reference": "Practioner/8085737b-28ec-4b23-8604-83fd20076933"
           }
         ],
         "valueCodeableConcept": {
@@ -8134,7 +8144,7 @@
           "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
         },
         "encounter": {
-          "reference": "Encounter/97991794"
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464"
         },
         "effectiveDateTime": "2023-09-01T15:17:00.000Z",
         "issued": "2023-09-01T15:18:19.000Z",
@@ -8168,7 +8178,7 @@
                 "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
               }
             ],
-            "reference": "Practitioner/683925"
+            "reference": "Practioner/8085737b-28ec-4b23-8604-83fd20076933"
           }
         ],
         "component": [
@@ -8266,7 +8276,7 @@
           "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
         },
         "encounter": {
-          "reference": "Encounter/97991794"
+          "reference": "Encounter/42eede74-6328-44e4-8dcf-fd9f4057b464"
         },
         "effectiveDateTime": "2023-09-01T15:17:00.000Z",
         "issued": "2023-09-01T15:18:19.000Z",
@@ -8300,7 +8310,7 @@
                 "url": "http://hl7.org/fhir/StructureDefinition/event-performerFunction"
               }
             ],
-            "reference": "Practitioner/683925"
+            "reference": "Practioner/8085737b-28ec-4b23-8604-83fd20076933"
           }
         ],
         "valueCodeableConcept": {
@@ -8658,8 +8668,8 @@
         },
         "authoredOn": "2023-12-15T15:24:55-05:00",
         "requester": {
-          "reference": "Practitioner/297f1408-0613-42e3-b526-2e113a5584ea ",
-          "display": "Susan Miller MD"
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
+          "display": "Hai Pocondriac"
         },
         "dosageInstruction": [
           {
@@ -8719,13 +8729,13 @@
         "performer": [
           {
             "actor": {
-              "reference": "Practitioner/297f1408-0613-42e3-b526-2e113a5584ea ",
-              "display": "Susan Miller MD"
+              "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
+              "display": "Hai Pocondriac"
             }
           }
         ],
         "request": {
-          "reference": "MedicationRequest/122M",
+          "reference": "MedicationRequest/49725a38-06d2-4a40-9e67-f9845dd544ab",
           "display": "Medication order for penicillin G benzathine 2400000 UNT Injection"
         },
         "dosage": {
@@ -8792,8 +8802,8 @@
         "participant": [
           {
             "individual": {
-              "reference": "Practitioner/297f1408-0613-42e3-b526-2e113a5584ea ",
-              "display": "Susan Miller MD"
+              "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
+              "display": "Hai Pocondriac"
             }
           }
         ],
@@ -9190,7 +9200,7 @@
       "fullUrl": "ServiceRequest/6af1f84c-9592-4f82-bec8-963ab55f5e89",
       "resource": {
         "resourceType": "ServiceRequest",
-        "id": "107H",
+        "id": "6af1f84c-9592-4f82-bec8-963ab55f5e89",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-01-16T15:16:09.000+00:00",
@@ -9243,8 +9253,8 @@
         },
         "authoredOn": "2023-12-15T11:56:15-05:00",
         "requester": {
-          "reference": "Practitioner/297f1408-0613-42e3-b526-2e113a5584ea",
-          "display": "Susan Miller MD"
+          "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
+          "display": "Hai Pocondriac"
         },
         "reasonReference": [
           {
@@ -9434,7 +9444,7 @@
           {
             "detail": [
               {
-                "reference": "Observation/113H",
+                "reference": "Observation/212723e5-1ce0-400a-bb14-caacd3e36bbc",
                 "display": "Housing Status"
               }
             ]
@@ -9619,150 +9629,7 @@
         "url": "Condition/3bc88fa3-c57e-4c0f-b02b-89a46f5b6739"
       }
     },
-    {
-      "fullUrl": "Practitioner/297f1408-0613-42e3-b526-2e113a5584ea",
-      "resource": {
-        "resourceType": "Practitioner",
-        "id": "297f1408-0613-42e3-b526-2e113a5584ea ",
-        "meta": {
-          "versionId": "1",
-          "lastUpdated": "2024-01-16T15:10:21.000+00:00",
-          "source": "#iStxdAp9atcGA86k",
-          "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
-          ]
-        },
-        "text": {
-          "status": "generated",
-          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">This is a simple narrative with only plain text</div>"
-        },
-        "extension": [
-          {
-            "url": "http://mihin.org/extension/copyright",
-            "valueString": "Copyright 2014-2023 Michigan Health Information Network Shared Services. Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0.  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
-          }
-        ],
-        "identifier": [
-          {
-            "system": "http://hl7.org.fhir/sid/us-npi",
-            "value": "1679452846"
-          },
-          {
-            "system": "http://www.acme.org/practitioners",
-            "value": "3497201"
-          }
-        ],
-        "name": [
-          {
-            "family": "Miller",
-            "given": ["Susan"],
-            "prefix": ["Dr"]
-          }
-        ],
-        "telecom": [
-          {
-            "system": "phone",
-            "value": "937-555-4171",
-            "use": "work"
-          },
-          {
-            "system": "phone",
-            "value": "937-555-2838",
-            "use": "mobile"
-          }
-        ],
-        "address": [
-          {
-            "use": "work",
-            "line": ["210 Walnut St"],
-            "city": "Hamersville",
-            "state": "OH",
-            "postalCode": "45130"
-          }
-        ]
-      },
-      "search": {
-        "mode": "match"
-      },
-      "request": {
-        "method": "PUT",
-        "url": "Practitioner/297f1408-0613-42e3-b526-2e113a5584ea"
-      }
-    },
-    {
-      "fullUrl": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131",
-      "resource": {
-        "resourceType": "Organization",
-        "id": "cc8a572b-0ae5-4497-97cf-bab563cbb131",
-        "meta": {
-          "versionId": "1",
-          "lastUpdated": "2024-01-16T15:10:33.000+00:00",
-          "source": "#bwuzbwMbMAdhDTk3",
-          "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
-          ]
-        },
-        "text": {
-          "status": "generated",
-          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">This is a simple narrative with only plain text</div>"
-        },
-        "extension": [
-          {
-            "url": "http://mihin.org/extension/copyright",
-            "valueString": "Copyright 2014-2023 Michigan Health Information Network Shared Services. Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0.  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
-          }
-        ],
-        "identifier": [
-          {
-            "system": "http://hl7.org.fhir/sid/us-npi",
-            "value": "6497258403"
-          },
-          {
-            "system": "http://www.acme.org/organization",
-            "value": "3497521864"
-          }
-        ],
-        "active": true,
-        "type": [
-          {
-            "coding": [
-              {
-                "system": "http://terminology.hl7.org/CodeSystem/organization-type",
-                "code": "prov",
-                "display": "Healthcare Provider"
-              }
-            ]
-          }
-        ],
-        "name": "Better Health Community Medical Center",
-        "telecom": [
-          {
-            "system": "phone",
-            "value": "(+1) 734-677-7777"
-          },
-          {
-            "system": "email",
-            "value": "betterhealthcommunitymedicalcenter@acme.org"
-          }
-        ],
-        "address": [
-          {
-            "line": ["2034 West Main St"],
-            "city": "Hamersville",
-            "state": "OH",
-            "postalCode": "45130",
-            "country": "USA"
-          }
-        ]
-      },
-      "search": {
-        "mode": "match"
-      },
-      "request": {
-        "method": "PUT",
-        "url": "Organization/cc8a572b-0ae5-4497-97cf-bab563cbb131"
-      }
-    },
+
     {
       "fullUrl": "Observation/6d22c4f2-1e19-42c7-8618-ed0f6b8e4f7b",
       "resource": {
@@ -9950,7 +9817,7 @@
       "fullUrl": "Condition/804a1d9d-bef0-469a-af40-a0145503c3aa",
       "resource": {
         "resourceType": "Condition",
-        "id": "130983",
+        "id": "804a1d9d-bef0-469a-af40-a0145503c3aa",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-04-22T22:53:54.000+00:00",
@@ -10023,7 +9890,7 @@
               "end": "2024-03-03"
             },
             "individual": {
-              "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
+              "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
               "type": "Practitioner"
             }
           }
@@ -10111,7 +9978,7 @@
       },
       "request": {
         "method": "PUT",
-        "url": "QuestionnaireResponse/546a8b86-6901-4ade-ace4-816566a1e620"
+        "url": "MedicationRequest/546a8b86-6901-4ade-ace4-816566a1e620"
       }
     },
     {
@@ -10161,7 +10028,7 @@
             "reference": "Observation/6d22c4f2-1e19-42c7-8618-ed0f6b8e4f7b"
           },
           {
-            "reference": "Observation/130981"
+            "reference": "Observation/606c78ab-b778-4ad2-8db2-b2e205f15c41"
           }
         ]
       },
@@ -10177,7 +10044,7 @@
       "fullUrl": "Observation/606c78ab-b778-4ad2-8db2-b2e205f15c41",
       "resource": {
         "resourceType": "Observation",
-        "id": "131106",
+        "id": "606c78ab-b778-4ad2-8db2-b2e205f15c41",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-05-15T14:43:43.000+00:00",
@@ -10245,7 +10112,7 @@
       "fullUrl": "Observation/c43d2272-bb9a-4d61-8908-f000b77783de",
       "resource": {
         "resourceType": "Observation",
-        "id": "131107",
+        "id": "c43d2272-bb9a-4d61-8908-f000b77783de",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-05-15T14:43:43.000+00:00",
@@ -10360,7 +10227,7 @@
       "fullUrl": "Condition/547054c8-cbf0-4110-916b-6ccfd1345ff0",
       "resource": {
         "resourceType": "Condition",
-        "id": "131109",
+        "id": "547054c8-cbf0-4110-916b-6ccfd1345ff0",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-05-15T14:43:44.000+00:00",
@@ -10410,7 +10277,7 @@
       "fullUrl": "Condition/6bbcfd78-deb7-4715-9dfc-68e1f0918ad2",
       "resource": {
         "resourceType": "Condition",
-        "id": "131110",
+        "id": "6bbcfd78-deb7-4715-9dfc-68e1f0918ad2",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-05-15T14:43:44.000+00:00",
@@ -10460,7 +10327,7 @@
       "fullUrl": "Encounter/22b3486d-269e-43b0-bfa9-2aaac9d92050",
       "resource": {
         "resourceType": "Encounter",
-        "id": "131111",
+        "id": "22b3486d-269e-43b0-bfa9-2aaac9d92050",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-05-15T14:43:44.000+00:00",
@@ -10483,7 +10350,7 @@
               "end": "2024-05-03"
             },
             "individual": {
-              "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
+              "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
               "type": "Practitioner"
             }
           }
@@ -10517,7 +10384,7 @@
       "fullUrl": "MedicationRequest/41e37368-1036-4abb-adf7-f7157cfa5a0f",
       "resource": {
         "resourceType": "MedicationRequest",
-        "id": "131112",
+        "id": "41e37368-1036-4abb-adf7-f7157cfa5a0f",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-05-15T14:43:44.000+00:00",
@@ -10573,7 +10440,7 @@
       "fullUrl": "MedicationRequest/d2d609fe-aef2-403d-9614-a6d2bc823a03",
       "resource": {
         "resourceType": "MedicationRequest",
-        "id": "131113",
+        "id": "d2d609fe-aef2-403d-9614-a6d2bc823a03",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-05-15T14:43:44.000+00:00",
@@ -10629,7 +10496,7 @@
       "fullUrl": "DiagnosticReport/55066176-b4a0-485c-b68e-b31f3e28a442",
       "resource": {
         "resourceType": "DiagnosticReport",
-        "id": "131114",
+        "id": "55066176-b4a0-485c-b68e-b31f3e28a442",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-05-15T14:43:44.000+00:00",
@@ -10677,57 +10544,10 @@
       }
     },
     {
-      "fullUrl": "Practitioner/9806f83f-41c4-48b2-a23f-ffeb328f8348",
-      "resource": {
-        "resourceType": "Practitioner",
-        "id": "5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
-        "meta": {
-          "versionId": "1",
-          "lastUpdated": "2022-01-06T03:09:18.000+00:00",
-          "source": "#851299c0e07f2170"
-        },
-        "identifier": [
-          {
-            "system": "http://hl7.org/fhir/sid/us-npi",
-            "value": "1760480503d96030446269cb1e0a862d"
-          }
-        ],
-        "active": true,
-        "name": [
-          {
-            "family": "Squier",
-            "given": ["Wilma"]
-          }
-        ],
-        "telecom": [
-          {
-            "system": "phone",
-            "value": "943-962-8386"
-          }
-        ],
-        "address": [
-          {
-            "line": ["5489 Main Street"],
-            "district": "MARICOPA",
-            "state": "Arizona",
-            "postalCode": "85000",
-            "country": "USA"
-          }
-        ]
-      },
-      "search": {
-        "mode": "match"
-      },
-      "request": {
-        "method": "PUT",
-        "url": "Practitioner/9806f83f-41c4-48b2-a23f-ffeb328f8348"
-      }
-    },
-    {
       "fullUrl": "Observation/16cd022c-ce74-47dc-96a5-62afeb62a238",
       "resource": {
         "resourceType": "Observation",
-        "id": "131043",
+        "id": "16cd022c-ce74-47dc-96a5-62afeb62a238",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-04-23T11:56:09.000+00:00",
@@ -11098,7 +10918,7 @@
               "end": "2022-12-15"
             },
             "individual": {
-              "reference": "Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
+              "reference": "Practitioner/8085737b-28ec-4b23-8604-83fd20076933",
               "type": "Practitioner"
             }
           }
@@ -11193,7 +11013,7 @@
       "fullUrl": "MedicationRequest/43f7e264-161a-4e8a-9cef-aea6d6f7bfb7",
       "resource": {
         "resourceType": "MedicationRequest",
-        "id": "131051",
+        "id": "43f7e264-161a-4e8a-9cef-aea6d6f7bfb7",
         "meta": {
           "versionId": "4",
           "lastUpdated": "2024-04-23T12:08:31.000+00:00",
@@ -11254,7 +11074,7 @@
       "fullUrl": "DiagnosticReport/7ea6d8c0-b493-4208-8e07-30432aa34ee3",
       "resource": {
         "resourceType": "DiagnosticReport",
-        "id": "131052",
+        "id": "7ea6d8c0-b493-4208-8e07-30432aa34ee3",
         "meta": {
           "versionId": "3",
           "lastUpdated": "2024-04-23T12:06:17.000+00:00",
@@ -11294,7 +11114,7 @@
         "issued": "2022-11-30",
         "result": [
           {
-            "reference": "Observation/131043"
+            "reference": "Observation/16cd022c-ce74-47dc-96a5-62afeb62a238"
           },
           {
             "reference": "Observation/317a32d1-16ef-479d-8ba5-eec53da3b549"
@@ -11313,7 +11133,7 @@
       "fullUrl": "MedicationRequest/d3c8fbcd-8212-437e-bafd-7cb946770c3f",
       "resource": {
         "resourceType": "MedicationRequest",
-        "id": "131115",
+        "id": "d3c8fbcd-8212-437e-bafd-7cb946770c3f",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2024-05-16T12:33:18.000+00:00",
@@ -11358,49 +11178,6 @@
       "request": {
         "method": "PUT",
         "url": "MedicationRequest/d3c8fbcd-8212-437e-bafd-7cb946770c3f"
-      }
-    },
-    {
-      "fullUrl": "https://gw.interop.community/JMCHeliosSTISandbox/open/Practitioner/5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
-      "resource": {
-        "resourceType": "Practitioner",
-        "id": "5122d9eb-e0c8-4fd4-a734-3d7909d2f811",
-        "meta": {
-          "versionId": "1",
-          "lastUpdated": "2022-01-06T03:09:18.000+00:00",
-          "source": "#851299c0e07f2170"
-        },
-        "identifier": [
-          {
-            "system": "http://hl7.org/fhir/sid/us-npi",
-            "value": "5122d9eb-e0c8-4fd4-a734-3d7909d2f811"
-          }
-        ],
-        "active": true,
-        "name": [
-          {
-            "family": "Squier",
-            "given": ["Wilma"]
-          }
-        ],
-        "telecom": [
-          {
-            "system": "phone",
-            "value": "943-962-8386"
-          }
-        ],
-        "address": [
-          {
-            "line": ["5489 Main Street"],
-            "district": "MARICOPA",
-            "state": "Arizona",
-            "postalCode": "85000",
-            "country": "USA"
-          }
-        ]
-      },
-      "search": {
-        "mode": "match"
       }
     }
   ]


### PR DESCRIPTION
# PULL REQUEST

## Summary
Makes a very sick patient for use in the patient discovery page. Putting it up to make sure it looks semi-reasonable before progressing

## Related Issue
Part one #2645. Once merged, will post the patient to OpenHAPI and handle the autopopulation in the final ticket to align the patient discovery page with our designs

## Acceptance Criteria
Since we're removing the dropdowns from patient discovery to later stages, we'll need a golden patient that has all the relevant use case sicknesses to populate at once, which will allow us to get all the relevant use cases later on

## Additional Information
Anything else the review team should know?
