### PR TITLE
Add back tefca.env for easier local development in QC

### DIFF
--- a/containers/tefca-viewer/src/app/database-service.ts
+++ b/containers/tefca-viewer/src/app/database-service.ts
@@ -1,6 +1,6 @@
 "use server";
 import { Pool, PoolConfig, QueryResultRow } from "pg";
-// import dotenv from "dotenv";
+import dotenv from "dotenv";
 import { ValueSetItem, valueSetTypeToClincalServiceTypeMap } from "./constants";
 
 const getQuerybyNameSQL = `
@@ -13,7 +13,10 @@ select q.query_name, q.id, qtv.valueset_id, vs.name as valueset_name, vs.author 
   where q.query_name = $1;
 `;
 
-// Load environment variables from .env and establish a Pool configuration
+// Load environment variables from tefca.env if not in production
+if (process.env.NODE_ENV !== "production") {
+  dotenv.config({ path: "tefca.env" });
+}
 const dbConfig: PoolConfig = {
   connectionString: process.env.DATABASE_URL,
   max: 10, // Maximum # of connections in the pool

--- a/containers/tefca-viewer/tefca.env
+++ b/containers/tefca-viewer/tefca.env
@@ -1,0 +1,1 @@
+DATABASE_URL=postgresql://postgres:pw@localhost:5432/tefca_db


### PR DESCRIPTION
# PULL REQUEST

## Summary
Adds back tefca.env to make `npm run dev` work locally to pull from database.

## Related Issue
Fixes part of updates done while chasing down leads for SSL.

## Acceptance Criteria
Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

## Additional Information
Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # (PR title: Remember to name your PR descriptively!)
