### PR TITLE
Add "Select an Option" to FHIR Server Dropdown + Fix e2e tests

### DIFF
--- a/containers/tefca-viewer/e2e/query_workflow.spec.ts
+++ b/containers/tefca-viewer/e2e/query_workflow.spec.ts
@@ -29,30 +29,33 @@ test.describe("querying with the TryTEFCA viewer", () => {
     ).toBeVisible();
   });
 
-  //TODO: Add this test back in once you no longer have to click to select the query from the dropdown
-  // test("unsuccessful user query: no patients", async ({ page }) => {
-  //   await page.getByRole("button", { name: "Go to the demo" }).click();
-  //   await page
-  //     .getByLabel("Query", { exact: true })
-  //     .selectOption("social-determinants");
-  //   await page.getByRole("button", { name: "Fill fields" }).click();
+  test("unsuccessful user query: no patients", async ({ page }) => {
+    await page.getByRole("button", { name: "Go to the demo" }).click();
+    await page
+      .getByLabel("Query", { exact: true })
+      .selectOption("social-determinants");
+    await page.getByRole("button", { name: "Advanced" }).click();
+    await page
+      .getByLabel("FHIR Server (QHIN)", { exact: true })
+      .selectOption("HELIOS Meld: Direct");
 
-  //   await page.getByLabel("First Name").fill("Ellie");
-  //   await page.getByLabel("Last Name").fill("Williams");
-  //   await page.getByLabel("Phone Number").fill("5555555555");
-  //   await page.getByLabel("Medical Record Number").fill("TLOU1TLOU2");
-  //   await page.getByRole("button", { name: "Search for patient" }).click();
+    await page.getByLabel("First Name").fill("Ellie");
+    await page.getByLabel("Last Name").fill("Williams");
+    await page.getByLabel("Phone Number").fill("5555555555");
+    await page.getByLabel("Medical Record Number").fill("TLOU1TLOU2");
+    await page.getByRole("button", { name: "Search for patient" }).click();
 
-  //   // Better luck next time, user!
-  //   await expect(
-  //     page.getByRole("heading", { name: "No Patients Found" })
-  //   ).toBeVisible();
-  //   await expect(page.getByText("There are no patient records")).toBeVisible();
-  //   await page.getByRole("link", { name: "Search for a new patient" }).click();
-  //   await expect(
-  //     page.getByRole("heading", { name: "Search for a Patient", exact: true })
-  //   ).toBeVisible();
-  // });
+    // Better luck next time, user!
+    await expect(
+      page.getByRole("heading", { name: "No Records Found" }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("No records were found for your search"),
+    ).toBeVisible();
+    await page
+      .getByRole("link", { name: "Revise your patient search" })
+      .click();
+  });
 
   test("successful demo user query: the quest for watermelon mcgee", async ({
     page,

--- a/containers/tefca-viewer/playwright.config.ts
+++ b/containers/tefca-viewer/playwright.config.ts
@@ -68,8 +68,8 @@ export default defineConfig({
     // },
   ],
 
-  /* Hook to ensure Docker is shut down after tests or on error */
-  globalTeardown: "./playwright-teardown",
   /* Hook to ensure DB is started & migrations have run before tests start*/
   globalSetup: "./playwright-setup",
+  /* Hook to ensure Docker is shut down after tests or on error */
+  globalTeardown: "./playwright-teardown",
 });

--- a/containers/tefca-viewer/src/app/query/components/searchForm/SearchForm.tsx
+++ b/containers/tefca-viewer/src/app/query/components/searchForm/SearchForm.tsx
@@ -247,13 +247,15 @@ const SearchForm: React.FC<SearchFormProps> = ({
                     id="fhir_server"
                     name="fhir_server"
                     value={fhirServer}
+                    defaultValue={""}
                     onChange={(event) => {
                       setFhirServer(event.target.value as FHIR_SERVERS);
                     }}
                     required
                   >
                     <option value="" disabled>
-                      Select FHIR Server
+                      {" "}
+                      -- Select an Option --{" "}
                     </option>
                     {Object.keys(fhirServers).map((fhirServer: string) => (
                       <option key={fhirServer} value={fhirServer}>


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR fixes a failing end to end test by adding "Select an Option" to the FHIR Server dropdown and by updating the content in the playwright tests to reflect the text on the page when we find no patients. I think the test failing represents an edge case where we weren't "changing" the state of the FHIR Server because we were selecting the default value (HELIOS Meld: Direct) so the search was silently failing**. To force the user to select a FHIR server, I added "Select an Option" to the dropdown like we have for the Query dropdown. 

** Currently, if a user forgets to select a Query (`useCase`) or a FHIR Server (`fhirServer`), the query will fail but nothing is display to notify the user about this. Perhaps we should add a warning toaster  or some kind of alert (I think we had this previously??) to let them know which fields are missing.

## Related Issue
Fixes #2699 

## Acceptance Criteria
Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information
Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
