### PR TITLE
Add polling to run to ensure Query Connector is running before e2e tests run

### DIFF
--- a/.github/workflows/container-tefca-viewer.yaml
+++ b/.github/workflows/container-tefca-viewer.yaml
@@ -98,6 +98,12 @@ jobs:
       - name: Run Query Connector
         working-directory: ./containers/${{env.CONTAINER}}
         run: docker compose up -d
+      - name: Poll until Query Connector is ready
+        run: |
+          until curl -s http://localhost:3000/tefca-viewer; do
+            echo "Waiting for Query Connector to be ready before running Playwright..."
+            sleep 5
+          done
       - name: Playwright Tests
         working-directory: ./containers/${{env.CONTAINER}}
         run: npx playwright test e2e --reporter=list --config playwright.config.ts

--- a/containers/tefca-viewer/e2e/query_workflow.spec.ts
+++ b/containers/tefca-viewer/e2e/query_workflow.spec.ts
@@ -20,7 +20,7 @@ test.describe("querying with the TryTEFCA viewer", () => {
       page.getByRole("heading", { name: "How does it work?" }),
     ).toBeVisible();
 
-    // Check that interactable elements are present (TEFCA header and Get Started)
+    // Check that interactable elements are present (header and Get Started)
     await expect(
       page.getByRole("link", { name: "TEFCA Viewer" }),
     ).toBeVisible();


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR adds a polling step to the workflow to ensure that the Query Connector is ready before proceeding to the e2e tests. Because we are running in detached mode, it seems like the workflow proceeded to the testing without the app being ready. Although there were no failures, the e2e tests did not run the first time they were called, but would run on a manually re-run. With the polling, we first make sure that the everything is set up before running the tests, which will hopefully resolve the "intermittent" failures we were seeing on earlier PRs. 

## Related Issue
Fixes #2708 

## Acceptance Criteria
Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information
Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
